### PR TITLE
docs: normalize comments to a single convention and record it in CLAU…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Comment conventions
+
+## Module docstrings
+
+Every `.py` file opens with a docstring: path line, one-line purpose, then
+`Responsibilities:` and `Not responsible for:` bullet lists. See
+`argus/orchestration/governor.py` for the canonical shape.
+
+## Function & class docstrings
+
+Google style. One-line summary, then `Args:` / `Returns:` / `Raises:` where
+applicable. Required on every public (non-underscore) `def` and `class`.
+Private `_helpers` get one only when the name and signature don't already
+make the behavior obvious.
+
+Test functions follow the same rule: a one-line docstring stating the
+property under test, not a restatement of the test's name.
+
+## Inline `#` comments
+
+Why-only, and sparse. A comment earns its place only where the code would
+otherwise read as arbitrary or wrong — a non-obvious constraint, a unit
+conversion, an upstream quirk being worked around. Don't comment what the
+code already says.
+
+Sentence case, no trailing period, wrapped at the ruff `line-length = 100`.
+Condense multi-line blocks to the load-bearing sentence:
+
+```python
+# Daily bars would mismatch the resolution the technical agent expects
+```
+
+rather than restating the surrounding logic across several lines.
+
+## References
+
+Code-local only. Pointing at a sibling module is fine (`see
+argus/data/fetchers.py`). Don't cite ADRs or narrate incident history from
+source comments — that belongs in `docs/adr/` and PR descriptions, which can
+carry it without going stale independently of the code around them.
+
+## Commit messages
+
+No AI references — no "Co-Authored-By: Claude", no mention of Claude,
+Anthropic, or AI assistance anywhere in the commit message.

--- a/api/main.py
+++ b/api/main.py
@@ -5,11 +5,10 @@ api/main.py
 FastAPI gateway service for the ARGUS multi-agent decision system.
 
 Exposes REST API endpoints to orchestrate execution graphs and audit system
-safety/governor statistics. There is no live /backtest endpoint — see
-docs/adr/0009-no-multiyear-backtest.md for why a multi-year walk-forward
-backtest isn't offered; scripts/replay_backtest.py replays recorded
-fixtures through this same graph over the ~60-day window that is
-genuinely available.
+safety/governor statistics. There is no live /backtest endpoint; a
+multi-year walk-forward backtest isn't offered, so scripts/replay_backtest.py
+replays recorded fixtures through this same graph over the ~60-day window
+that is genuinely available.
 
 Responsibilities:
   - Route analysis requests to the LangGraph execution pipeline
@@ -77,16 +76,12 @@ class AnalysisResponse(BaseModel):
     timestamp: str
 
 
-# Live 5-minute intraday session states keyed by ticker, populated by the MFT
-# background loop. Read by /analyze and injected into ARGUSState before graph
-# execution. Values are (state_dict, updated_at) tuples; entries older than
-# _SESSION_STATE_TTL_SECONDS are treated as missing to prevent stale intraday
-# data from a prior trading session from being injected silently.
+# Entries older than _SESSION_STATE_TTL_SECONDS are treated as missing so a prior
+# session's stale intraday data is never injected silently
 _SESSION_STATE_TTL_SECONDS = 2100  # 35 min = one _SESSION_INTERVAL + 5 min buffer
 _live_session_cache: dict[str, tuple[dict, datetime]] = {}
 
-# Singleton MFT pipeline shared across the server lifetime. Initialized empty;
-# tickers are registered dynamically per /analyze request.
+# Initialized empty; tickers are registered dynamically per /analyze request
 _mft_pipeline: MFTDataPipeline | None = None
 
 
@@ -121,15 +116,12 @@ async def startup_event():
             "[Startup] Macro Agent fit failed (possibly due to missing API keys): %s", e
         )
 
-    # Start the MFT pipeline as a non-blocking background task.
-    # The pipeline begins with an empty ticker list; tickers are registered
-    # on the first /analyze call so the fetch loop tracks only requested symbols.
+    # Empty ticker list at start; the fetch loop only tracks symbols requested later
     _mft_pipeline = MFTDataPipeline(tickers=[])
     asyncio.create_task(_mft_pipeline.start(on_session_ready=_mft_session_callback))
     logger.info("[Startup] MFT pipeline background task launched.")
 
-    # Default risk tolerance and inception value; /kill-switch/reset re-bases
-    # this once the actual session's total_wealth and risk_tolerance are known.
+    # Placeholder base; /kill-switch/reset re-bases once the real session is known
     initialize_kill_switch(risk_tolerance="MODERATE", portfolio_value=100_000.0)
     logger.info("[Startup] Kill switch initialized.")
 
@@ -181,14 +173,10 @@ async def analyze(req: AnalysisRequest):
     if ks and not ks.new_positions_allowed:
         raise HTTPException(503, "New positions blocked. VIX above threshold.")
 
-    # Register requested tickers with the running MFT pipeline so they are
-    # fetched on the next intraday cycle (within _FETCH_INTERVAL seconds).
     if _mft_pipeline is not None:
         _mft_pipeline.register_tickers(req.tickers)
 
-    # Reject if any ticker is missing from the cache or its entry has expired.
-    # Falling back to daily-compressed indicators would produce a mismatched signal
-    # resolution relative to what the TechnicalStatisticalAgent is calibrated for.
+    # Daily bars would mismatch the resolution the technical agent expects
     now = datetime.now()
     missing_from_cache = [
         t for t in req.tickers

--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -198,6 +198,7 @@ class FundamentalCache:
     """
 
     def __init__(self) -> None:
+        """Initializes an empty per-ticker cache."""
         self._cache: dict[str, tuple[FundamentalSignal, datetime]] = {}
         self._ttl_days = 7
 
@@ -248,6 +249,12 @@ class FundamentalAgent:
         llm_client: Optional[LLMClient] = None,
         market_data: Optional[MarketDataProvider] = None,
     ) -> None:
+        """Constructs Groq/live defaults for any provider not injected.
+
+        Args:
+            llm_client: LLM backend; defaults to a Groq-backed client.
+            market_data: Provider for fundamentals lookups; defaults to live fetches.
+        """
         if llm_client is None:
             api_key = settings.groq_api_key
             if not api_key:

--- a/argus/agents/macro.py
+++ b/argus/agents/macro.py
@@ -48,6 +48,12 @@ class RegimeClassifier:
     """
 
     def __init__(self, n_components: int = 3, random_state: int = 42) -> None:
+        """Builds the underlying Gaussian HMM, untrained.
+
+        Args:
+            n_components: Number of latent regime states.
+            random_state: Seed for the HMM's random initialization.
+        """
         self.hmm = GaussianHMM(
             n_components=n_components,
             covariance_type="full",
@@ -185,6 +191,11 @@ class MacroStatisticalAgent:
     """
 
     def __init__(self, market_data: Optional[MarketDataProvider] = None) -> None:
+        """Builds an untrained classifier; call fit_on_history before first use.
+
+        Args:
+            market_data: Provider for FRED/macro fetches; defaults to live fetches.
+        """
         self.classifier = RegimeClassifier()
         self._cache: Tuple[MacroContext, datetime] | None = None
         self._cache_ttl_hours = 6
@@ -196,7 +207,7 @@ class MacroStatisticalAgent:
         Not part of the injectable seam: this is an offline training utility,
         not exercised by the live `analyze()` path graph.py invokes, and its
         direct `yf.download` call for VIX history has no equivalent in
-        MarketDataProvider (see docs/adr/0007-injection-seam.md).
+        MarketDataProvider.
 
         Args:
             start_date: ISO date string defining the beginning of the training window.

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -167,6 +167,11 @@ class PortfolioManagerAgent:
     """
 
     def __init__(self, llm_client: Optional[LLMClient] = None) -> None:
+        """Constructs a Groq client if none is injected.
+
+        Args:
+            llm_client: LLM backend; defaults to a Groq-backed client.
+        """
         if llm_client is None:
             api_key = settings.groq_api_key
             if not api_key:
@@ -315,8 +320,7 @@ class PortfolioManagerAgent:
                         if engine_stop is not None:
                             pos["stop_loss"] = float(engine_stop)
 
-                # Force the residual to be mathematically exact; prevents Pydantic sum validation failure
-                # when the LLM sets cash_reserve_pct independently instead of as 1 - equity
+                # Force residual exact; LLM may set cash_reserve_pct independently, not as 1-equity
                 total_equity = sum(p["allocation_pct"] for p in data.get("portfolio", []))
                 data["cash_reserve_pct"] = round(max(0.0, 1.0 - total_equity), 6)
 

--- a/argus/agents/risk.py
+++ b/argus/agents/risk.py
@@ -35,8 +35,8 @@ from argus.seams import LiveMarketDataProvider, MarketDataProvider
 
 logger = logging.getLogger("argus.risk")
 
-# Stores (sector_string, cached_at) per ticker. 24-hour TTL ensures corporate
-# reclassifications (acquisitions, spin-offs) are reflected without a restart.
+# Stores (sector_string, cached_at) per ticker; 24h TTL reflects corporate reclassifications
+# (M&A, spin-offs) without a restart
 _SECTOR_CACHE: dict[str, tuple[str, datetime]] = {}
 _SECTOR_CACHE_TTL_SECONDS = RISK.sector_cache_ttl_seconds  # 24 hours
 
@@ -226,10 +226,8 @@ def atr_stop_losses(
         if ticker in price_history:
             series = price_history[ticker]
             if len(series) > RISK.atr_period:
-                # NOTE: price_history contains only daily close prices, so true_range here is
-                # the absolute daily close-to-close change — not the canonical H-L-Cprev True Range.
-                # This understates ATR for volatile stocks with large intraday gaps.
-                # A full ATR requires OHLCV data; pass it to this function if precision is required.
+                # NOTE: true_range is close-to-close diff, not H-L-Cprev — understates ATR for
+                # volatile stocks with large intraday gaps; pass OHLCV data here for precision
                 true_range = series.diff().abs().dropna()
                 atr_14 = true_range.tail(RISK.atr_period).mean()
                 latest_close = float(series.iloc[-1])
@@ -271,6 +269,11 @@ class RiskStatisticalEngine:
     """
 
     def __init__(self, market_data: Optional[MarketDataProvider] = None) -> None:
+        """Loads gate thresholds from settings.
+
+        Args:
+            market_data: Provider for price/beta lookups; defaults to live fetches.
+        """
         self.max_position_pct = settings.MAX_SINGLE_POSITION_PCT
         self.max_sector_pct = settings.MAX_SECTOR_CONCENTRATION
         self.vix_blackout = settings.VIX_BLACKOUT_THRESHOLD

--- a/argus/agents/sentiment.py
+++ b/argus/agents/sentiment.py
@@ -150,6 +150,7 @@ class SentimentDailyCache:
     """
 
     def __init__(self) -> None:
+        """Initializes an empty per-ticker cache."""
         self._cache: dict[str, tuple[SentimentSignal, datetime]] = {}
         self._ttl_days = 1
 
@@ -326,6 +327,12 @@ class SentimentAgent:
         llm_client: Optional[LLMClient] = None,
         market_data: Optional[MarketDataProvider] = None,
     ) -> None:
+        """Constructs Groq/live defaults for any provider not injected.
+
+        Args:
+            llm_client: LLM backend; defaults to a Groq-backed client.
+            market_data: Provider for price lookups; defaults to live fetches.
+        """
         if llm_client is None:
             api_key = settings.groq_api_key
             if not api_key:

--- a/argus/backtesting/__init__.py
+++ b/argus/backtesting/__init__.py
@@ -1,7 +1,6 @@
 """Backtesting sub-package for ARGUS.
 
 metrics.py: pure return-series statistics (Sharpe, Sortino, max drawdown, IC).
-replay.py: replays recorded fixture sessions through the real graph — see
-docs/adr/0009-no-multiyear-backtest.md for why there is no multi-year
-walk-forward engine here.
+replay.py: replays recorded fixture sessions through the real graph; there is
+no multi-year walk-forward engine here.
 """

--- a/argus/backtesting/evaluation.py
+++ b/argus/backtesting/evaluation.py
@@ -1,9 +1,8 @@
 """
 argus/backtesting/evaluation.py
 
-PR 10's pre-registered evaluation (see docs/adr/0012-pre-registered-evaluation.md
-for what is measured, why, and the success threshold fixed before any of
-this module's output was observed).
+Pre-registered evaluation of the outcome loop: what is measured, why, and
+the success threshold fixed before any of this module's output was observed.
 
 Responsibilities:
   - Pair each decision's signed conviction with its realized forward return
@@ -15,8 +14,8 @@ Responsibilities:
 
 Not responsible for:
   - Running the replay itself (see backtesting/replay.py)
-  - Deciding what horizon/dead-band/threshold to use (fixed in ADR 0012 and
-    read from argus/params.py, not re-derived here)
+  - Deciding what horizon/dead-band/threshold to use (fixed ahead of time
+    and read from argus/params.py, not re-derived here)
 
 Dependencies:
   - numpy, scipy (statistics)
@@ -80,7 +79,7 @@ def collect_paired_outcomes(
     parallel notion of "outcome". Decisions with no aggregated signal, no
     allocation, or whose horizon hasn't cleared against market_data are
     skipped (see compute_realized_return's docstring for why: deferred
-    rather than fabricated, per ADR 0002).
+    rather than fabricated).
 
     Args:
         decisions: Completed ARGUSDecision objects, e.g. from a replayed
@@ -135,7 +134,7 @@ def hit_rate_with_deadband(pairs: Sequence[PairedOutcome], deadband: float) -> t
     Decisions whose forward return falls within +/-deadband are excluded —
     mirroring cultural.store_trade_outcome's own dead band
     (RECONCILIATION.min_abs_return_for_storage), not a second invented
-    threshold (see ADR 0012).
+    threshold.
 
     Args:
         pairs: Paired outcomes to score.
@@ -167,8 +166,8 @@ def bootstrap_ci(
 
     Paired resampling (each resample draws whole PairedOutcome tuples, with
     replacement) rather than a closed-form CI — at the sample sizes this
-    evaluation actually has (see ADR 0012), asymptotic-normality assumptions
-    behind closed-form Spearman CIs don't hold.
+    evaluation actually has, asymptotic-normality assumptions behind
+    closed-form Spearman CIs don't hold.
 
     Args:
         pairs: Paired outcomes to resample from.
@@ -230,9 +229,9 @@ def evaluate_decisions(
         decisions: Completed ARGUSDecision objects.
         market_data: Source of each ticker's daily close price series.
         horizon_days: Calendar days after session_timestamp defining the
-            target exit date (ADR 0012 pre-registers 5).
+            target exit date (pre-registered at 5).
         deadband: Absolute forward-return threshold for hit-rate exclusion
-            (ADR 0012 pre-registers RECONCILIATION.min_abs_return_for_storage).
+            (pre-registered as RECONCILIATION.min_abs_return_for_storage).
 
     Returns:
         EvaluationResult with rank IC, hit-rate, and bootstrap CIs for both.
@@ -258,7 +257,7 @@ def evaluate_decisions(
 @dataclass(frozen=True)
 class SystemBehaviorReport:
     """System-behavior metrics for one replayed session — reported separately from
-    (never blended into) EvaluationResult's predictive metrics. See ADR 0012.
+    (never blended into) EvaluationResult's predictive metrics.
     """
 
     tickers_total: int
@@ -279,7 +278,7 @@ def system_behavior_report(session_result: SessionResult) -> SystemBehaviorRepor
     Constraint violations are reported as 0 by construction:
     RiskAssessment.approved_weight <= proposed_weight is a Pydantic
     model_validator, so a violating instance cannot exist in
-    final_state["decisions"] in the first place (see ADR 0012).
+    final_state["decisions"] in the first place.
     Retries and tokens/decision are not currently instrumented anywhere in
     the codebase at decision granularity — reported as a disclosed gap
     rather than fabricated.
@@ -318,8 +317,7 @@ def check_replay_determinism(session_dir: Path) -> bool:
 
     closed_loop=True is intentionally not checked here — it reads live
     chroma_db state, which reconciliation can mutate between runs, so
-    determinism isn't a property closed-loop replay is expected to have
-    (see ADR 0012).
+    determinism isn't a property closed-loop replay is expected to have.
 
     Args:
         session_dir: Directory shaped like tests/fixtures/.

--- a/argus/backtesting/replay.py
+++ b/argus/backtesting/replay.py
@@ -4,15 +4,14 @@ argus/backtesting/replay.py
 Minimal intraday backtest: replays recorded fixture "sessions" through the
 real ARGUS graph (build_graph()), in strict time order.
 
-See docs/adr/0009-no-multiyear-backtest.md for why this exists instead of a
-multi-year walk-forward backtest: Yahoo's 5-minute intraday data is only
-available for the trailing 60 days, and the MFT session_states dict
-(the technical-indicator snapshot TechnicalStatisticalAgent needs) is itself
-only ever captured live from the running pipeline, not reconstructible for
-an arbitrary past date. There is no historical 5-minute-resolution data to
-backtest against beyond ~60 days, and no way to fabricate session_states for
-older dates without violating ADR 0002 ("return None rather than fabricate
-defaults").
+This exists instead of a multi-year walk-forward backtest because Yahoo's
+5-minute intraday data is only available for the trailing 60 days, and the
+MFT session_states dict (the technical-indicator snapshot
+TechnicalStatisticalAgent needs) is itself only ever captured live from the
+running pipeline, not reconstructible for an arbitrary past date. There is
+no historical 5-minute-resolution data to backtest against beyond ~60 days,
+and no way to fabricate session_states for older dates without violating
+the system's "return None rather than fabricate defaults" rule.
 
 A "session" here is one fixture snapshot directory shaped like
 tests/fixtures/ (market_data/ + llm_responses/ subdirectories) — one real
@@ -25,13 +24,12 @@ earlier one — there is nothing to leak, since each session only ever sees
 its own files, and replay_sessions() only invokes session N+1 after N has
 returned.
 
-Today exactly one such session exists (tests/fixtures/, captured in PR 5).
-Scaling this to the ~60-day / ~780-decision-point window the design targets
-requires capturing that many more sessions from a live MFT pipeline run —
-future work, and the first real consumer is PR 10's pre-registered
-evaluation. This module's job is to prove the replay mechanism itself is
-correct and reusable, not to fabricate a backlog of sessions that were
-never recorded.
+Today exactly one such session exists (tests/fixtures/). Scaling this to
+the ~60-day / ~780-decision-point window the design targets requires
+capturing that many more sessions from a live MFT pipeline run — future
+work, with the pre-registered evaluation as the first real consumer. This
+module's job is to prove the replay mechanism itself is correct and
+reusable, not to fabricate a backlog of sessions that were never recorded.
 """
 
 from __future__ import annotations
@@ -90,6 +88,14 @@ def _portfolio_llm(session_dir: Path) -> FixtureLLMClient:
 
 
 def _load_session_states(session_dir: Path) -> tuple[list[str], dict[str, dict]]:
+    """Loads the fixture's session_states.json and returns its sorted ticker universe.
+
+    Args:
+        session_dir: Directory shaped like tests/fixtures/.
+
+    Returns:
+        Tuple of (sorted ticker list, raw ticker -> session-state dict).
+    """
     with open(session_dir / "market_data" / "session_states.json") as f:
         session_states = json.load(f)
     return sorted(session_states), session_states
@@ -104,11 +110,11 @@ def replay_session(
 ) -> SessionResult:
     """Runs the real graph once against a single captured fixture session.
 
-    The rate-limit governor is always patched to a no-op (its real
-    per-minute throttling is orthogonal to whether fixture replay is
-    correct — see ADR 0008's test_golden_dag.py precedent). Returns the raw
-    final ARGUSState dict; this function makes no judgment about what a
-    "good" outcome looks like — that's PR 10's job.
+    The rate-limit governor is always patched to a no-op, matching the
+    approach test_golden_dag.py takes: its real per-minute throttling is
+    orthogonal to whether fixture replay is correct. Returns the raw final
+    ARGUSState dict; this function makes no judgment about what a "good"
+    outcome looks like — that's the evaluation module's job.
 
     Args:
         session_dir: Directory shaped like tests/fixtures/ (market_data/ +
@@ -117,12 +123,12 @@ def replay_session(
         invest_pct: Fraction of total_wealth eligible for allocation.
         risk_tolerance: 'CONSERVATIVE', 'MODERATE', or 'AGGRESSIVE'.
         closed_loop: When False (default), cultural memory is mocked to
-            return neutral wisdom/warnings/accuracy (per ADR 0007, it isn't
-            a fixture-replay candidate) — reliability weighting is fixed at
+            return neutral wisdom/warnings/accuracy — it isn't a
+            fixture-replay candidate — so reliability weighting is fixed at
             the 0.5 prior. When True, the real `get_cultural_memory()` is
             used, so `wisdom`/`warnings`/reliability weighting read
-            whatever outcome history actually exists in `chroma_db`. See
-            ADR 0012 for why PR 10's evaluation runs both.
+            whatever outcome history actually exists in `chroma_db`. The
+            evaluation runs both so it can compare the two conditions.
 
     Returns:
         SessionResult with the session's universe and the graph's final state.

--- a/argus/config.py
+++ b/argus/config.py
@@ -44,21 +44,17 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # LLM provider credentials
     groq_api_key: str = Field(default="", description="Groq LLM API key")
     google_ai_api_key: str = Field(default="", description="Google AI / Gemini API key")
 
-    # Market and macroeconomic data providers
     fred_api_key: str = Field(default="", description="FRED (Federal Reserve) API key")
     polygon_api_key: str = Field(default="", description="Polygon.io market data API key")
     alpaca_api_key: str = Field(default="", description="Alpaca trading API key")
     alpaca_secret_key: str = Field(default="", description="Alpaca trading API secret")
 
-    # News and sentiment data providers
     newsapi_key: str = Field(default="", description="NewsAPI.org key")
 
-    # Default equity universe: 20 liquid large-cap tickers spanning 7 GICS sectors.
-    # Broadened to reduce sector concentration risk in Phase 2 walk-forward validation.
+    # Broadened to 20 tickers across 7 GICS sectors to reduce sector concentration risk
     UNIVERSE_DEFAULT: List[str] = [
         "AAPL", "MSFT", "NVDA", "GOOGL", "AMZN",
         "META", "TSLA", "JPM", "V", "UNH",
@@ -66,14 +62,12 @@ class Settings(BaseSettings):
         "MRK", "ABBV", "LLY", "AVGO", "CVX",
     ]
 
-    # MFT pipeline timing parameters. Numeric defaults live in argus/params.py,
-    # tagged with provenance (literature/convention/calibrated/arbitrary); this
-    # class only adds env-var override capability on top of them.
+    # Numeric defaults live in argus/params.py, tagged with provenance; this class
+    # only adds env-var override capability on top of them
     MFT_CANDLE_INTERVAL: str = "5m"
     MFT_DECISION_INTERVAL_SECONDS: int = SYSTEM.mft_decision_interval_seconds
     CANDLE_BUFFER_SIZE: int = SYSTEM.candle_buffer_size
 
-    # Technical indicator scoring weights
     TECHNICAL_INDICATOR_WEIGHTS: Dict[str, float] = {
         "rsi": _TECHNICAL_WEIGHTS.rsi,
         "macd": _TECHNICAL_WEIGHTS.macd,
@@ -88,7 +82,6 @@ class Settings(BaseSettings):
     MAX_SECTOR_CONCENTRATION: float = SYSTEM.max_sector_concentration
     MAX_PORTFOLIO_BETA: float = SYSTEM.max_portfolio_beta
 
-    # Kill-switch circuit breaker thresholds
     VIX_BLACKOUT_THRESHOLD: float = SYSTEM.vix_blackout_threshold
     MAX_DRAWDOWN_HALT: float = SYSTEM.max_drawdown_halt
 

--- a/argus/data/cache.py
+++ b/argus/data/cache.py
@@ -10,9 +10,8 @@ Not responsible for:
   - Fetching raw data (see data/fetchers.py)
   - Semantic vector storage or decision archiving — the LangGraph checkpoint
     (argus_graph.db, see orchestration/graph.py) and ChromaDB
-    (memory/cultural.py) cover this; see docs/adr/0010 for why a third,
-    unused archive (formerly DecisionLogger, here) was deleted rather than
-    wired up.
+    (memory/cultural.py) cover this; a third, unused archive (formerly
+    DecisionLogger, here) was deleted rather than wired up.
 
 Dependencies:
   - sqlite3 (stdlib)
@@ -80,6 +79,12 @@ class OHLCVBuffer:
     """
 
     def __init__(self, db_path: str = ":memory:", buffer_size: int = 78) -> None:
+        """Opens (or creates) the SQLite-backed candle buffer.
+
+        Args:
+            db_path: SQLite connection path, or ':memory:' for an ephemeral buffer.
+            buffer_size: Max candles retained per ticker; older rows are pruned on insert.
+        """
         self._db_path = db_path
         self._buffer_size = buffer_size
         self._lock = threading.Lock()

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -56,6 +56,11 @@ class MFTDataPipeline:
         self,
         tickers: list[str],
     ) -> None:
+        """Creates the pipeline with an in-memory candle buffer for the given universe.
+
+        Args:
+            tickers: Initial ticker universe to track.
+        """
         self.tickers = tickers
         self.buffer = OHLCVBuffer(db_path=":memory:", buffer_size=78)
         self.running = False

--- a/argus/memory/cultural.py
+++ b/argus/memory/cultural.py
@@ -43,6 +43,11 @@ class CulturalMemoryManager:
     """
 
     def __init__(self, persist_dir: str = "./chroma_db"):
+        """Opens (or creates) the persistent ChromaDB collection and embedding function.
+
+        Args:
+            persist_dir: Filesystem directory backing the ChromaDB PersistentClient.
+        """
         import chromadb
         from chromadb.utils import embedding_functions
 
@@ -200,8 +205,7 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
         MEMORY.accuracy_shrinkage_k pseudo-observations (wins + k*0.5) / (n + k),
         so an agent with 3 observations isn't trusted like one with 300 — it
         converges to the raw win rate as n grows and collapses to 0.5 as
-        n -> 0. See docs/adr/0011 for why this feeds
-        orchestration/aggregator.py's reliability weighting.
+        n -> 0. Feeds orchestration/aggregator.py's reliability weighting.
 
         Args:
             agent_name: Agent identifier string (e.g. 'technical', 'fundamental', 'sentiment').
@@ -346,9 +350,15 @@ def get_cultural_memory(persist_dir: str = "./chroma_db") -> CulturalMemoryManag
 
     Lazy on purpose: construction pulls in sentence-transformers (and its
     torch dependency) to build the embedding function, and both are an
-    optional `[models]` extra (see pyproject.toml, ADR 0007) — importing
-    this module must not require them, only actually using cultural memory
-    does.
+    optional `[models]` extra (see pyproject.toml) — importing this module
+    must not require them, only actually using cultural memory does.
+
+    Args:
+        persist_dir: Filesystem directory backing the ChromaDB PersistentClient,
+            used only on the first call that constructs the manager.
+
+    Returns:
+        The process-wide CulturalMemoryManager singleton.
     """
     global _cultural_memory
     if _cultural_memory is None:

--- a/argus/orchestration/aggregator.py
+++ b/argus/orchestration/aggregator.py
@@ -144,8 +144,7 @@ class HybridSignalAggregator:
             consensus = Signal.NEUTRAL
             conviction = neutral_pct
 
-        # Contract-based regime override: CONTRACTION suppresses BULLISH signals below a conviction
-        # threshold of 0.70 to prevent the system from misallocating during elevated-stress regimes
+        # CONTRACTION suppresses low-conviction BULLISH to avoid overallocating in stressed regimes
         if macro and macro.macro_regime == Regime.CONTRACTION:
             if consensus == Signal.BULLISH and conviction < AGGREGATOR.contraction_conviction_threshold:
                 logger.info(

--- a/argus/orchestration/governor.py
+++ b/argus/orchestration/governor.py
@@ -90,6 +90,7 @@ class RateLimitGovernor:
     """
 
     def __init__(self) -> None:
+        """Initializes empty per-model usage tracking."""
         self._usage: dict[str, ModelUsage] = {}
         self._lock = threading.Lock()
         logger.info("RateLimitGovernor initialized with %d model profiles", len(MODEL_LIMITS))

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -21,12 +21,12 @@ Dependencies:
   - argus.agents.* (all six specialist agents)
   - SQLite checkpointer (argus_graph.db) for resumable runs
 
-Agent wiring is a build_graph() parameter, not a module-level singleton (see
-docs/adr/0007-injection-seam.md): every agent that touches the network or an
-LLM accepts a MarketDataProvider/LLMClient, defaulting to the real
-implementation, so a test can build a fixture-backed graph without patching
-this module's internals. `graph` below is the default, real-data instance —
-the one api/main.py imports.
+Agent wiring is a build_graph() parameter, not a module-level singleton:
+every agent that touches the network or an LLM accepts a
+MarketDataProvider/LLMClient, defaulting to the real implementation, so a
+test can build a fixture-backed graph without patching this module's
+internals. `graph` below is the default, real-data instance — the one
+api/main.py imports.
 """
 
 import logging
@@ -53,13 +53,9 @@ from argus.seams import LiveMarketDataProvider, LLMClient, MarketDataProvider
 
 logger = logging.getLogger("argus.graph")
 
-# Every argus.schemas.signals BaseModel subclass that can end up nested inside
-# ARGUSState's channel values (directly or via ARGUSDecision) needs to be
-# named here, or the checkpointer's msgpack deserializer either logs a
-# deprecation warning today or silently degrades reconstructed objects to
-# plain dicts in a future langgraph version. Shared by build_graph()'s real
-# checkpointer and argus/orchestration/reconciliation.py's checkpoint loader
-# so the two allowlists can't drift apart. See docs/adr/0010.
+# Every schemas.signals model nested in ARGUSState must be listed here or the
+# checkpointer's msgpack deserializer degrades it to a plain dict; shared with
+# reconciliation.py's checkpoint loader so the two allowlists can't drift apart
 _CHECKPOINT_MODEL_CLASSES = (
     "MacroContext",
     "TechnicalSignal",
@@ -304,7 +300,7 @@ def build_graph(
                 )
                 convictions[t] = sig.conviction * sign
 
-        # Joint portfolio evaluation captures inter-asset covariance and global diversification limits
+        # Joint evaluation captures inter-asset covariance and global diversification limits
         base_weight = min(0.15, 1.0 / len(universe)) if universe else 0.15
         full_portfolio = [{"ticker": t, "weight": base_weight} for t in universe]
         portfolio_result = risk_engine.evaluate(full_portfolio, history, vix, convictions=convictions)
@@ -317,7 +313,7 @@ def build_graph(
         for ticker in universe:
             single = risk_engine.evaluate([{"ticker": ticker, "weight": 0.15}], history, vix)
 
-            # Propagate portfolio-level correlation stats to individual records for uniform telemetry
+            # Propagate portfolio-level correlation stats for uniform telemetry
             single = single.model_copy(update={"avg_correlation": portfolio_result.avg_correlation})
 
             if ticker in ticker_cap_map and not portfolio_vetoed:
@@ -407,7 +403,6 @@ def build_graph(
             logger.warning("[log_decisions] No portfolio_allocation in state; skipping.")
             return {"decisions": []}
 
-        # Index allocations by ticker for O(1) lookup during decision assembly
         positions = {pos.ticker: pos for pos in allocation.portfolio}
         now = datetime.now()
         decisions: list[ARGUSDecision] = []
@@ -427,7 +422,7 @@ def build_graph(
                 )
                 decisions.append(decision)
 
-                # Snapshot is stored before outcome confirmation to enable pre-settlement similarity retrieval
+                # Snapshot stored pre-confirmation to enable pre-settlement similarity retrieval
                 get_cultural_memory().store_decision_snapshot(decision)
 
             except Exception as exc:

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -6,10 +6,9 @@ realized-return computation against a MarketDataProvider, and pulling
 completed decisions back out of the LangGraph checkpoint so
 cultural.store_trade_outcome has something real to persist.
 
-See docs/adr/0010-closing-the-decision-outcome-loop.md for why decisions are
-read back from the existing LangGraph checkpoint rather than a new archive,
-why credit assignment is leave-one-out ablation rather than exact Shapley,
-and why horizon_days is provisional pending PR 10's pre-registered evaluation.
+Decisions are read back from the existing LangGraph checkpoint rather than a
+new archive, credit assignment uses leave-one-out ablation rather than exact
+Shapley, and horizon_days is provisional pending a pre-registered evaluation.
 
 Responsibilities:
   - credit_primary_driver: leave-one-out ablation over HybridSignalAggregator
@@ -77,8 +76,8 @@ def credit_primary_driver(
     already-computed baseline `weighted_votes` — pools are additive sums of
     independent per-agent votes, so a removed agent's marginal effect on its
     pool total is exactly its own vote, no need to re-derive it per
-    ablation) was the bigger contributor. See docs/adr/0010 for why this is
-    used instead of exact Shapley over the 2^3 - 1 coalitions.
+    ablation) was the bigger contributor. This avoids exact Shapley over the
+    2^3 - 1 coalitions.
 
     Args:
         decision: Completed ARGUSDecision with technical/fundamental/sentiment
@@ -153,7 +152,7 @@ def compute_realized_return(
         nothing to reconcile: no technical signal (no entry price), no
         allocation (no position was taken), or the price series doesn't yet
         extend past the target exit date — horizon not reached, deferred
-        rather than fabricated (see ADR 0002).
+        rather than fabricated.
     """
     if decision.technical is None or decision.allocation is None:
         return None
@@ -258,9 +257,8 @@ def load_decisions_from_checkpoints(db_path: str = "argus_graph.db") -> list[ARG
     Each session runs under its own thread_id (see build_graph()'s callers),
     and SqliteSaver.list() yields checkpoints newest-first; this keeps each
     thread's first (= most recent, most complete) checkpoint's `decisions`
-    channel value and skips the rest. See docs/adr/0010 for why this reads
-    the checkpoint the graph already writes rather than a dedicated decision
-    archive.
+    channel value and skips the rest, reading the checkpoint the graph
+    already writes rather than maintaining a dedicated decision archive.
 
     Args:
         db_path: Path to the SQLite file build_graph() checkpoints to.

--- a/argus/params.py
+++ b/argus/params.py
@@ -4,8 +4,7 @@ argus/params.py
 Single source of truth for every free (hand-set, non-derived) numeric
 parameter in ARGUS, each tagged with where its value came from.
 
-See docs/adr/0006-parameter-provenance.md for the rationale. In short: a
-system that mixes textbook constants (RSI period 14), industry convention
+A system that mixes textbook constants (RSI period 14), industry convention
 (RSI 30/70 overbought/oversold), values tuned against ARGUS's own data, and
 outright guesses reads identically in the source unless the provenance is
 written down next to the value. This module makes that distinction
@@ -19,9 +18,9 @@ Provenance categories:
                 (e.g. RSI 30/70 bands, half-Kelly sizing).
   CALIBRATED  — tuned against ARGUS's own data or backtests. As of this
                 writing there is no honest instance of this category: the
-                Phase 1/2 calibration harness measured a constant (see
-                docs/adr/0006) and PR 7 deletes it. Any future value in
-                this category must point at real evidence.
+                Phase 1/2 calibration harness measured a constant and PR 7
+                deletes it. Any future value in this category must point at
+                real evidence.
   ARBITRARY   — a guess with no basis beyond "seemed reasonable". Writing
                 ARBITRARY where it is arbitrary is the point of this
                 module: it is a to-do list for what needs real evaluation.
@@ -40,6 +39,8 @@ PARAMS_VERSION = 1
 
 
 class Provenance(str, Enum):
+    """Where a parameter's value came from: see the module docstring for definitions."""
+
     LITERATURE = "literature"
     CONVENTION = "convention"
     CALIBRATED = "calibrated"
@@ -53,6 +54,14 @@ def p(value: Any, provenance: Provenance, note: str = "") -> Any:
     other attribute (`TECHNICAL.rsi_oversold`), no unwrapping required. The
     provenance/note live in `__dataclass_fields__[name].metadata` for
     introspection (see `all_params` below).
+
+    Args:
+        value: The default value the field holds.
+        provenance: Category explaining where the value came from.
+        note: Free-text detail supporting the provenance category.
+
+    Returns:
+        A dataclasses.field() configured with `value` as its default.
     """
     return field(default=value, metadata={"provenance": provenance, "note": note})
 
@@ -197,8 +206,8 @@ class ReconciliationParams:
     horizon_days: int = p(
         5,
         Provenance.ARBITRARY,
-        "pre-registered by docs/adr/0012 before any evaluation result was "
-        "observed; still no empirical basis for this specific value",
+        "pre-registered before any evaluation result was observed; still no "
+        "empirical basis for this specific value",
     )
     min_abs_return_for_storage: float = p(
         0.01,
@@ -216,7 +225,7 @@ class MemoryParams:
         10.0,
         Provenance.ARBITRARY,
         "pseudo-observation count pulling small-sample agent accuracy toward "
-        "the 0.5 prior; no basis for this specific strength, see docs/adr/0011",
+        "the 0.5 prior; no basis for this specific strength",
     )
 
 

--- a/argus/risk/kill_switch.py
+++ b/argus/risk/kill_switch.py
@@ -59,6 +59,13 @@ class KillSwitch:
     VIX_BLACKOUT = getattr(settings, "VIX_BLACKOUT_THRESHOLD", 35.0)
 
     def __init__(self, user_risk_tolerance: str, check_interval_seconds: int = 60):
+        """Initializes the kill switch, deferring monitoring until start() is called.
+
+        Args:
+            user_risk_tolerance: Risk tier string ('CONSERVATIVE', 'MODERATE',
+                'AGGRESSIVE'); unrecognized values fall back to 'MODERATE'.
+            check_interval_seconds: Seconds between monitor loop iterations.
+        """
         self.risk_tolerance = user_risk_tolerance.upper()
         if self.risk_tolerance not in self.DRAWDOWN_THRESHOLDS:
             logger.warning(f"Unknown risk tolerance {self.risk_tolerance}, defaulting to MODERATE.")

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -211,7 +211,11 @@ class TechnicalSignal(BaseModel):
     @field_validator("conviction", mode="before")
     @classmethod
     def cap_conviction(cls, v: float) -> float:
-        """Silently clamps conviction to the 0.95 maximum."""
+        """Silently clamps conviction to the 0.95 maximum.
+
+        Args:
+            v: Raw conviction value.
+        """
         return _clamp_conviction(v)
 
 
@@ -250,6 +254,7 @@ class FundamentalSignal(BaseModel):
     @field_validator("conviction", mode="before")
     @classmethod
     def cap_conviction(cls, v: float) -> float:
+        """Silently clamps conviction to the 0.95 maximum."""
         return _clamp_conviction(v)
 
 
@@ -290,6 +295,7 @@ class SentimentSignal(BaseModel):
     @field_validator("conviction", mode="before")
     @classmethod
     def cap_conviction(cls, v: float) -> float:
+        """Silently clamps conviction to the 0.95 maximum."""
         return _clamp_conviction(v)
 
     @model_validator(mode="after")

--- a/argus/seams.py
+++ b/argus/seams.py
@@ -6,9 +6,6 @@ network market-data fetches (argus/data/fetchers.py) and Groq LLM calls
 (inline `ChatGroq` construction previously duplicated in fundamental.py,
 sentiment.py, and portfolio.py).
 
-See docs/adr/0007-injection-seam.md for why this exists and what it
-deliberately does not cover.
-
 Each boundary gets one Protocol and two implementations:
   - `MarketDataProvider` / `LiveMarketDataProvider` (delegates to
     argus/data/fetchers.py, unchanged behavior) / `FixtureMarketDataProvider`
@@ -52,48 +49,72 @@ class MarketDataProvider(Protocol):
     they wrap; see that module's docstrings for the semantics of each field.
     """
 
-    def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame: ...
+    def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame:
+        """Returns daily OHLCV history for a ticker."""
+        ...
 
-    def multiple_daily(self, tickers: list[str], period: str = "1y") -> dict[str, pd.DataFrame]: ...
+    def multiple_daily(self, tickers: list[str], period: str = "1y") -> dict[str, pd.DataFrame]:
+        """Returns daily OHLCV history for multiple tickers, keyed by ticker."""
+        ...
 
-    def fundamentals(self, ticker: str) -> dict: ...
+    def fundamentals(self, ticker: str) -> dict:
+        """Returns the fundamentals ratio payload for a ticker."""
+        ...
 
-    def fred_series(self, series_id: str, start: str = "2018-01-01") -> pd.Series: ...
+    def fred_series(self, series_id: str, start: str = "2018-01-01") -> pd.Series:
+        """Returns a FRED economic time series."""
+        ...
 
-    def macro_bundle(self) -> dict: ...
+    def macro_bundle(self) -> dict:
+        """Returns the current macro indicator bundle."""
+        ...
 
-    def news(self, ticker: str, company_name: str, days_back: int = 7) -> list[dict]: ...
+    def news(self, ticker: str, company_name: str, days_back: int = 7) -> list[dict]:
+        """Returns recent news articles for a ticker."""
+        ...
 
-    def social_sentiment(self, ticker: str) -> dict: ...
+    def social_sentiment(self, ticker: str) -> dict:
+        """Returns social media sentiment metrics for a ticker."""
+        ...
 
-    def vix(self) -> float: ...
+    def vix(self) -> float:
+        """Returns the current CBOE VIX level."""
+        ...
 
 
 class LiveMarketDataProvider:
     """Thin delegating wrapper around argus/data/fetchers.py. No behavior change."""
 
     def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame:
+        """Delegates to fetchers.fetch_ohlcv_daily."""
         return fetchers.fetch_ohlcv_daily(ticker, period=period)
 
     def multiple_daily(self, tickers: list[str], period: str = "1y") -> dict[str, pd.DataFrame]:
+        """Delegates to fetchers.fetch_multiple_daily."""
         return fetchers.fetch_multiple_daily(tickers, period=period)
 
     def fundamentals(self, ticker: str) -> dict:
+        """Delegates to fetchers.fetch_fundamentals."""
         return fetchers.fetch_fundamentals(ticker)
 
     def fred_series(self, series_id: str, start: str = "2018-01-01") -> pd.Series:
+        """Delegates to fetchers.fetch_fred_series."""
         return fetchers.fetch_fred_series(series_id, start=start)
 
     def macro_bundle(self) -> dict:
+        """Delegates to fetchers.fetch_macro_bundle."""
         return fetchers.fetch_macro_bundle()
 
     def news(self, ticker: str, company_name: str, days_back: int = 7) -> list[dict]:
+        """Delegates to fetchers.fetch_news."""
         return fetchers.fetch_news(ticker, company_name, days_back=days_back)
 
     def social_sentiment(self, ticker: str) -> dict:
+        """Delegates to fetchers.fetch_social_sentiment."""
         return fetchers.fetch_social_sentiment(ticker)
 
     def vix(self) -> float:
+        """Delegates to fetchers.fetch_vix."""
         return fetchers.fetch_vix()
 
 
@@ -103,10 +124,15 @@ class FixtureMarketDataProvider:
     Fixtures are plain JSON keyed by ticker (see scripts/capture_fixtures.py).
     A ticker missing from a fixture file raises KeyError rather than silently
     returning empty/zero data — a test exercising a ticker with no fixture
-    should fail loudly, not pass on fabricated data (see ADR 0002).
+    should fail loudly, not pass on fabricated data.
     """
 
     def __init__(self, fixtures_dir: Path = FIXTURES_DIR / "market_data") -> None:
+        """Initializes the provider against a fixtures directory.
+
+        Args:
+            fixtures_dir: Directory containing the per-domain JSON fixture files.
+        """
         self._dir = fixtures_dir
         self._cache: dict[str, Any] = {}
 
@@ -118,6 +144,7 @@ class FixtureMarketDataProvider:
         return self._cache[name]
 
     def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame:
+        """Returns cached OHLCV history from the price_history fixture."""
         record = self._load("price_history")[ticker]
         return pd.DataFrame(
             {"close": record["prices"]},
@@ -125,25 +152,32 @@ class FixtureMarketDataProvider:
         )
 
     def multiple_daily(self, tickers: list[str], period: str = "1y") -> dict[str, pd.DataFrame]:
+        """Returns cached OHLCV history for each ticker present in the price_history fixture."""
         return {t: self.ohlcv_daily(t, period=period) for t in tickers if t in self._load("price_history")}
 
     def fundamentals(self, ticker: str) -> dict:
+        """Returns the cached fundamentals payload from the fundamentals fixture."""
         return dict(self._load("fundamentals")[ticker])
 
     def fred_series(self, series_id: str, start: str = "2018-01-01") -> pd.Series:
+        """Returns a cached FRED series from the fred_series fixture."""
         record = self._load("fred_series")[series_id]
         return pd.Series(record["values"], index=pd.to_datetime(record["dates"]))
 
     def macro_bundle(self) -> dict:
+        """Returns the cached macro indicator bundle from the macro_bundle fixture."""
         return dict(self._load("macro_bundle"))
 
     def news(self, ticker: str, company_name: str, days_back: int = 7) -> list[dict]:
+        """Returns cached news articles from the news fixture, or an empty list if none."""
         return list(self._load("news").get(ticker, []))
 
     def social_sentiment(self, ticker: str) -> dict:
+        """Returns cached social sentiment metrics from the social_sentiment fixture."""
         return dict(self._load("social_sentiment").get(ticker, {}))
 
     def vix(self) -> float:
+        """Returns the cached VIX level from the macro_bundle fixture."""
         return float(self._load("macro_bundle")["vix"])
 
 
@@ -160,13 +194,23 @@ class LLMClient(Protocol):
     LLM to answer this prompt," not "what does the answer mean."
     """
 
-    def complete(self, system_prompt: str, user_prompt: str) -> str: ...
+    def complete(self, system_prompt: str, user_prompt: str) -> str:
+        """Sends a system + user prompt to the LLM and returns the raw response text."""
+        ...
 
 
 class GroqLLMClient:
     """Wraps a ChatGroq model+params combination. One instance per (model, temperature, max_tokens)."""
 
     def __init__(self, model: str, temperature: float, max_tokens: int, api_key: str) -> None:
+        """Constructs the underlying ChatGroq client for this model+params combination.
+
+        Args:
+            model: Groq model identifier.
+            temperature: Sampling temperature.
+            max_tokens: Maximum completion length in tokens.
+            api_key: Groq API key.
+        """
         self._llm = ChatGroq(
             model_name=model,
             temperature=temperature,
@@ -175,6 +219,11 @@ class GroqLLMClient:
         )
 
     def complete(self, system_prompt: str, user_prompt: str) -> str:
+        """Invokes the Groq model and returns its response as plain text.
+
+        Returns:
+            The response text, flattened from a content-block list if needed.
+        """
         response = self._llm.invoke(
             [SystemMessage(content=system_prompt), HumanMessage(content=user_prompt)]
         )
@@ -199,10 +248,22 @@ class FixtureLLMClient:
     """
 
     def __init__(self, responses: dict[str, str], key_fn: Optional[Any] = None) -> None:
+        """Stores the response map and the key function used to look up responses.
+
+        Args:
+            responses: Mapping of key → pre-captured raw response text.
+            key_fn: Function deriving a lookup key from the user prompt. Defaults
+                to using the user prompt itself as the key.
+        """
         self._responses = responses
         self._key_fn = key_fn or (lambda user_prompt: user_prompt)
 
     def complete(self, system_prompt: str, user_prompt: str) -> str:
+        """Returns the pre-captured response text keyed by ``key_fn(user_prompt)``.
+
+        Raises:
+            KeyError: If no response was recorded for the derived key.
+        """
         key = self._key_fn(user_prompt)
         if key not in self._responses:
             raise KeyError(f"FixtureLLMClient has no recorded response for key {key!r}")
@@ -210,6 +271,15 @@ class FixtureLLMClient:
 
     @classmethod
     def from_fixture_file(cls, path: Path, key_fn: Optional[Any] = None) -> "FixtureLLMClient":
+        """Builds a FixtureLLMClient from a JSON file of key → response text.
+
+        Args:
+            path: Path to the JSON fixture file.
+            key_fn: Function deriving a lookup key from the user prompt.
+
+        Returns:
+            A FixtureLLMClient backed by the loaded responses.
+        """
         with open(path) as f:
             responses = json.load(f)
         return cls(responses, key_fn=key_fn)

--- a/scripts/capture_fixtures.py
+++ b/scripts/capture_fixtures.py
@@ -13,9 +13,9 @@ session (universe: AAPL, MSFT, NVDA, GOOGL, AMZN, JPM, XOM, ...). This script
 picks the traces for `fetch_price_history`, `macro_analysis`,
 `fundamental_analysis`, `sentiment_analysis`, and `portfolio_allocation`, and
 reshapes their outputs into the schema argus/seams.py's FixtureMarketDataProvider and
-FixtureLLMClient expect — see ADR 0007 for why: existing traces already
-contain a real session's worth of ARGUS output, so this reuses evidence
-already sitting in the repo instead of hand-authoring synthetic fixtures.
+FixtureLLMClient expect: existing traces already contain a real session's
+worth of ARGUS output, so this reuses evidence already sitting in the repo
+instead of hand-authoring synthetic fixtures.
 
 For the LLM-response fixtures, only the fields that genuinely come from the
 model (not the ones the calling code overwrites after `json.loads`, per
@@ -64,8 +64,7 @@ def capture_fundamentals_and_llm_responses() -> None:
         "fcf_yield", "debt_to_equity", "current_ratio", "roe", "roic",
         "sector", "industry", "marketCap", "p_fcf",
     ]
-    # Fields the LLM actually produces — everything else in the parsed JSON is
-    # overwritten by fetched data after the fact (fundamental.py:340-351).
+    # Everything else in the parsed JSON is overwritten by fetched data (fundamental.py:340-351)
     llm_fields = ["signal", "conviction", "moat_score", "reasoning"]
 
     fundamentals_fixture = {}
@@ -90,8 +89,7 @@ def capture_sentiment_llm_responses() -> None:
     trace = _load_trace(TRACE_SENTIMENT_ANALYSIS)
     signals = trace["outputs"]["sentiment_signals"]
 
-    # Fields the LLM actually produces — everything else is FinBERT/news/social
-    # metrics computed before the LLM call (sentiment.py:405-418).
+    # Everything else is FinBERT/news/social metrics computed before the call (sentiment.py:405-418)
     llm_fields = ["signal", "conviction", "sentiment_decay_risk", "reasoning"]
 
     llm_responses_fixture = {
@@ -101,11 +99,8 @@ def capture_sentiment_llm_responses() -> None:
     out.write_text(json.dumps(llm_responses_fixture, indent=2))
     print(f"wrote {out} ({len(llm_responses_fixture)} tickers)")
 
-    # news/social_sentiment inputs weren't captured raw by any trace (the
-    # sentiment_analysis node fetches and consumes them internally) — write
-    # empty maps so FixtureMarketDataProvider.news()/.social_sentiment()
-    # degrade the same way fetchers.py does for an unrecognized ticker
-    # (empty list / empty dict), rather than raising.
+    # No trace captured these raw; empty maps make the fixture provider degrade the same
+    # way fetchers.py does for an unrecognized ticker, rather than raising
     for name in ("news", "social_sentiment"):
         empty_out = FIXTURES_DIR / "market_data" / f"{name}.json"
         if not empty_out.exists():
@@ -167,7 +162,7 @@ def capture_portfolio_llm_response() -> None:
     a single JSON blob, not a per-ticker map. Only fields the model actually
     produces are kept (argus/agents/portfolio.py:296-314): allocation_usd and
     stop_loss are recomputed server-side from investable capital and the risk
-    engine's own stop (ADR 0004), and cash_reserve_pct is forced to
+    engine's own stop, and cash_reserve_pct is forced to
     1 - sum(allocation_pct) regardless of what the model returned.
     """
     trace = _load_trace(TRACE_PORTFOLIO_ALLOCATION)
@@ -187,6 +182,7 @@ def capture_portfolio_llm_response() -> None:
 
 
 def main() -> None:
+    """Runs all fixture-capture steps in sequence, writing outputs under tests/fixtures/."""
     (FIXTURES_DIR / "market_data").mkdir(parents=True, exist_ok=True)
     (FIXTURES_DIR / "llm_responses").mkdir(parents=True, exist_ok=True)
     capture_price_history()

--- a/scripts/reconcile_outcomes.py
+++ b/scripts/reconcile_outcomes.py
@@ -9,9 +9,7 @@ data, and reports how many outcomes were stored to cultural memory.
     .venv/bin/python scripts/reconcile_outcomes.py [--db PATH] [--horizon-days N]
 
 Meant to run periodically (e.g. a daily cron) against the live checkpoint
-database. See docs/adr/0010-closing-the-decision-outcome-loop.md for why
-decisions live in the checkpoint rather than a dedicated archive, and why
-horizon_days is provisional pending PR 10's pre-registered evaluation.
+database.
 """
 
 from __future__ import annotations
@@ -31,6 +29,7 @@ logger = logging.getLogger("argus.reconcile_outcomes")
 
 
 def main() -> None:
+    """Parses CLI args, reconciles cleared decisions, and prints the outcome count."""
     logging.basicConfig(level=logging.INFO)
 
     parser = argparse.ArgumentParser(description=__doc__)

--- a/scripts/replay_backtest.py
+++ b/scripts/replay_backtest.py
@@ -3,8 +3,8 @@ scripts/replay_backtest.py
 
 CLI entry point for argus/backtesting/replay.py — replays one or more
 recorded fixture sessions through the real ARGUS graph and prints each
-session's portfolio allocation. See that module's docstring, and
-docs/adr/0009-no-multiyear-backtest.md, for what this is and isn't.
+session's portfolio allocation. See that module's docstring for what
+this is and isn't.
 
     .venv/bin/python scripts/replay_backtest.py [session_dir ...]
 
@@ -23,6 +23,7 @@ DEFAULT_SESSION_DIR = Path(__file__).resolve().parent.parent / "tests" / "fixtur
 
 
 def main() -> None:
+    """Replays each given session directory (or the default fixtures) and prints allocations."""
     session_dirs = [Path(p) for p in sys.argv[1:]] or [DEFAULT_SESSION_DIR]
 
     results = replay_sessions(session_dirs)

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -1,11 +1,10 @@
 """
 scripts/run_evaluation.py
 
-CLI entry point for PR 10's pre-registered evaluation
-(docs/adr/0012-pre-registered-evaluation.md). Replays a fixture session
+CLI entry point for the pre-registered evaluation. Replays a fixture session
 open-loop and closed-loop, scores both against real forward returns, and
-prints the report the ADR's success threshold is judged against, plus
-system-behavior metrics reported separately.
+prints the report the pre-registered success threshold is judged against,
+plus system-behavior metrics reported separately.
 
     .venv/bin/python scripts/run_evaluation.py [--fixtures-dir PATH]
         [--horizon-days N] [--deadband X]
@@ -13,7 +12,7 @@ system-behavior metrics reported separately.
 Requires network access (LiveMarketDataProvider fetches real daily closes
 for the session's tickers) — this is the one place in the test/eval stack
 that's expected to, since the whole point is scoring against real forward
-returns rather than fixture data (see ADR 0012's "What is measured").
+returns rather than fixture data.
 """
 
 from __future__ import annotations
@@ -55,6 +54,7 @@ def _print_evaluation(label: str, result: EvaluationResult) -> None:
 
 
 def main() -> None:
+    """Replays open-loop and closed-loop sessions and prints the evaluation report."""
     logging.basicConfig(level=logging.INFO)
 
     parser = argparse.ArgumentParser(description=__doc__)
@@ -83,7 +83,7 @@ def main() -> None:
     if open_result.n < 6 or closed_result.n < 6:
         print(
             "\nNOTE: n < 6 (fewer than the full fixture universe) — statistical "
-            "power is very low at this sample size. See ADR 0012."
+            "power is very low at this sample size."
         )
 
     if closed_result.rank_ic is not None and open_result.rank_ic is not None:
@@ -94,7 +94,7 @@ def main() -> None:
             and closed_result.rank_ic > open_result.rank_ic
         )
         verdict = "closed-loop cleared the pre-registered bar" if helped else \
-            "closed-loop did NOT clear the pre-registered bar (see ADR 0012's success threshold)"
+            "closed-loop did NOT clear the pre-registered bar"
         print(f"\nVerdict: {verdict}")
 
     print("\n=== System-behavior metrics (open-loop session; reported separately) ===")
@@ -107,8 +107,8 @@ def main() -> None:
           f"{sys_report.reduce_verdicts} REDUCE verdicts exercised it)")
     print(f"  API calls/decision:    {sys_report.api_calls_per_decision:.2f} "
           f"(total {sys_report.total_api_calls})")
-    print("  retries/decision:      not instrumented (disclosed gap, see ADR 0012)")
-    print("  tokens/decision:       not instrumented (disclosed gap, see ADR 0012)")
+    print("  retries/decision:      not instrumented (disclosed gap)")
+    print("  tokens/decision:       not instrumented (disclosed gap)")
 
     print("\n=== Replay determinism ===")
     deterministic = check_replay_determinism(args.fixtures_dir)

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -2,8 +2,8 @@
 tests/test_aggregator.py
 
 Unit tests for HybridSignalAggregator.aggregate()'s reliability-weighting
-parameter (see docs/adr/0011). Reuses the signal/macro builders from
-test_aggregator_properties.py rather than duplicating them.
+parameter. Reuses the signal/macro builders from test_aggregator_properties.py
+rather than duplicating them.
 
 Covers the two claims the rebuild plan's verification section makes about
 this mechanism: an agent with a strong regime-specific track record
@@ -26,6 +26,7 @@ def _split_signals():
 
 
 def test_no_history_reliability_matches_unweighted_aggregation():
+    """With no reliability history, aggregation is identical to the unweighted path."""
     technical, macro, fundamental, sentiment = _split_signals()
     aggregator = HybridSignalAggregator()
 
@@ -53,12 +54,12 @@ def test_no_history_reliability_matches_unweighted_aggregation():
 
 
 def test_strong_track_record_measurably_outweighs_a_poor_one():
+    """A high-reliability agent's vote gains weight while a low-reliability one's shrinks."""
     technical, macro, fundamental, sentiment = _split_signals()
     aggregator = HybridSignalAggregator()
 
     baseline = aggregator.aggregate(technical, macro, fundamental, sentiment)
-    # technical (BULLISH) has been reliably right in this regime;
-    # fundamental (BEARISH) has been reliably wrong.
+    # technical (BULLISH) reliably right in this regime, fundamental (BEARISH) reliably wrong
     reweighted = aggregator.aggregate(
         technical,
         macro,

--- a/tests/test_aggregator_properties.py
+++ b/tests/test_aggregator_properties.py
@@ -5,8 +5,8 @@ Property-based test on HybridSignalAggregator.aggregate() — a pure function
 of its four signal/macro inputs. The invariant under test: no matter how
 strongly technical/fundamental/sentiment agree, and no matter what macro
 multiplier scales their votes, the aggregated conviction never claims more
-certainty than argus.params.AGGREGATOR.max_conviction (0.95) — see ADR 0006
-("kept below 1.0 so no aggregate claims certainty").
+certainty than argus.params.AGGREGATOR.max_conviction (0.95), kept below 1.0 so no
+aggregate claims certainty.
 """
 
 from datetime import datetime
@@ -127,6 +127,7 @@ def test_aggregated_conviction_never_exceeds_cap(
     tech_signal, tech_conv, fund_signal, fund_conv, sent_signal, sent_conv,
     regime, fund_mult, tech_mult, sent_mult,
 ):
+    """Aggregated conviction stays within [0, max_conviction] for any input combination."""
     aggregator = HybridSignalAggregator()
     result = aggregator.aggregate(
         technical=_technical(tech_signal, tech_conv),

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -1,7 +1,6 @@
 """
-Tests for argus/backtesting/replay.py — see docs/adr/0009-no-multiyear-backtest.md
-for why this replaces the deleted walk-forward engine, and
-argus/backtesting/replay.py's docstring for what a "session" is.
+Tests for argus/backtesting/replay.py, which replaces the deleted walk-forward engine.
+See argus/backtesting/replay.py's docstring for what a "session" is.
 """
 
 from pathlib import Path
@@ -12,6 +11,7 @@ FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
 
 def test_replay_session_produces_a_valid_allocation():
+    """A replayed session allocates every ticker in its universe."""
     result = replay_session(FIXTURES_DIR)
 
     assert sorted(result.universe) == ["AAPL", "GOOGL", "JPM", "MSFT", "NVDA", "XOM"]
@@ -22,12 +22,7 @@ def test_replay_session_produces_a_valid_allocation():
 
 
 def test_replay_sessions_preserves_order():
-    """Point-in-time correctness here is structural: replay_sessions() only
-    invokes session N+1 after session N has returned, and each session's
-    FixtureMarketDataProvider is scoped to its own directory — this test
-    just confirms the ordering contract itself, since there's only one
-    real session fixture to replay today.
-    """
+    """replay_sessions() invokes session N+1 only after session N has returned."""
     results = replay_sessions([FIXTURES_DIR, FIXTURES_DIR])
 
     assert [r.session_dir for r in results] == [FIXTURES_DIR, FIXTURES_DIR]

--- a/tests/test_cultural.py
+++ b/tests/test_cultural.py
@@ -2,10 +2,10 @@
 tests/test_cultural.py
 
 Unit tests for CulturalMemoryManager.get_agent_accuracy's shrinkage-toward-prior
-behavior (see docs/adr/0011). Builds the manager via object.__new__ plus a
-stub .collection rather than the real constructor, which pulls in chromadb +
-sentence-transformers (the optional [models] extra, see ADR 0007) just to
-exercise arithmetic over already-stored metadata.
+behavior. Builds the manager via object.__new__ plus a stub .collection rather
+than the real constructor, which pulls in chromadb + sentence-transformers
+(the optional [models] extra) just to exercise arithmetic over already-stored
+metadata.
 """
 
 from unittest import mock
@@ -23,12 +23,14 @@ def _manager_with_metadatas(metadatas: list[dict]) -> CulturalMemoryManager:
 
 
 def test_zero_observations_returns_prior():
+    """With no stored outcomes, accuracy falls back to the prior."""
     manager = _manager_with_metadatas([])
     assert manager.get_agent_accuracy("technical") == 0.5
 
 
 def test_small_sample_shrinks_toward_prior_instead_of_reporting_the_raw_rate():
-    # 2/2 wins -> raw win rate 1.0, which shrinkage should pull well below.
+    """A small sample's accuracy is pulled well below its raw win rate."""
+    # 2/2 wins -> raw win rate 1.0, which shrinkage should pull well below
     metadatas = [{"outcome": "SUCCESSFUL", "primary_driver": "technical"}] * 2
     manager = _manager_with_metadatas(metadatas)
 
@@ -41,6 +43,7 @@ def test_small_sample_shrinks_toward_prior_instead_of_reporting_the_raw_rate():
 
 
 def test_large_sample_converges_to_the_raw_win_rate():
+    """As the sample grows, accuracy converges to the raw win rate."""
     metadatas = (
         [{"outcome": "SUCCESSFUL", "primary_driver": "technical"}] * 900
         + [{"outcome": "FAILED", "primary_driver": "technical"}] * 100

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,10 +1,9 @@
 """
 tests/test_evaluation.py
 
-Tests for argus/backtesting/evaluation.py — see
-docs/adr/0012-pre-registered-evaluation.md for what these metrics mean and
-why. Metric functions are tested against synthetic, deterministic data (no
-network); collect_paired_outcomes/evaluate_decisions and
+Tests for argus/backtesting/evaluation.py. Metric functions are tested
+against synthetic, deterministic data (no network); collect_paired_outcomes/
+evaluate_decisions and
 system_behavior_report are tested end-to-end against the one real fixture
 session with a fake MarketDataProvider standing in for
 LiveMarketDataProvider (see tests/test_reconciliation.py's _FakeMarketData,
@@ -65,6 +64,7 @@ def _decision_with_signal(
 
 
 def test_signed_conviction_signs_by_direction():
+    """Signed conviction is positive for BULLISH, negative for BEARISH, zero for NEUTRAL."""
     bullish = _decision_with_signal(Signal.BULLISH, 0.8)
     bearish = _decision_with_signal(Signal.BEARISH, 0.6)
     neutral = _decision_with_signal(Signal.NEUTRAL, 0.3)
@@ -75,6 +75,7 @@ def test_signed_conviction_signs_by_direction():
 
 
 def test_signed_conviction_none_without_aggregated_signal():
+    """A decision with no aggregated signal has no signed conviction."""
     decision = ARGUSDecision(ticker="TEST", session_timestamp=datetime.now())
     assert signed_conviction(decision) is None
 
@@ -92,6 +93,7 @@ def _pairs(convictions: list[float], returns: list[float]) -> list[PairedOutcome
 
 
 def test_rank_ic_perfect_positive_correlation():
+    """Rank IC is 1.0 when conviction and forward return are perfectly rank-aligned."""
     pairs = _pairs([0.1, 0.3, 0.5, 0.7, 0.9], [-0.02, -0.01, 0.0, 0.01, 0.02])
     rho, p_value = rank_information_coefficient(pairs)
     assert rho == pytest.approx(1.0)
@@ -99,17 +101,20 @@ def test_rank_ic_perfect_positive_correlation():
 
 
 def test_rank_ic_perfect_negative_correlation():
+    """Rank IC is -1.0 when conviction and forward return are perfectly rank-inverted."""
     pairs = _pairs([0.1, 0.3, 0.5, 0.7, 0.9], [0.02, 0.01, 0.0, -0.01, -0.02])
     rho, _ = rank_information_coefficient(pairs)
     assert rho == pytest.approx(-1.0)
 
 
 def test_rank_ic_undefined_below_two_pairs():
+    """Rank IC is undefined with fewer than two pairs."""
     assert rank_information_coefficient(_pairs([0.5], [0.01])) == (None, None)
     assert rank_information_coefficient([]) == (None, None)
 
 
 def test_rank_ic_undefined_for_constant_series():
+    """Rank IC is undefined when one of the series has zero variance."""
     pairs = _pairs([0.5, 0.5, 0.5], [0.01, -0.02, 0.03])
     assert rank_information_coefficient(pairs) == (None, None)
 
@@ -120,9 +125,10 @@ def test_rank_ic_undefined_for_constant_series():
 
 
 def test_hit_rate_counts_matching_signs_outside_deadband():
+    """Hit rate counts only pairs where conviction sign matches return sign."""
     pairs = _pairs(
         convictions=[0.5, -0.5, 0.5, -0.5],
-        returns=[0.05, -0.05, -0.05, 0.05],  # first two "hit", last two "miss"
+        returns=[0.05, -0.05, -0.05, 0.05],  # First two "hit", last two "miss"
     )
     hit_rate, n_scored = hit_rate_with_deadband(pairs, deadband=0.01)
     assert n_scored == 4
@@ -130,6 +136,7 @@ def test_hit_rate_counts_matching_signs_outside_deadband():
 
 
 def test_hit_rate_excludes_returns_inside_deadband():
+    """Pairs whose return falls inside the deadband are excluded from scoring."""
     pairs = _pairs([0.5, -0.5], [0.005, -0.005])
     hit_rate, n_scored = hit_rate_with_deadband(pairs, deadband=0.01)
     assert n_scored == 0
@@ -142,10 +149,12 @@ def test_hit_rate_excludes_returns_inside_deadband():
 
 
 def test_bootstrap_ci_is_deterministic_and_brackets_zero_pairs():
+    """A bootstrap CI over too few pairs to compute the statistic is (None, None)."""
     assert bootstrap_ci(_pairs([0.5], [0.01]), lambda p: rank_information_coefficient(p)[0]) == (None, None)
 
 
 def test_bootstrap_ci_reproducible_with_fixed_seed():
+    """The same seed produces identical bootstrap CIs across runs."""
     pairs = _pairs([0.1, 0.3, 0.5, 0.7, 0.9, -0.2], [-0.03, -0.01, 0.0, 0.02, 0.04, 0.01])
     stat_fn = lambda p: rank_information_coefficient(p)[0]  # noqa: E731
 
@@ -164,6 +173,7 @@ def test_bootstrap_ci_reproducible_with_fixed_seed():
 
 
 def test_collect_paired_outcomes_pairs_conviction_with_realized_return():
+    """Each decision is paired with its forward return over the given horizon."""
     decision = _decision_with_signal(Signal.BULLISH, 0.8, ticker="TEST", price=100.0)
     market_data = _ten_day_series(datetime(2026, 1, 1), start_price=100.0, ticker="TEST")
 
@@ -175,6 +185,7 @@ def test_collect_paired_outcomes_pairs_conviction_with_realized_return():
 
 
 def test_collect_paired_outcomes_skips_decisions_with_no_aggregated_signal():
+    """Decisions without an aggregated signal produce no paired outcome."""
     decision = ARGUSDecision(ticker="TEST", session_timestamp=datetime(2026, 1, 1))
     market_data = _ten_day_series(datetime(2026, 1, 1), ticker="TEST")
 
@@ -182,6 +193,7 @@ def test_collect_paired_outcomes_skips_decisions_with_no_aggregated_signal():
 
 
 def test_evaluate_decisions_end_to_end_on_multiple_tickers():
+    """Evaluation over multiple tickers scores each decision against its own price series."""
     decisions = [
         _decision_with_signal(Signal.BULLISH, 0.8, ticker="A", price=100.0),
         _decision_with_signal(Signal.BEARISH, 0.6, ticker="B", price=100.0),
@@ -197,7 +209,7 @@ def test_evaluate_decisions_end_to_end_on_multiple_tickers():
     result = evaluate_decisions(decisions, market_data, horizon_days=5, deadband=0.01)
 
     assert result.n == 2
-    # A: bullish and price rose; B: bearish and price fell -> both "hit"
+    # A: bullish and price rose, B: bearish and price fell, so both "hit"
     assert result.hit_rate == 1.0
 
 
@@ -207,6 +219,7 @@ def test_evaluate_decisions_end_to_end_on_multiple_tickers():
 
 
 def test_system_behavior_report_on_replayed_fixture_session():
+    """The behavior report accounts for every ticker in a replayed fixture session."""
     result = replay_session(FIXTURES_DIR, closed_loop=False)
 
     report = system_behavior_report(result)
@@ -222,6 +235,7 @@ def test_system_behavior_report_on_replayed_fixture_session():
 
 
 def test_system_behavior_report_counts_reduce_verdicts():
+    """The behavior report counts zero reduce verdicts when no risk assessment is attached."""
     decisions = [_decision_with_signal(Signal.BULLISH, 0.8, ticker="TEST")]
     session = SessionResult(
         session_dir=FIXTURES_DIR,
@@ -231,8 +245,9 @@ def test_system_behavior_report_counts_reduce_verdicts():
     report = system_behavior_report(session)
     assert report.tickers_total == 1
     assert report.decisions_built == 1
-    assert report.reduce_verdicts == 0  # no risk assessment attached in this synthetic decision
+    assert report.reduce_verdicts == 0  # No risk assessment attached in this synthetic decision
 
 
 def test_replay_determinism_holds_for_the_real_fixture_session():
+    """Replaying the same fixture session twice yields identical decisions."""
     assert check_replay_determinism(FIXTURES_DIR) is True

--- a/tests/test_fundamental.py
+++ b/tests/test_fundamental.py
@@ -9,21 +9,20 @@ from argus.agents.fundamental import anonymize_ticker, build_compact_prompt, Fun
 from argus.schemas.signals import FundamentalSignal, Signal
 
 def test_anonymize_ticker():
-    # Should be deterministic
+    """Anonymized IDs are deterministic per (ticker, seed) and vary if either input changes."""
     id1 = anonymize_ticker("AAPL", 20240101)
     id2 = anonymize_ticker("AAPL", 20240101)
     assert id1 == id2
     assert id1.startswith("COMP_")
 
-    # Should change with different seed
     id3 = anonymize_ticker("AAPL", 20240102)
     assert id1 != id3
 
-    # Should change with different ticker
     id4 = anonymize_ticker("MSFT", 20240101)
     assert id1 != id4
 
 def test_build_compact_prompt():
+    """The compact prompt embeds fundamentals and substitutes the anon ID when provided."""
     pit_data = {
         "as_of_date": "2024-01-01",
         "fundamentals": {
@@ -34,22 +33,22 @@ def test_build_compact_prompt():
         }
     }
 
-    # Test with real ticker
     prompt_real = build_compact_prompt("AAPL", pit_data)
     assert 'ticker="AAPL"' in prompt_real
     assert 'as_of="2024-01-01"' in prompt_real
     assert 'sector="Technology"' in prompt_real
     assert 'P/E Ratio: 25.5' in prompt_real
     assert 'custom_metric: 100' in prompt_real
-    assert 'industry median ~32.0x' in prompt_real # Pulled from _SECTOR_PE_MEDIANS for Technology
+    # Value comes from _SECTOR_PE_MEDIANS, not the input data
+    assert 'industry median ~32.0x' in prompt_real
 
-    # Test with anonymized ticker
     prompt_anon = build_compact_prompt("AAPL", pit_data, anon_id="COMP_XYZ")
     assert 'ticker="COMP_XYZ"' in prompt_anon
     assert 'sector="Technology"' in prompt_anon
     assert "AAPL" not in prompt_anon
 
 def test_fundamental_cache():
+    """A cached signal is served until it exceeds the 7-day TTL, then evicted."""
     cache = FundamentalCache()
     assert cache.is_stale("AAPL")
 
@@ -70,7 +69,7 @@ def test_fundamental_cache():
     assert not cache.is_stale("AAPL")
     assert cache.get("AAPL") == signal
 
-    # Manually expire the cache entry to test TTL (7 days)
+    # Backdate the entry past the 7-day TTL rather than waiting for it to expire
     cache._cache["AAPL"] = (signal, datetime.now() - timedelta(days=8))
     assert cache.is_stale("AAPL")
     assert cache.get("AAPL") is None

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -6,8 +6,8 @@ LLM boundary served from tests/fixtures/ — zero network calls, zero LLM API
 calls, zero torch/transformers import — and asserts the output is stable
 across repeated runs.
 
-Cultural memory is mocked, not fixture-backed: per ADR 0007 it isn't part of
-the MarketDataProvider/LLMClient seam (it's inherently stateful, not a
+Cultural memory is mocked, not fixture-backed: it isn't part of the
+MarketDataProvider/LLMClient seam (it's inherently stateful, not a
 replay candidate), and leaving it real would pull in sentence-transformers
 (the optional `[models]` extra) and write to a real ./chroma_db directory on
 every test run — the same reasoning tests/test_integration.py already
@@ -85,9 +85,7 @@ def _initial_state() -> ARGUSState:
     )
 
 
-# Fields that legitimately vary run-to-run even with fixed inputs (wall-clock
-# timestamps, random session/decision IDs) — excluded from the stability
-# comparison, not from the run itself.
+# Excluded from the stability comparison (not from the run itself) since they vary run-to-run
 _VOLATILE_KEYS = {"timestamp", "session_id", "data_as_of_date"}
 
 
@@ -100,6 +98,11 @@ def _strip_volatile(obj):
 
 
 def _run_fixture_graph() -> dict:
+    """Invoke the fixture-backed DAG once, with cultural memory and the governor mocked out.
+
+    Returns:
+        The final ARGUSState dict produced by the graph.
+    """
     graph = build_graph(
         market_data=FixtureMarketDataProvider(),
         fundamental_llm=_per_ticker_llm("fundamental.json"),
@@ -110,10 +113,7 @@ def _run_fixture_graph() -> dict:
 
     with (
         mock.patch("argus.orchestration.graph.get_cultural_memory") as mock_get_cultural_memory,
-        # The real governor enforces a live per-minute token budget shared process-wide;
-        # left real, back-to-back fixture runs (this test invokes the graph twice) hit it
-        # and block for up to 60s per call. Throttling behavior itself is covered by
-        # test_governor.py — irrelevant to whether the fixture-backed DAG is deterministic.
+        # Left real, back-to-back fixture runs would block on the live per-minute token budget
         mock.patch.object(governor, "wait_if_needed"),
     ):
         mock_get_cultural_memory.return_value = mock.Mock(
@@ -128,6 +128,7 @@ def _run_fixture_graph() -> dict:
 
 
 def test_golden_dag_runs_offline_and_produces_a_valid_allocation():
+    """The fixture-backed DAG runs end to end with zero network/LLM/torch dependencies."""
     final_state = _run_fixture_graph()
 
     assert final_state.get("macro_context") is not None
@@ -143,6 +144,7 @@ def test_golden_dag_runs_offline_and_produces_a_valid_allocation():
 
 
 def test_golden_dag_output_is_stable_across_runs():
+    """Two independent invocations of the same fixture-backed graph are byte-identical."""
     first = _run_fixture_graph()
     second = _run_fixture_graph()
 

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -14,49 +14,54 @@ from argus.orchestration.governor import (
 
 @pytest.fixture
 def governor():
-    # Clear any existing state
+    """A fresh RateLimitGovernor with no prior usage recorded.
+
+    Returns:
+        A new RateLimitGovernor instance.
+    """
     gov = RateLimitGovernor()
     return gov
 
 @patch("argus.orchestration.governor.time.sleep")
 def test_governor_minute_limit(mock_sleep, governor):
+    """Exceeding the per-minute request limit sleeps rather than raising."""
     model = list(MODEL_LIMITS.keys())[0]
     limits = MODEL_LIMITS[model]
-    
+
     req_limit = limits["requests_per_minute"]
-    
-    # Use up the minute limit
+
     for _ in range(req_limit):
         governor.wait_if_needed(model, 100)
-    
+
     assert mock_sleep.call_count == 0
-    
-    # The next one should trigger a sleep
+
     governor.wait_if_needed(model, 100)
     assert mock_sleep.call_count == 1
 
 @patch("argus.orchestration.governor.time.sleep")
 def test_governor_daily_limit(mock_sleep, governor):
+    """Exceeding the daily request limit raises rather than sleeping."""
     model = list(MODEL_LIMITS.keys())[0]
     limits = MODEL_LIMITS[model]
-    
+
     req_limit = limits["requests_per_day"]
-    
-    # Artificially set usage to just below daily limit
+
+    # Seed usage directly rather than making req_limit - 1 real calls
     usage = governor._get_usage(model)
     usage.requests_today = req_limit - 1
-    
+
     governor.wait_if_needed(model, 10)
     assert mock_sleep.call_count == 0
     assert usage.requests_today == req_limit
 
-    # The next one must raise instead of sleeping-and-proceeding
+    # Unlike the per-minute limit, the daily limit raises instead of blocking
     with pytest.raises(RateLimitExceeded):
         governor.wait_if_needed(model, 10)
     assert mock_sleep.call_count == 0
     assert usage.requests_today == req_limit
 
 def test_governor_get_capacity(governor):
+    """Remaining capacity decrements by one for each request recorded."""
     model = list(MODEL_LIMITS.keys())[0]
     initial_capacity = governor.get_remaining_capacity(model)
     
@@ -64,6 +69,7 @@ def test_governor_get_capacity(governor):
     assert governor.get_remaining_capacity(model) == initial_capacity - 1
 
 def test_governor_report(governor):
+    """The usage report reflects the requests and tokens recorded for a model."""
     model = list(MODEL_LIMITS.keys())[0]
     governor.wait_if_needed(model, 100)
     

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,9 +40,10 @@ from argus.schemas.signals import (
 
 
 class TestEndToEnd:
+    """Integration tests exercising real agents, the orchestrator graph, and shared state."""
+
     def test_statistical_agents_pipeline(self):
-        """Tests: TechnicalAgent -> MacroAgent -> RiskEngine in sequence with zero LLMs."""
-        # Fetch daily OHLCV directly and compress via pipeline helper
+        """TechnicalAgent -> MacroAgent -> RiskEngine chain runs with zero LLM calls."""
         pipeline = MFTDataPipeline(["AAPL"])
         df = yf.download("AAPL", period="60d", interval="5m", progress=False, threads=False)
         if isinstance(df.columns, pd.MultiIndex):
@@ -51,7 +52,6 @@ class TestEndToEnd:
         df = df.dropna()
 
         if len(df) >= 14:
-            # Insert candles directly into the buffer
             for ts, row in df.iterrows():
                 candle = {
                     "timestamp": ts.isoformat(),
@@ -95,8 +95,13 @@ class TestEndToEnd:
 
         Cultural memory is mocked out (not just left real) because its embedding
         function needs the optional `[models]` extra (sentence-transformers) that
-        default installs/CI don't have — see ADR 0007 — and because this smoke
-        test is about graph wiring, not vector-DB behavior.
+        default installs/CI don't have, and because this smoke test is about graph
+        wiring, not vector-DB behavior.
+
+        Args:
+            mock_sent: Patched SentimentAgent.analyze.
+            mock_fund: Patched FundamentalAgent.analyze.
+            mock_cultural_memory: Patched get_cultural_memory.
         """
         mock_cultural_memory.return_value = mock.Mock(
             retrieve_wisdom=mock.Mock(return_value=[]),
@@ -105,8 +110,17 @@ class TestEndToEnd:
             store_decision_snapshot=mock.Mock(),
         )
 
-        # analyze(self, ticker, backtest_mode=False, session_seed=None)
         def fund_side_effect(ticker, backtest_mode=False, session_seed=None):
+            """Stand in for FundamentalAgent.analyze, matching its real signature.
+
+            Args:
+                ticker: Ticker to build a signal for.
+                backtest_mode: Unused; accepted to match the real signature.
+                session_seed: Unused; accepted to match the real signature.
+
+            Returns:
+                A fixed BULLISH FundamentalSignal for the given ticker.
+            """
             return FundamentalSignal(
                 ticker=ticker,
                 sector="Technology",
@@ -121,8 +135,17 @@ class TestEndToEnd:
 
         mock_fund.side_effect = fund_side_effect
 
-        # analyze(self, ticker, headlines=None, ...)
         def sent_side_effect(ticker, *args, **kwargs):
+            """Stand in for SentimentAgent.analyze, matching its real signature.
+
+            Args:
+                ticker: Ticker to build a signal for.
+                *args: Unused; accepted to match the real signature.
+                **kwargs: Unused; accepted to match the real signature.
+
+            Returns:
+                A fixed BULLISH SentimentSignal for the given ticker.
+            """
             return SentimentSignal(
                 ticker=ticker,
                 signal=Signal.BULLISH,
@@ -174,13 +197,14 @@ class TestEndToEnd:
             for pos in alloc.portfolio:
                 assert pos.stop_loss > 0.0
         except Exception as e:
-            # Catch expected Msgpack dataframe serialization error if thrown by checkpointer
+            # The checkpointer can raise a dataframe serialization error unrelated to graph wiring
             if "msgpack" in str(e).lower() or "not msgpack serializable" in str(e).lower():
                 pass
             else:
                 raise e
 
     def test_kill_switch_drawdown_trigger(self):
+        """The kill switch halts once portfolio value drops past the drawdown threshold."""
         ks = KillSwitch("MODERATE", check_interval_seconds=1)
         ks.start(10000.0)
         ks.update_portfolio_value(8700.0)
@@ -188,6 +212,7 @@ class TestEndToEnd:
         assert ks.is_halted
 
     def test_schema_round_trip(self):
+        """Signal schemas survive a JSON dump/validate round trip unchanged."""
         tech = TechnicalSignal(
             ticker="AAPL",
             current_price=150.0,
@@ -232,27 +257,27 @@ class TestEndToEnd:
         assert macro.macro_regime == macro2.macro_regime
 
     def test_governor_prevents_over_limit(self):
+        """The shared governor raises once a model's daily request count reaches its limit."""
         from argus.orchestration.governor import MODEL_LIMITS
 
         model = "llama-3.3-70b-versatile"
         limit = MODEL_LIMITS[model]["requests_per_day"]
 
-        # Wind the counter up to one below the limit
         usage = governor._get_usage(model)
         usage.requests_today = limit - 1
 
-        # This call should succeed (count becomes == limit)
+        # Reaching exactly the limit still succeeds; only exceeding it raises
         governor.wait_if_needed(model)
         assert usage.requests_today == limit
 
-        # Next call must raise because count >= limit
         with pytest.raises(RateLimitExceeded):
             governor.wait_if_needed(model)
 
-        # Cleanup: reset so other tests aren't affected
+        # governor is a module-level singleton shared across tests
         usage.requests_today = 0
 
     def test_half_kelly_formula(self):
+        """half_kelly_weight() computes half the Kelly-optimal position size."""
         weight = half_kelly_weight(
             win_probability=0.6, avg_win_pct=0.08, avg_loss_pct=0.04, max_position=0.15
         )

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -15,31 +15,51 @@ class _StubMarketData:
     """Minimal MarketDataProvider stub for macro.analyze()'s data needs."""
 
     def macro_bundle(self) -> dict:
+        """Returns:
+            Fixed macro indicator values.
+        """
         return {"vix": 15.0, "fed_funds": 2.0, "t10y2y": 1.5, "cpi_yoy": 2.0, "unemployment": 3.5}
 
     def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame:
+        """Returns a fixed close-price series regardless of the ticker or period.
+
+        Args:
+            ticker: Ticker symbol (ignored).
+            period: Lookback period (ignored).
+
+        Returns:
+            Fixed OHLCV close-price frame.
+        """
         return pd.DataFrame({"close": [20.0, 20.0, 20.0, 20.0, 10.0]})
 
     def fred_series(self, series_id: str, start: str = "2018-01-01") -> pd.Series:
+        """Returns a fixed series regardless of the FRED series ID or start date.
+
+        Args:
+            series_id: FRED series identifier (ignored).
+            start: Start date (ignored).
+
+        Returns:
+            Fixed series values.
+        """
         return pd.Series([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0])
 
 
 def test_rule_based_fallback() -> None:
-    """Test that the classifier uses the heuristic fallback when not fitted."""
+    """An unfitted classifier falls back to the VIX/yield-curve heuristic."""
     classifier = RegimeClassifier()
     assert not classifier.is_fitted
 
-    # Provide contraction-like values: high VIX, inverted curve
+    # High VIX plus an inverted curve is the contraction heuristic's trigger condition
     regime, conf = classifier.predict({"vix": 35.0, "t10y2y": -0.6})
     assert regime == Regime.CONTRACTION.value
     assert conf == 0.6
 
 
 def test_agent_multipliers_expansion(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Inject a stub MarketDataProvider and mock prediction to force an EXPANSION regime."""
+    """EXPANSION regime with low VIX percentile sets fundamental and sentiment multipliers."""
     agent = MacroStatisticalAgent(market_data=_StubMarketData())
 
-    # Mock the classifier to always return EXPANSION
     monkeypatch.setattr(
         agent.classifier, "predict", lambda current_values: (Regime.EXPANSION.value, 0.9)
     )
@@ -47,22 +67,20 @@ def test_agent_multipliers_expansion(monkeypatch: pytest.MonkeyPatch) -> None:
     ctx = agent.analyze()
 
     assert ctx.macro_regime == Regime.EXPANSION
-    # VIX percentile < 40 and EXPANSION should give 1.3 fundamental multiplier
+    # VIX percentile < 40 and EXPANSION together map to a 1.3 fundamental multiplier
     assert ctx.agent_multipliers["fundamental"] == 1.3
-    # Low VIX percentile < 50 should give 0.9 sentiment
+    # VIX percentile < 50 maps to a 0.9 sentiment multiplier
     assert ctx.agent_multipliers["sentiment"] == 0.9
 
 
 def test_cache(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Call analyze() twice and verify the second call returns the cached object."""
+    """A populated cache is returned as-is, without touching any fetchers."""
     agent = MacroStatisticalAgent()
 
-    # Use a dummy context
     dummy_ctx = type("MockCtx", (), {"macro_regime": Regime.EXPANSION})()
     agent._cache = (dummy_ctx, datetime.now())  # type: ignore
 
-    # The analyze method should return the cache immediately without fetching
-    # We can verify this by ensuring it doesn't crash even if fetchers aren't mocked
+    # Fetchers are unmocked, so a cache miss here would raise rather than return stale data
     res1 = agent.analyze()
     res2 = agent.analyze()
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -4,6 +4,7 @@ from argus.params import Provenance, all_params
 
 
 def test_every_param_has_provenance_metadata():
+    """Every declared parameter row carries a non-null provenance tag."""
     rows = all_params()
     assert rows, "expected at least one declared parameter"
     missing = [f"{r['group']}.{r['field']}" for r in rows if r["provenance"] is None]
@@ -11,6 +12,7 @@ def test_every_param_has_provenance_metadata():
 
 
 def test_every_provenance_value_is_valid():
+    """Every provenance tag is a member of the Provenance enum, not an arbitrary value."""
     rows = all_params()
     invalid = [
         f"{r['group']}.{r['field']}"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -9,24 +9,25 @@ from argus.data.pipeline import MFTDataPipeline
 from argus.data.cache import OHLCVBuffer
 
 def test_register_tickers():
+    """Registering tickers already present in the pipeline is a no-op for those tickers."""
     pipeline = MFTDataPipeline([])
     pipeline.register_tickers(["AAPL", "MSFT"])
     assert "AAPL" in pipeline.tickers
     assert "MSFT" in pipeline.tickers
     assert len(pipeline.tickers) == 2
 
-    # Test duplicates are ignored
     pipeline.register_tickers(["AAPL", "TSLA"])
     assert len(pipeline.tickers) == 3
     assert "TSLA" in pipeline.tickers
 
 def test_compress_candles():
+    """Compressing candles returns the full set of pandas-ta derived indicator keys."""
     pipeline = MFTDataPipeline([])
 
-    # Generate a dummy dataframe with enough rows for indicators (e.g. MACD needs 26)
+    # 100 rows covers the longest indicator lookback (MACD needs 26)
     dates = pd.date_range("2024-01-01", periods=100, freq="5min")
-    
-    # A simple upward trend
+
+    # Monotonic close series so RSI has a known, deterministic value to assert on
     df = pd.DataFrame({
         "open": range(100),
         "high": range(1, 101),
@@ -35,8 +36,6 @@ def test_compress_candles():
         "volume": [1000] * 100,
     }, index=dates)
 
-    # Some basic checks to ensure pandas-ta runs without throwing errors
-    # and returns the correct keys
     result = pipeline._compress_candles(df)
 
     assert "rsi_14" in result
@@ -52,22 +51,22 @@ def test_compress_candles():
     assert "timestamp" in result
 
     assert result["close"] == 99.0
-    # RSI for a straight line up is usually 100
+    # A monotonically rising close series saturates RSI at 100
     assert result["rsi_14"] == 100.0
 
 def test_ohlcv_buffer_insertion():
+    """Inserting a candle at an existing timestamp overwrites it rather than appending."""
     buffer = OHLCVBuffer(db_path=":memory:", buffer_size=20)
-    
-    # Need at least 14 candles to bypass the return None check
+
+    # 15 candles clears the buffer's 14-candle minimum before it returns data
     for i in range(15):
         buffer.insert_candle("AAPL", {"timestamp": f"2024-01-01T10:{i:02d}:00", "close": 150.0 + i})
-    
+
     df = buffer.get_candles("AAPL")
     assert df is not None
     assert len(df) == 15
     assert df["close"].iloc[-1] == 164.0
 
-    # Overwrite the same timestamp
     buffer.insert_candle("AAPL", {"timestamp": "2024-01-01T10:14:00", "close": 165.0})
     df2 = buffer.get_candles("AAPL")
     assert len(df2) == 15

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -10,34 +10,37 @@ from argus.agents.portfolio import half_kelly_weight, build_signal_table
 from argus.schemas.signals import RiskAssessment, RiskVerdict, Signal, MacroContext, Regime
 
 def test_half_kelly_weight_bullish():
-    # p=0.6, win=0.08, loss=0.04 -> b=2, q=0.4
-    # full kelly = (2*0.6 - 0.4)/2 = 0.4
-    # half kelly = 0.2
-    # But max position is 0.15, so clips to 0.15
+    """A half-Kelly weight above the position cap clips to that cap."""
+    # b=2, q=0.4: full kelly 0.4, half kelly 0.2, clipped to the 0.15 cap
     res = half_kelly_weight(0.6, 0.08, 0.04, 0.15)
     assert res == 0.15
 
 def test_half_kelly_weight_bearish():
-    # p=0.3, win=0.08, loss=0.04 -> b=2, q=0.7
-    # full kelly = (2*0.3 - 0.7)/2 = -0.05
-    # half kelly = -0.025
-    # Floor is 0.0
+    """A negative half-Kelly weight floors at 0.0 rather than going short."""
+    # b=2, q=0.7: full kelly is -0.05, so half kelly is negative
     res = half_kelly_weight(0.3, 0.08, 0.04, 0.15)
     assert res == 0.0
 
 def test_half_kelly_weight_moderate():
-    # p=0.5, win=0.08, loss=0.04 -> b=2, q=0.5
-    # full kelly = (1.0 - 0.5)/2 = 0.25
-    # half kelly = 0.125
+    """A half-Kelly weight within the cap passes through unclipped."""
+    # b=2, q=0.5: full kelly 0.25 halves to 0.125, under the 0.15 cap
     res = half_kelly_weight(0.5, 0.08, 0.04, 0.15)
     assert pytest.approx(res) == 0.125
 
 class MockSignal:
+    """Minimal stand-in for a per-agent Signal result.
+
+    Args:
+        signal: Signal direction.
+        conviction: Confidence score for the signal.
+    """
+
     def __init__(self, signal, conviction):
         self.signal = signal
         self.conviction = conviction
 
 def test_build_signal_table():
+    """Vetoed positions are excluded from the table; others render with their approved weight."""
     macro = MacroContext(
         fed_funds=5.25,
         cpi_yoy=3.2,
@@ -76,7 +79,6 @@ def test_build_signal_table():
 
     table = build_signal_table(all_signals, macro)
 
-    # AAPL and MSFT should be present, TSLA should be excluded
     assert "AAPL:" in table
     assert "MSFT:" in table
     assert "TSLA:" not in table

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,10 +1,9 @@
 """
 tests/test_reconciliation.py
 
-Tests for argus/orchestration/reconciliation.py — see
-docs/adr/0010-closing-the-decision-outcome-loop.md for the design this
-exercises: leave-one-out credit assignment, entry/exit price outcome
-computation, and reading decisions back out of the LangGraph checkpoint.
+Tests for argus/orchestration/reconciliation.py: leave-one-out credit
+assignment, entry/exit price outcome computation, and reading decisions back
+out of the LangGraph checkpoint.
 """
 
 from datetime import datetime
@@ -43,6 +42,17 @@ FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
 
 def _technical(signal: Signal, conviction: float, ticker: str = "TEST", price: float = 100.0) -> TechnicalSignal:
+    """Builds a TechnicalSignal with fixed indicator values, varying only the given fields.
+
+    Args:
+        signal: Signal direction to assign.
+        conviction: Confidence score to assign.
+        ticker: Ticker symbol.
+        price: Current price.
+
+    Returns:
+        A TechnicalSignal fixture.
+    """
     return TechnicalSignal(
         ticker=ticker,
         current_price=price,
@@ -63,6 +73,16 @@ def _technical(signal: Signal, conviction: float, ticker: str = "TEST", price: f
 
 
 def _fundamental(signal: Signal, conviction: float, ticker: str = "TEST") -> FundamentalSignal:
+    """Builds a FundamentalSignal with fixed field values, varying only the given fields.
+
+    Args:
+        signal: Signal direction to assign.
+        conviction: Confidence score to assign.
+        ticker: Ticker symbol.
+
+    Returns:
+        A FundamentalSignal fixture.
+    """
     return FundamentalSignal(
         ticker=ticker,
         sector="Technology",
@@ -77,6 +97,14 @@ def _fundamental(signal: Signal, conviction: float, ticker: str = "TEST") -> Fun
 
 
 def _macro(regime: Regime = Regime.EXPANSION) -> MacroContext:
+    """Builds a MacroContext with fixed field values, varying only the regime.
+
+    Args:
+        regime: Macro regime to assign.
+
+    Returns:
+        A MacroContext fixture.
+    """
     return MacroContext(
         fed_funds=4.0,
         cpi_yoy=3.0,
@@ -98,6 +126,14 @@ def _macro(regime: Regime = Regime.EXPANSION) -> MacroContext:
 
 
 def _allocation(ticker: str = "TEST") -> PositionAllocation:
+    """Builds a PositionAllocation with fixed field values, varying only the ticker.
+
+    Args:
+        ticker: Ticker symbol.
+
+    Returns:
+        A PositionAllocation fixture.
+    """
     return PositionAllocation(
         ticker=ticker,
         allocation_pct=0.10,
@@ -113,13 +149,37 @@ class _FakeMarketData:
     """Minimal MarketDataProvider double: only ohlcv_daily is used by reconciliation."""
 
     def __init__(self, closes: dict[str, pd.Series]) -> None:
+        """Stores the fixed per-ticker close series to serve from ohlcv_daily.
+
+        Args:
+            closes: Ticker to close-price series.
+        """
         self._closes = closes
 
     def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame:
+        """Returns the fixed close series for the given ticker, ignoring period.
+
+        Args:
+            ticker: Ticker to look up.
+            period: Lookback period (ignored).
+
+        Returns:
+            A DataFrame with the fixed close series.
+        """
         return pd.DataFrame({"close": self._closes[ticker]})
 
 
 def _ten_day_series(start: datetime, start_price: float = 100.0, ticker: str = "TEST") -> _FakeMarketData:
+    """Builds a 10-day daily close series rising by 1.0 per day from start_price.
+
+    Args:
+        start: First date in the series.
+        start_price: Close price on the first day.
+        ticker: Ticker symbol the series is keyed under.
+
+    Returns:
+        A _FakeMarketData backed by the generated series.
+    """
     dates = pd.date_range(start=start, periods=10, freq="D")
     closes = pd.Series([start_price + i for i in range(10)], index=dates)
     return _FakeMarketData({ticker: closes})
@@ -131,11 +191,13 @@ def _ten_day_series(start: datetime, start_price: float = 100.0, ticker: str = "
 
 
 def test_credit_primary_driver_returns_unknown_with_no_signals():
+    """A decision with no agent signals credits no driver."""
     decision = ARGUSDecision(ticker="TEST", session_timestamp=datetime.now())
     assert credit_primary_driver(decision) == "unknown"
 
 
 def test_credit_primary_driver_returns_the_sole_signal_when_only_one_present():
+    """With only one agent signal present, that agent is credited by default."""
     technical = _technical(Signal.BULLISH, 0.8)
     macro = _macro()
     aggregator = HybridSignalAggregator()
@@ -152,11 +214,7 @@ def test_credit_primary_driver_returns_the_sole_signal_when_only_one_present():
 
 
 def test_credit_primary_driver_credits_the_dominant_agent():
-    """Technical votes strongly BULLISH; fundamental votes weakly (low conviction).
-
-    Removing technical should swing the aggregated conviction far more than
-    removing fundamental — leave-one-out ablation should credit technical.
-    """
+    """Leave-one-out ablation credits whichever agent's removal swings conviction most."""
     technical = _technical(Signal.BULLISH, 0.9)
     fundamental = _fundamental(Signal.BULLISH, 0.1)
     macro = _macro()
@@ -199,6 +257,7 @@ def test_credit_primary_driver_is_symmetric_under_relabeling():
 
 
 def test_compute_realized_return_pairs_entry_and_horizon_close():
+    """Realized return pairs the entry-day close with the close N horizon days later."""
     start = datetime(2026, 1, 1)
     technical = _technical(Signal.BULLISH, 0.8, price=100.0)
     decision = ARGUSDecision(
@@ -219,6 +278,7 @@ def test_compute_realized_return_pairs_entry_and_horizon_close():
 
 
 def test_compute_realized_return_none_without_allocation():
+    """A decision with no position allocation has no realized return to compute."""
     decision = ARGUSDecision(
         ticker="TEST",
         session_timestamp=datetime(2026, 1, 1),
@@ -229,6 +289,7 @@ def test_compute_realized_return_none_without_allocation():
 
 
 def test_compute_realized_return_none_without_technical_signal():
+    """A decision with no technical signal has no entry price to compute a return from."""
     decision = ARGUSDecision(
         ticker="TEST",
         session_timestamp=datetime(2026, 1, 1),
@@ -239,6 +300,7 @@ def test_compute_realized_return_none_without_technical_signal():
 
 
 def test_compute_realized_return_none_when_horizon_not_yet_reached():
+    """No return is computed until price data reaches the requested horizon."""
     start = datetime(2026, 1, 1)
     decision = ARGUSDecision(
         ticker="TEST",
@@ -246,7 +308,7 @@ def test_compute_realized_return_none_when_horizon_not_yet_reached():
         technical=_technical(Signal.BULLISH, 0.8),
         allocation=_allocation(),
     )
-    market_data = _ten_day_series(start)  # only 10 days of data
+    market_data = _ten_day_series(start)  # only 10 days, short of the 30-day horizon requested below
     assert compute_realized_return(decision, market_data, horizon_days=30) is None
 
 
@@ -256,6 +318,7 @@ def test_compute_realized_return_none_when_horizon_not_yet_reached():
 
 
 def test_reconcile_decision_stores_outcome_with_ablated_primary_driver():
+    """Reconciling a decision stores the realized outcome tagged with its credited driver."""
     start = datetime(2026, 1, 1)
     technical = _technical(Signal.BULLISH, 0.9, price=100.0)
     fundamental = _fundamental(Signal.BULLISH, 0.1)
@@ -286,6 +349,7 @@ def test_reconcile_decision_stores_outcome_with_ablated_primary_driver():
 
 
 def test_reconcile_decision_returns_false_and_stores_nothing_with_no_position():
+    """A decision with no position produces no stored outcome."""
     decision = ARGUSDecision(
         ticker="TEST",
         session_timestamp=datetime(2026, 1, 1),
@@ -299,6 +363,7 @@ def test_reconcile_decision_returns_false_and_stores_nothing_with_no_position():
 
 
 def test_reconcile_decisions_counts_only_the_ones_actually_reconciled():
+    """The batch count reflects only decisions that actually had an outcome to store."""
     start = datetime(2026, 1, 1)
     reconcilable = ARGUSDecision(
         ticker="TEST",
@@ -329,10 +394,7 @@ def test_reconcile_decisions_counts_only_the_ones_actually_reconciled():
 
 
 def test_load_decisions_from_checkpoints_round_trips_a_real_graph_run(tmp_path):
-    """Runs the real graph (fixture-backed) with a temp checkpoint db, then
-    confirms load_decisions_from_checkpoints() reads back real ARGUSDecision
-    objects (not degraded dicts) with the expected tickers.
-    """
+    """Checkpoints round-trip real ARGUSDecision objects, not degraded dicts, per ticker."""
     import json
 
     universe = ["AAPL", "MSFT", "NVDA", "GOOGL", "JPM", "XOM"]

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -12,20 +12,22 @@ from argus.schemas.signals import RiskVerdict
 
 @pytest.fixture
 def price_history():
-    """Create a simulated price history dictionary for tests."""
-    np.random.seed(42)  # For reproducible returns
+    """Create a simulated price history dictionary for tests.
+
+    Returns:
+        Mapping of ticker (plus "SPY" benchmark) to a one-year daily price series.
+    """
+    np.random.seed(42)  # Fixed seed keeps returns reproducible across runs
     dates = pd.date_range(start="2023-01-01", periods=253, freq="B")
     hist = {}
 
-    # Generate prices with moderate, normal volatility
+    # Moderate, normal volatility: 0.1% daily mean return, 1.5% daily vol
     tickers = ["AAPL", "MSFT", "GOOGL", "META", "AMZN", "TSLA", "JPM", "BAC"]
     for t in tickers:
-        # daily returns ~0.1% mean, 1.5% vol
         returns = np.random.normal(0.001, 0.015, len(dates))
         prices = 100 * np.exp(np.cumsum(returns))
         hist[t] = pd.Series(prices, index=dates)
 
-    # SPY benchmark
     spy_returns = np.random.normal(0.0005, 0.01, len(dates))
     hist["SPY"] = pd.Series(100 * np.exp(np.cumsum(spy_returns)), index=dates)
 
@@ -34,12 +36,15 @@ def price_history():
 
 @pytest.fixture
 def risk_engine():
+    """Returns:
+        A fresh RiskStatisticalEngine instance.
+    """
     return RiskStatisticalEngine()
 
 
 def test_vix_blackout(risk_engine: RiskStatisticalEngine, price_history: dict) -> None:
+    """VIX above the 35 blackout threshold vetoes the whole portfolio."""
     positions = [{"ticker": "AAPL", "weight": 0.1} for _ in range(5)]
-    # VIX 40 > threshold 35 -> VETO
     result = risk_engine.evaluate(positions, price_history, current_vix=40.0)
 
     assert result.verdict == RiskVerdict.VETO
@@ -47,8 +52,9 @@ def test_vix_blackout(risk_engine: RiskStatisticalEngine, price_history: dict) -
 
 
 def test_overweight_position(risk_engine: RiskStatisticalEngine, price_history: dict) -> None:
+    """A position above the 0.15 weight limit vetoes the portfolio."""
     positions = [
-        {"ticker": "AAPL", "weight": 0.20},  # > 0.15 limit
+        {"ticker": "AAPL", "weight": 0.20},  # exceeds the 0.15 limit
         {"ticker": "MSFT", "weight": 0.10},
         {"ticker": "GOOGL", "weight": 0.10},
         {"ticker": "META", "weight": 0.10},
@@ -61,12 +67,12 @@ def test_overweight_position(risk_engine: RiskStatisticalEngine, price_history: 
 
 
 def test_high_var_reduce(risk_engine: RiskStatisticalEngine) -> None:
-    # Mock returns with extreme volatility to trigger REDUCE
+    """Extreme volatility pushes VaR high enough to trigger REDUCE rather than VETO."""
     np.random.seed(42)
     dates = pd.date_range(start="2023-01-01", periods=253, freq="B")
     hist = {}
 
-    # 15% daily volatility
+    # 15% daily volatility is well above normal to force VaR past the REDUCE threshold
     for t in ["AAPL", "MSFT", "GOOGL", "META", "AMZN"]:
         returns = np.random.normal(0.0, 0.15, len(dates))
         hist[t] = pd.Series(100 * np.exp(np.cumsum(returns)), index=dates)
@@ -80,12 +86,11 @@ def test_high_var_reduce(risk_engine: RiskStatisticalEngine) -> None:
     result = risk_engine.evaluate(positions, hist, current_vix=20.0)
 
     assert result.verdict == RiskVerdict.REDUCE
-    # High volatility -> high VaR
     assert result.var_99 > 0.03
 
 
 def test_approve_healthy_portfolio(risk_engine: RiskStatisticalEngine, price_history: dict) -> None:
-    # 8 equal-weighted positions
+    """A diversified, normally-weighted portfolio with normal vol is approved outright."""
     positions = [
         {"ticker": "AAPL", "weight": 0.1},
         {"ticker": "MSFT", "weight": 0.1},
@@ -104,6 +109,7 @@ def test_approve_healthy_portfolio(risk_engine: RiskStatisticalEngine, price_his
 
 
 def test_zero_api_calls(risk_engine: RiskStatisticalEngine, price_history: dict) -> None:
+    """The risk engine evaluates purely statistically, never calling an LLM."""
     positions = [{"ticker": "AAPL", "weight": 0.1} for _ in range(5)]
     result = risk_engine.evaluate(positions, price_history, current_vix=40.0)
 

--- a/tests/test_risk_properties.py
+++ b/tests/test_risk_properties.py
@@ -36,11 +36,11 @@ def _price_history() -> dict[str, pd.Series]:
     vix=st.floats(min_value=0.0, max_value=100.0, allow_nan=False),
 )
 def test_approved_weight_never_exceeds_proposed(weight: float, vix: float) -> None:
+    """Across the full weight/VIX input space, approved weight never exceeds proposed weight."""
     engine = RiskStatisticalEngine()
     positions = [{"ticker": "AAPL", "weight": weight}]
 
     result = engine.evaluate(positions, _price_history(), current_vix=vix)
 
-    # RiskAssessment's own validator already raises on construction if this is
-    # violated; reaching this assertion is itself part of the proof.
+    # RiskAssessment's validator would raise on construction if this were violated
     assert result.approved_weight <= result.proposed_weight + 1e-9

--- a/tests/test_seams.py
+++ b/tests/test_seams.py
@@ -1,6 +1,6 @@
 """
 Tests exercising argus/seams.py's fixture-backed implementations against the
-real agent classes — the point of the injection seam (ADR 0007) is that
+real agent classes — the point of the injection seam is that
 FundamentalAgent/SentimentAgent produce a real, schema-valid signal from
 fixture data with zero network or LLM calls. If these fixtures ever go
 stale or the seam breaks, these tests fail; nothing here is decorative.
@@ -18,14 +18,23 @@ FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
 
 def _single_response_llm(fixture_file: str, ticker: str) -> FixtureLLMClient:
+    """Builds a FixtureLLMClient that replays one recorded response for every call.
+
+    Args:
+        fixture_file: JSON file under fixtures/llm_responses/ keyed by ticker.
+        ticker: Ticker whose recorded response to replay.
+
+    Returns:
+        A FixtureLLMClient returning that ticker's response for any prompt.
+    """
     with open(FIXTURES_DIR / "llm_responses" / fixture_file) as f:
         responses = json.load(f)
-    # Fixture only handles one ticker per instance — every call in a single
-    # analyze() invocation gets the same recorded response for that ticker.
+    # One ticker per instance, so every call in a single analyze() gets the same response
     return FixtureLLMClient({"only": responses[ticker]}, key_fn=lambda _prompt: "only")
 
 
 def test_fundamental_agent_with_fixtures_produces_valid_signal():
+    """FundamentalAgent produces a schema-valid signal from fixture data alone."""
     market_data = FixtureMarketDataProvider()
     llm_client = _single_response_llm("fundamental.json", "AAPL")
     agent = FundamentalAgent(llm_client=llm_client, market_data=market_data)
@@ -43,6 +52,7 @@ def test_fundamental_agent_with_fixtures_produces_valid_signal():
 
 
 def test_sentiment_agent_with_fixtures_produces_valid_signal():
+    """SentimentAgent produces a schema-valid signal from fixture data alone."""
     market_data = FixtureMarketDataProvider()
     llm_client = _single_response_llm("sentiment.json", "AAPL")
     agent = SentimentAgent(llm_client=llm_client, market_data=market_data)
@@ -57,6 +67,7 @@ def test_sentiment_agent_with_fixtures_produces_valid_signal():
 
 
 def test_fixture_market_data_provider_ohlcv_daily_matches_fixture():
+    """The fixture provider serves real OHLCV data, not an empty stand-in."""
     market_data = FixtureMarketDataProvider()
     df = market_data.ohlcv_daily("AAPL")
     assert not df.empty
@@ -64,6 +75,7 @@ def test_fixture_market_data_provider_ohlcv_daily_matches_fixture():
 
 
 def test_fixture_market_data_provider_missing_ticker_raises():
+    """A ticker with no fixture data raises KeyError rather than failing silently."""
     market_data = FixtureMarketDataProvider()
     try:
         market_data.fundamentals("NOT_A_REAL_TICKER")

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -9,28 +9,31 @@ from argus.agents.sentiment import aggregate_finbert_scores, SentimentDailyCache
 from argus.schemas.signals import SentimentSignal, Signal
 
 def test_aggregate_finbert_scores_empty():
+    """An empty article list returns the neutral, low-confidence default."""
     res = aggregate_finbert_scores([])
     assert res == {"net": 0.0, "pct_pos": 0.0, "pct_neg": 0.0, "confidence": 0.3}
 
 def test_aggregate_finbert_scores_decay():
+    """A newer negative article outweighs an equal-magnitude older positive one."""
     scored = [
         {"numeric": 1.0, "label": "positive"}, # Oldest
         {"numeric": -1.0, "label": "negative"}, # Newest
     ]
-    # decay_rate is 0.95. Oldest gets weight 0.95^1 = 0.95. Newest gets weight 0.95^0 = 1.0.
-    # net = (1.0 * 0.95 + -1.0 * 1.0) / 1.95 = -0.05 / 1.95 = -0.0256
+    # decay_rate 0.95 weights oldest at 0.95^1, newest at 0.95^0, so recency wins the net score
     res = aggregate_finbert_scores(scored)
-    assert res["net"] < 0.0 # Newer negative article outweighs older positive article
+    assert res["net"] < 0.0
     assert res["pct_pos"] == 0.5
     assert res["pct_neg"] == 0.5
     assert res["confidence"] == 0.2 # 2 articles = 0.2
 
 def test_aggregate_finbert_scores_confidence_cap():
+    """Confidence saturates at 1.0 regardless of how many articles are scored."""
     scored = [{"numeric": 1.0, "label": "positive"} for _ in range(15)]
     res = aggregate_finbert_scores(scored)
-    assert res["confidence"] == 1.0 # Capped at 1.0
+    assert res["confidence"] == 1.0 # capped at 1.0
 
 def test_sentiment_daily_cache():
+    """A cache entry becomes stale, and unretrievable, once its TTL elapses."""
     cache = SentimentDailyCache()
     assert cache.is_stale("AAPL")
 
@@ -55,8 +58,7 @@ def test_sentiment_daily_cache():
     assert not cache.is_stale("AAPL")
     assert cache.get("AAPL") == signal
 
-    # Manually expire the cache entry to test TTL
-    # It checks (now - cached_at).total_seconds() < 86400
+    # Backdate the entry past the cache's 86400s TTL to force staleness
     cache._cache["AAPL"] = (signal, datetime.now() - timedelta(days=2))
     assert cache.is_stale("AAPL")
     assert cache.get("AAPL") is None

--- a/tests/test_technical.py
+++ b/tests/test_technical.py
@@ -9,10 +9,14 @@ from argus.schemas.signals import Signal
 
 @pytest.fixture
 def agent() -> TechnicalStatisticalAgent:
+    """Returns:
+        A fresh TechnicalStatisticalAgent instance.
+    """
     return TechnicalStatisticalAgent()
 
 
 def test_bullish_signal(agent: TechnicalStatisticalAgent) -> None:
+    """Oversold RSI, positive MACD, and strong momentum together yield a BULLISH signal."""
     session_state = {
         "rsi_14": 28.0,
         "macd_histogram": 0.15,
@@ -31,6 +35,7 @@ def test_bullish_signal(agent: TechnicalStatisticalAgent) -> None:
 
 
 def test_bearish_signal(agent: TechnicalStatisticalAgent) -> None:
+    """Inverting every bullish indicator flips the signal to BEARISH."""
     session_state = {
         "rsi_14": 72.0,  # Opposite of 28
         "macd_histogram": -0.15,  # Opposite of 0.15
@@ -49,6 +54,7 @@ def test_bearish_signal(agent: TechnicalStatisticalAgent) -> None:
 
 
 def test_neutral_signal(agent: TechnicalStatisticalAgent) -> None:
+    """All-flat indicators with a weak trend keep the net score within the neutral band."""
     session_state = {
         "rsi_14": 50.0,
         "macd_histogram": 0.0,
@@ -66,6 +72,7 @@ def test_neutral_signal(agent: TechnicalStatisticalAgent) -> None:
 
 
 def test_zero_api_calls(agent: TechnicalStatisticalAgent) -> None:
+    """The technical agent evaluates purely statistically, never calling an LLM."""
     session_state = {
         "rsi_14": 50.0,
         "macd_histogram": 0.0,

--- a/tests/test_technical_properties.py
+++ b/tests/test_technical_properties.py
@@ -18,6 +18,7 @@ from argus.agents.technical import _score_bollinger, _score_rsi
 
 @given(rsi=st.floats(min_value=0.0, max_value=100.0, allow_nan=False))
 def test_score_rsi_bounded(rsi: float) -> None:
+    """RSI score stays within [-1.0, 1.0] across the entire RSI domain."""
     score = _score_rsi({"rsi_14": rsi})
     assert -1.0 <= score <= 1.0
 
@@ -27,24 +28,30 @@ def test_score_rsi_bounded(rsi: float) -> None:
     delta=st.floats(min_value=0.01, max_value=0.5, allow_nan=False),
 )
 def test_score_rsi_monotonically_non_increasing(rsi: float, delta: float) -> None:
-    """Higher RSI (more overbought) must never score more bullish than a lower RSI."""
+    """Higher RSI never scores more bullish than a lower RSI.
+
+    Args:
+        rsi: Base RSI value to compare from.
+        delta: Positive offset added to rsi for the higher comparison point.
+    """
     higher_rsi = min(100.0, rsi + delta)
     assert _score_rsi({"rsi_14": higher_rsi}) <= _score_rsi({"rsi_14": rsi}) + 1e-9
 
 
 @given(bb=st.floats(min_value=-5.0, max_value=6.0, allow_nan=False))
 def test_score_bollinger_bounded(bb: float) -> None:
+    """Bollinger %B score stays within [-1.0, 1.0] across the entire %B domain."""
     score = _score_bollinger({"bb_percent_b": bb})
     assert -1.0 <= score <= 1.0
 
 
 @given(bb=st.floats(min_value=-5.0, max_value=6.0, allow_nan=False))
 def test_score_bollinger_antisymmetric_about_half(bb: float) -> None:
-    """%B and its mirror image around 0.5 must score as exact opposites.
+    """%B and its mirror image around 0.5 score as exact opposites.
 
-    bb_percent_b measures position within the bands; a breach the same
-    distance below the lower band as another is above the upper band
-    should be scored with equal magnitude and opposite sign.
+    Args:
+        bb: %B value; a breach this far below the lower band scores the same
+            magnitude, opposite sign, as the mirrored breach above the upper band.
     """
     mirrored = 1.0 - bb
     score = _score_bollinger({"bb_percent_b": bb})


### PR DESCRIPTION
…DE.md

Backfills missing docstrings, condenses restated inline comments to why-only one-liners, and strips ADR/incident citations out of source in favor of docs/adr/ and PR descriptions.