### PR TITLE
Fix macro HMM fit protocol and add a training validation gate

### DIFF
--- a/argus/agents/macro.py
+++ b/argus/agents/macro.py
@@ -24,6 +24,7 @@ Dependencies:
 from __future__ import annotations
 
 import logging
+import warnings
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Tuple
@@ -35,6 +36,8 @@ import pandas as pd
 import scipy.linalg
 import sklearn
 from hmmlearn.hmm import GaussianHMM
+from scipy.spatial.distance import mahalanobis
+from sklearn.exceptions import ConvergenceWarning
 from sklearn.preprocessing import StandardScaler
 
 from argus.config import settings
@@ -59,6 +62,103 @@ _FEATURE_DEFAULTS = {
     "vix_pctile": 50.0,
 }
 
+# Canned scenarios for scripts/train_macro_hmm.py's discrimination gate (and
+# tested directly against it): a trained model that maps every one of these to
+# the same label cannot be a function of the macro data. Values are on
+# FEATURE_COLUMNS' scale, not raw indicator levels.
+DISCRIMINATION_SCENARIOS: dict[str, dict[str, float]] = {
+    "goldilocks_boom": {
+        "d_fed_funds_6m": -0.1,
+        "d_unemp_12m": -0.2,
+        "cpi_yoy": 2.0,
+        "t10y2y": 1.5,
+        "vix_pctile": 10.0,
+    },
+    "gfc_crash": {
+        "d_fed_funds_6m": -2.5,
+        "d_unemp_12m": 3.5,
+        "cpi_yoy": 0.5,
+        "t10y2y": -0.3,
+        "vix_pctile": 95.0,
+    },
+    "covid_shock": {
+        "d_fed_funds_6m": -1.5,
+        "d_unemp_12m": 8.0,
+        "cpi_yoy": 0.3,
+        "t10y2y": 0.5,
+        "vix_pctile": 99.0,
+    },
+    "2023_curve_inversion": {
+        "d_fed_funds_6m": 1.0,
+        "d_unemp_12m": -0.3,
+        "cpi_yoy": 4.0,
+        "t10y2y": -1.0,
+        "vix_pctile": 40.0,
+    },
+    "stagflation": {
+        "d_fed_funds_6m": 0.5,
+        "d_unemp_12m": 1.0,
+        "cpi_yoy": 9.0,
+        "t10y2y": -0.5,
+        "vix_pctile": 70.0,
+    },
+}
+
+
+def _dwell_times_months(hidden_states: np.ndarray, n_components: int) -> dict[int, float]:
+    """Computes each state's mean run length (in observations) from a Viterbi path.
+
+    Args:
+        hidden_states: Decoded state sequence, ordered oldest to newest.
+        n_components: Number of HMM states.
+
+    Returns:
+        Dict mapping state index to mean dwell time; 0.0 for a state with no runs.
+    """
+    runs: dict[int, list[int]] = {s: [] for s in range(n_components)}
+    run_state = int(hidden_states[0])
+    run_len = 1
+    for state in hidden_states[1:]:
+        state = int(state)
+        if state == run_state:
+            run_len += 1
+        else:
+            runs[run_state].append(run_len)
+            run_state = state
+            run_len = 1
+    runs[run_state].append(run_len)
+    return {s: (float(np.mean(lengths)) if lengths else 0.0) for s, lengths in runs.items()}
+
+
+def _min_pairwise_mahalanobis(hmm: GaussianHMM, occupancy: np.ndarray) -> float:
+    """Computes the minimum pairwise Mahalanobis distance between state means.
+
+    Uses the occupancy-weighted pooled covariance across states, so a state's
+    own (possibly ill-conditioned) covariance doesn't dominate the metric.
+
+    Args:
+        hmm: A fitted GaussianHMM with full covariances.
+        occupancy: Fraction of decoded observations assigned to each state.
+
+    Returns:
+        The smallest pairwise distance, or 0.0 for a single-state model.
+    """
+    n = hmm.n_components
+    if n < 2:
+        return 0.0
+    pooled_cov = np.average(hmm.covars_, axis=0, weights=occupancy)
+    try:
+        inv_cov = np.linalg.inv(pooled_cov)
+    except np.linalg.LinAlgError:
+        inv_cov = np.linalg.pinv(pooled_cov)
+
+    min_dist = np.inf
+    for i in range(n):
+        for j in range(i + 1, n):
+            dist = mahalanobis(hmm.means_[i], hmm.means_[j], inv_cov)
+            min_dist = min(min_dist, dist)
+    return float(min_dist)
+
 
 def _major_minor(version: str) -> str:
     """Truncates a dotted version string to its major.minor prefix."""
@@ -68,23 +168,22 @@ def _major_minor(version: str) -> str:
 class RegimeClassifier:
     """Gaussian Hidden Markov Model mapping macro features to hidden economic states.
 
-    Trained on a long FRED history (2010+), then applied to current macro observations
-    to infer the latent regime. State-to-regime mapping is determined heuristically from
-    per-state feature means after fitting.
+    Trained on a long FRED history (1990+), then applied to current macro observations
+    to infer the latent regime. CONTRACTION is labelled by NBER (USREC) recession
+    enrichment; EXPANSION and TRANSITIONAL are labelled heuristically from per-state
+    feature means. See fit() and _map_states().
     """
 
-    def __init__(self, n_components: int = 3, random_state: int = 42) -> None:
+    def __init__(self, n_components: int = 3) -> None:
         """Builds the underlying Gaussian HMM, untrained.
 
         Args:
             n_components: Number of latent regime states.
-            random_state: Seed for the HMM's random initialization.
         """
         self.hmm = GaussianHMM(
             n_components=n_components,
             covariance_type="full",
             n_iter=300,
-            random_state=random_state,
         )
         self.scaler = StandardScaler()
         self.is_fitted = False
@@ -95,61 +194,171 @@ class RegimeClassifier:
         # so scripts/train_macro_hmm.py can print the human check on _map_states'
         # labeling immediately after fitting.
         self.state_means: dict[int, dict[str, float]] = {}
+        # Populated by fit(): separation/occupancy/dwell/enrichment/recall evidence
+        # for this fit, persisted into the artifact's metadata by save() and
+        # checked by validation_failures().
+        self.validation_metrics: dict = {}
 
-    def fit(self, macro_history: pd.DataFrame) -> None:
+    def fit(
+        self, macro_history: pd.DataFrame, recession_series: Optional[pd.Series] = None
+    ) -> None:
         """Fits the scaling transformer and HMM classifier on historic feature timelines.
+
+        Tries MACRO.hmm_n_init random restarts (seeds 0..n_init-1), rejecting any
+        restart whose states are not well separated or that leaves a state
+        under-occupied, and keeps the highest-likelihood survivor. A single fixed
+        seed is not enough: on this data, 3 of 5 seeds collapse two states onto
+        the same distribution, and the shipped artifact's seed (42) was one of them.
 
         Args:
             macro_history: DataFrame containing at least FEATURE_COLUMNS. NaN rows
                 are dropped before fitting.
+            recession_series: Optional NBER USREC series (1.0 during a recession
+                month, else 0.0), indexed to overlap macro_history. Used by
+                _map_states to label the CONTRACTION state by recession
+                enrichment; if None, no state is labelled CONTRACTION.
+
+        Raises:
+            ValueError: If every restart is rejected as degenerate or under-occupied.
         """
         df = macro_history.dropna().copy()
         if df.empty:
             logger.warning("RegimeClassifier.fit: Empty DataFrame after dropping NaNs.")
             return
 
+        n_components = self.hmm.n_components
         features = df[FEATURE_COLUMNS].values
-        scaled_features = self.scaler.fit_transform(features)
+        scaler = StandardScaler()
+        scaled_features = scaler.fit_transform(features)
 
-        self.hmm.fit(scaled_features)
-        self._map_states(df)
+        self._log_bic_diagnostic(scaled_features)
+
+        best_hmm: Optional[GaussianHMM] = None
+        best_score = -np.inf
+        best_separation = 0.0
+        best_occupancy = np.array([])
+        rejections: list[str] = []
+
+        for seed in range(MACRO.hmm_n_init):
+            candidate = GaussianHMM(
+                n_components=n_components,
+                covariance_type="full",
+                n_iter=300,
+                random_state=seed,
+            )
+            with warnings.catch_warnings():
+                # Sub-1e-4 monotonicity wobble near the optimum is benign, not a failure
+                warnings.filterwarnings("ignore", category=ConvergenceWarning)
+                candidate.fit(scaled_features)
+
+            hidden_states = candidate.predict(scaled_features)
+            occupancy = np.bincount(hidden_states, minlength=n_components) / len(hidden_states)
+            if occupancy.min() < MACRO.hmm_min_state_occupancy:
+                rejections.append(f"seed={seed}: min occupancy {occupancy.min():.3f}")
+                continue
+
+            separation = _min_pairwise_mahalanobis(candidate, occupancy)
+            if separation < MACRO.hmm_min_state_separation:
+                rejections.append(f"seed={seed}: min separation {separation:.3f}")
+                continue
+
+            score = candidate.score(scaled_features)
+            if score > best_score:
+                best_score = score
+                best_hmm = candidate
+                best_separation = separation
+                best_occupancy = occupancy
+
+        if best_hmm is None:
+            raise ValueError(
+                f"RegimeClassifier.fit: all {MACRO.hmm_n_init} restarts were degenerate "
+                f"or under-occupied ({'; '.join(rejections)})"
+            )
+
+        self.hmm = best_hmm
+        self.scaler = scaler
+        hidden_states = best_hmm.predict(scaled_features)
+
+        self.validation_metrics = {
+            "min_state_separation": best_separation,
+            "state_occupancy": {int(s): float(o) for s, o in enumerate(best_occupancy)},
+            "dwell_times_months": _dwell_times_months(hidden_states, n_components),
+            "log_likelihood": float(best_score),
+            "n_restarts_rejected": len(rejections),
+        }
+
+        self._map_states(df, recession_series)
         self.is_fitted = True
         self.n_train_observations = len(df)
 
-    def _map_states(self, df: pd.DataFrame) -> None:
-        """Maps hidden states to human-readable regimes based on per-state feature means.
+    def _log_bic_diagnostic(self, scaled_features: np.ndarray) -> None:
+        """Logs BIC for k in {2..5} states as a diagnostic; does not affect the fitted model.
 
-        CONTRACTION = state with the highest average VIX percentile.
-        EXPANSION = from remaining states, the one with the largest 6-month rate
-            decline and a positive yield curve (t10y2y > 0).
+        n_components stays fixed at 3 (see the class docstring) — BIC decreases
+        monotonically through k=5 on this data, but k>3 forces an arbitrary
+        many-to-3 mapping onto the Regime enum for no validated gain. Logged so
+        that choice stays visible instead of assumed.
+
+        Args:
+            scaled_features: Scaler-transformed training features.
+        """
+        n_obs, n_features = scaled_features.shape
+        for k in range(2, 6):
+            try:
+                candidate = GaussianHMM(
+                    n_components=k, covariance_type="full", n_iter=300, random_state=0
+                )
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category=ConvergenceWarning)
+                    candidate.fit(scaled_features)
+                log_likelihood = candidate.score(scaled_features)
+                n_params = (
+                    (k - 1) + k * (k - 1) + k * n_features + k * n_features * (n_features + 1) // 2
+                )
+                bic = -2 * log_likelihood + n_params * np.log(n_obs)
+                logger.info("RegimeClassifier.fit: BIC diagnostic k=%d -> %.1f", k, bic)
+            except Exception as exc:
+                logger.debug("RegimeClassifier.fit: BIC diagnostic failed for k=%d: %s", k, exc)
+
+    def _map_states(self, df: pd.DataFrame, recession_series: Optional[pd.Series] = None) -> None:
+        """Maps hidden states to human-readable regimes.
+
+        CONTRACTION = the state with the highest NBER (USREC) recession
+            frequency, provided it clears MACRO.contraction_enrichment_min
+            against the sample's base rate; otherwise no state is labelled
+            CONTRACTION. This replaces a VIX-percentile heuristic that always
+            assigned CONTRACTION to *some* state whether or not a
+            contractionary state actually existed — which is how the ZIRP era
+            got the label.
+        EXPANSION = of the remaining states, the one with the lowest average
+            d_unemp_12m (falling unemployment).
         TRANSITIONAL = all other states.
 
         Args:
             df: The same DataFrame used for fitting, used to label state sequences.
+            recession_series: Optional NBER USREC series; see fit()'s docstring.
         """
+        self.state_to_regime = {}
+
         features = df[FEATURE_COLUMNS].values
         scaled_features = self.scaler.transform(features)
         hidden_states = self.hmm.predict(scaled_features)
 
+        df = df.copy()
         df["state"] = hidden_states
         full_means = df.groupby("state")[FEATURE_COLUMNS].mean()
         self.state_means = {int(state): row.to_dict() for state, row in full_means.iterrows()}
 
-        means = df.groupby("state")[["vix_pctile", "d_fed_funds_6m", "t10y2y"]].mean()
+        contraction_state = self._label_contraction_state(df, recession_series)
 
-        contraction_state = int(means["vix_pctile"].idxmax())
-
-        remaining = means.drop(index=contraction_state, errors="ignore")
-        expansion_state = -1
-
+        remaining = df[df["state"] != contraction_state] if contraction_state is not None else df
+        expansion_state: Optional[int] = None
         if not remaining.empty:
-            pos_curve = remaining[remaining["t10y2y"] > 0]
-            if not pos_curve.empty:
-                expansion_state = int(pos_curve["d_fed_funds_6m"].idxmin())
-            else:
-                expansion_state = int(remaining["d_fed_funds_6m"].idxmin())
+            remaining_means = remaining.groupby("state")["d_unemp_12m"].mean()
+            if not remaining_means.empty:
+                expansion_state = int(remaining_means.idxmin())
 
-        for state in means.index:
+        for state in sorted(df["state"].unique()):
             state = int(state)
             if state == contraction_state:
                 self.state_to_regime[state] = Regime.CONTRACTION.value
@@ -159,6 +368,115 @@ class RegimeClassifier:
                 self.state_to_regime[state] = Regime.TRANSITIONAL.value
 
         logger.debug("HMM State Mapping: %s", self.state_to_regime)
+
+    def _label_contraction_state(
+        self, df_with_state: pd.DataFrame, recession_series: Optional[pd.Series]
+    ) -> Optional[int]:
+        """Picks the CONTRACTION state by NBER recession-frequency enrichment.
+
+        Args:
+            df_with_state: Training frame with a "state" column, from _map_states.
+            recession_series: NBER USREC series (1.0/0.0), or None if unavailable.
+
+        Returns:
+            The state index to label CONTRACTION, or None if no candidate clears
+            MACRO.contraction_enrichment_min. Either way, records enrichment and
+            recall into validation_metrics for validation_failures() and the
+            persisted artifact metadata.
+        """
+        if recession_series is None:
+            self.validation_metrics["contraction_enrichment"] = None
+            self.validation_metrics["contraction_recall"] = None
+            return None
+
+        aligned = recession_series.reindex(df_with_state.index).fillna(0.0)
+        base_rate = float(aligned.mean())
+        freq_by_state = aligned.groupby(df_with_state["state"]).mean()
+        self.validation_metrics["recession_frequency_by_state"] = {
+            int(s): float(f) for s, f in freq_by_state.items()
+        }
+
+        if base_rate <= 0 or freq_by_state.empty:
+            self.validation_metrics["contraction_enrichment"] = None
+            self.validation_metrics["contraction_recall"] = None
+            return None
+
+        candidate = int(freq_by_state.idxmax())
+        enrichment = float(freq_by_state.loc[candidate] / base_rate)
+        self.validation_metrics["contraction_enrichment"] = enrichment
+
+        if enrichment < MACRO.contraction_enrichment_min:
+            self.validation_metrics["contraction_recall"] = None
+            return None
+
+        recession_mask = aligned > 0
+        recall = (
+            float((df_with_state.loc[recession_mask, "state"] == candidate).mean())
+            if recession_mask.any()
+            else 0.0
+        )
+        self.validation_metrics["contraction_recall"] = recall
+        return candidate
+
+    def validation_failures(self) -> list[str]:
+        """Checks the fitted model against the training-gate thresholds in MACRO.
+
+        Meant for scripts/train_macro_hmm.py to hard-fail a training run before
+        persisting a broken artifact. fit() already rejects degenerate/
+        under-occupied restarts internally; this re-checks the winning fit plus
+        the checks fit() doesn't perform on its own (dwell time, CONTRACTION
+        enrichment, and a discrimination smoke test).
+
+        Returns:
+            Human-readable failure descriptions; empty if every check passes.
+        """
+        if not self.is_fitted:
+            return ["classifier is not fitted"]
+
+        failures: list[str] = []
+        m = self.validation_metrics
+
+        separation = m.get("min_state_separation", 0.0)
+        if separation < MACRO.hmm_min_state_separation:
+            failures.append(
+                f"min state separation {separation:.3f} below floor "
+                f"{MACRO.hmm_min_state_separation}"
+            )
+
+        occupancy = m.get("state_occupancy", {})
+        low_occupancy = {s: o for s, o in occupancy.items() if o < MACRO.hmm_min_state_occupancy}
+        if low_occupancy:
+            failures.append(
+                f"states below occupancy floor {MACRO.hmm_min_state_occupancy}: {low_occupancy}"
+            )
+
+        dwell = m.get("dwell_times_months", {})
+        bad_dwell = {
+            s: d
+            for s, d in dwell.items()
+            if not (MACRO.dwell_time_min_months <= d <= MACRO.dwell_time_max_months)
+        }
+        if bad_dwell:
+            failures.append(
+                f"states with dwell time outside [{MACRO.dwell_time_min_months}, "
+                f"{MACRO.dwell_time_max_months}] months: {bad_dwell}"
+            )
+
+        enrichment = m.get("contraction_enrichment")
+        if enrichment is None or enrichment < MACRO.contraction_enrichment_min:
+            failures.append(
+                f"CONTRACTION enrichment {enrichment} below floor "
+                f"{MACRO.contraction_enrichment_min}"
+            )
+
+        labels = {
+            self.predict(pd.DataFrame([scenario]))[0]
+            for scenario in DISCRIMINATION_SCENARIOS.values()
+        }
+        if len(labels) < 2:
+            failures.append(f"discrimination scenarios collapsed to a single label: {labels}")
+
+        return failures
 
     def predict(self, current: dict | pd.DataFrame) -> Tuple[str, float]:
         """Classifies the current economic regime and returns posterior probability confidence.
@@ -247,6 +565,7 @@ class RegimeClassifier:
                 "n_train_observations": self.n_train_observations,
                 "start_date": start_date,
                 "trained_at": datetime.now(timezone.utc).isoformat(),
+                "validation_metrics": self.validation_metrics,
             },
         }
         joblib.dump(payload, path)
@@ -300,6 +619,7 @@ class RegimeClassifier:
             classifier.state_to_regime = payload["state_to_regime"]
             classifier.is_fitted = payload["is_fitted"]
             classifier.n_train_observations = metadata.get("n_train_observations", 0)
+            classifier.validation_metrics = metadata.get("validation_metrics", {})
 
             if classifier.is_fitted:
                 # Fitting one long sequence gives hmmlearn nothing to average over,
@@ -366,7 +686,19 @@ class MacroStatisticalAgent:
         logger.debug("Fetching macro history from %s for HMM fitting...", start_date)
         try:
             df = build_macro_feature_frame(self.market_data, start=start_date)
-            self.classifier.fit(df)
+
+            recession_series = None
+            try:
+                usrec = self.market_data.fred_series("USREC", start=start_date)
+                recession_series = usrec.resample("ME").last()
+            except Exception as exc:
+                logger.warning(
+                    "fit_on_history: failed to fetch NBER USREC series (%s); "
+                    "CONTRACTION will not be labelled on this fit.",
+                    exc,
+                )
+
+            self.classifier.fit(df, recession_series=recession_series)
             logger.debug("HMM fitted on %d observations from %s.", len(df), start_date)
         except Exception as e:
             logger.error("Failed to fit HMM on history: %s", e)

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 4
+PARAMS_VERSION = 5
 
 
 class Provenance(str, Enum):
@@ -226,6 +226,49 @@ class MacroParams:
     )
     cpi_publication_lag_days: int = p(
         45, Provenance.LITERATURE, "BLS CPI release lag for CPIAUCSL"
+    )
+    hmm_n_init: int = p(
+        20,
+        Provenance.ARBITRARY,
+        "random restarts of the fit, keeping the highest-likelihood non-degenerate "
+        "one; 3 of 5 single-seed fits collapsed on the shipped data, so one seed "
+        "is not enough — 20 is a guess at 'enough', not backtested",
+    )
+    hmm_min_state_separation: float = p(
+        1.0,
+        Provenance.ARBITRARY,
+        "minimum pairwise Mahalanobis distance between state means (pooled "
+        "covariance) a restart must clear to be accepted; the shipped degenerate "
+        "model scored ~0.001, the validated target design scored 2.71 — 1.0 is a "
+        "floor with margin below the validated fit, not itself validated",
+    )
+    hmm_min_state_occupancy: float = p(
+        0.05,
+        Provenance.ARBITRARY,
+        "minimum fraction of training observations a state must claim to be "
+        "accepted, guarding against a restart that fits one state to a handful "
+        "of outlier months",
+    )
+    contraction_enrichment_min: float = p(
+        2.0,
+        Provenance.ARBITRARY,
+        "minimum ratio of a candidate CONTRACTION state's NBER (USREC) recession "
+        "frequency to the sample's overall recession base rate; the validated "
+        "target design achieved 3.2x — 2.0 is a floor below that, not itself "
+        "validated",
+    )
+    dwell_time_min_months: float = p(
+        3.0,
+        Provenance.ARBITRARY,
+        "minimum acceptable mean state dwell time in the training-gate check; "
+        "below this a state is switching faster than any real macro regime does",
+    )
+    dwell_time_max_months: float = p(
+        120.0,
+        Provenance.ARBITRARY,
+        "maximum acceptable mean state dwell time in the training-gate check; "
+        "above this a state is effectively never leaving, i.e. tracking a rate "
+        "era rather than a regime",
     )
 
 

--- a/scripts/train_macro_hmm.py
+++ b/scripts/train_macro_hmm.py
@@ -6,12 +6,16 @@ CLI entry point to fit RegimeClassifier (argus/agents/macro.py) on a long FRED +
 VIX history and persist the result as the artifact every MacroStatisticalAgent
 construction site loads.
 
-    .venv/bin/python -m scripts.train_macro_hmm [--start-date 2010-01-01] [--output PATH]
+    .venv/bin/python -m scripts.train_macro_hmm [--start-date 1990-01-01] [--output PATH]
 
 Offline-only: calls MacroStatisticalAgent.fit_on_history(), which does its own
 direct yf.download() for VIX history and fetch_fred_series() calls for FRED
 series — both real network calls, not fixture-backed. Not run by CI or any
 scheduled workflow; retraining is manual (see the README's Deployment section).
+
+The artifact is only written if RegimeClassifier.validation_failures() comes
+back empty — a non-zero exit here means the fit produced a model that isn't a
+function of the macro data, and no artifact is written for it.
 """
 
 import argparse
@@ -36,7 +40,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--start-date",
-        default="2010-01-01",
+        default="1990-01-01",
         help="ISO date string for the beginning of the training window",
     )
     parser.add_argument(
@@ -54,15 +58,29 @@ def main() -> None:
         print("Fit failed — classifier.is_fitted is False. Check the error logged above.")
         raise SystemExit(1)
 
-    classifier.save(args.output, start_date=args.start_date)
-
-    print(f"Saved artifact to {args.output} ({classifier.n_train_observations} observations).")
     print("\nPer-state feature means and assigned regime label:")
     for state in sorted(classifier.state_means):
         means = classifier.state_means[state]
         regime = classifier.state_to_regime.get(state, Regime.TRANSITIONAL.value)
         formatted = ", ".join(f"{col}={val:.3f}" for col, val in means.items())
         print(f"  state {state} -> {regime:<12} {formatted}")
+
+    print("\nValidation metrics:")
+    for key, value in classifier.validation_metrics.items():
+        print(f"  {key}: {value}")
+
+    failures = classifier.validation_failures()
+    if failures:
+        print("\nValidation gate FAILED — artifact not saved:")
+        for reason in failures:
+            print(f"  - {reason}")
+        raise SystemExit(1)
+
+    classifier.save(args.output, start_date=args.start_date)
+    print(
+        f"\nValidation gate passed. Saved artifact to {args.output} "
+        f"({classifier.n_train_observations} observations)."
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -3,6 +3,7 @@ Tests for the Macro-Economic Agent (argus/agents/macro.py).
 """
 
 import logging
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -10,8 +11,14 @@ import joblib
 import numpy as np
 import pandas as pd
 import pytest
+from hmmlearn.hmm import GaussianHMM
 
-from argus.agents.macro import FEATURE_COLUMNS, MacroStatisticalAgent, RegimeClassifier
+from argus.agents.macro import (
+    DISCRIMINATION_SCENARIOS,
+    FEATURE_COLUMNS,
+    MacroStatisticalAgent,
+    RegimeClassifier,
+)
 from argus.schemas.signals import Regime
 
 
@@ -117,25 +124,29 @@ _TRANSITIONAL_POINT = {
 }
 
 
-def _fit_synthetic_classifier(seed: int = 3) -> RegimeClassifier:
-    """Fits a RegimeClassifier on synthetic, well-separated 3-regime data.
+_N_PER_BLOCK = 60
 
-    Blocks (not shuffled) so the HMM also learns a sensible transition structure,
-    rather than i.i.d. noise around three means.
+
+def _synthetic_history(seed: int = 3) -> pd.DataFrame:
+    """Builds synthetic, well-separated 3-regime feature history, unfitted.
+
+    Blocks (not shuffled) so a fitted HMM also learns a sensible transition
+    structure, rather than i.i.d. noise around three means.
 
     Args:
         seed: RNG seed for the per-point Gaussian noise.
 
     Returns:
-        A fitted RegimeClassifier whose state_to_regime covers all three regimes.
+        DataFrame with FEATURE_COLUMNS, four blocks of _N_PER_BLOCK rows each
+        (expansion, contraction, transitional, expansion), daily-indexed from
+        2015-01-01.
     """
     rng = np.random.default_rng(seed)
-    n_per_block = 60
 
     def block(point: dict) -> pd.DataFrame:
         return pd.DataFrame(
             {
-                col: point[col] + rng.normal(0, 0.05 if col != "vix_pctile" else 2.0, n_per_block)
+                col: point[col] + rng.normal(0, 0.05 if col != "vix_pctile" else 2.0, _N_PER_BLOCK)
                 for col in FEATURE_COLUMNS
             }
         )
@@ -150,20 +161,40 @@ def _fit_synthetic_classifier(seed: int = 3) -> RegimeClassifier:
         ignore_index=True,
     )
     history.index = pd.date_range("2015-01-01", periods=len(history), freq="D")
+    return history
 
-    # random_state=2 (vs. RegimeClassifier's production default of 42) is picked because
-    # it reliably separates this synthetic data into 3 clean clusters; EM's local-optimum
-    # sensitivity means not every seed does on data this small.
-    classifier = RegimeClassifier(n_components=3, random_state=2)
-    classifier.fit(history)
 
-    # Fitting on one single long sequence (rather than several independent ones) gives
-    # hmmlearn nothing to average over for the initial-state distribution, so startprob_
-    # collapses to a near one-hot pointing at whichever state the training sequence's very
-    # first sample happened to land in — an artifact of where the sequence starts, not a
-    # real prior. Neutralizing it isolates the emission/transition dynamics windowed
-    # inference is actually about.
-    classifier.hmm.startprob_ = np.full(3, 1.0 / 3)
+def _fit_synthetic_classifier(seed: int = 3) -> RegimeClassifier:
+    """Fits a RegimeClassifier on synthetic, well-separated 3-regime data.
+
+    fit() itself tries multiple random restarts (see RegimeClassifier.fit), so
+    no particular constructor seed needs to be hand-picked for this data to
+    separate cleanly.
+
+    Args:
+        seed: RNG seed for the per-point Gaussian noise.
+
+    Returns:
+        A fitted RegimeClassifier whose state_to_regime covers all three regimes.
+    """
+    history = _synthetic_history(seed)
+
+    # Recession flag over the contraction block only, so _map_states' NBER-enrichment
+    # labelling (see RegimeClassifier._label_contraction_state) has something to key
+    # CONTRACTION on, the same way it would from a real USREC series.
+    recession_series = pd.Series(0.0, index=history.index)
+    recession_series.iloc[_N_PER_BLOCK : 2 * _N_PER_BLOCK] = 1.0
+
+    classifier = RegimeClassifier(n_components=3)
+    classifier.fit(history, recession_series=recession_series)
+
+    # save()/load() round-trip so the returned classifier carries load()'s stationary-
+    # startprob_ fix (see RegimeClassifier.load) instead of a test-only hand patch —
+    # hand-patching here would mask a regression in that fix from the rest of the suite.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        artifact_path = Path(tmp_dir) / "synthetic.joblib"
+        classifier.save(artifact_path)
+        classifier = RegimeClassifier.load(artifact_path)
 
     assert classifier.is_fitted
     assert set(classifier.state_to_regime.values()) == {
@@ -279,6 +310,110 @@ def test_windowed_predict_resists_a_single_point_spike() -> None:
     window = pd.DataFrame([_EXPANSION_POINT] * 9 + [noisy_point])
     windowed_regime, _ = classifier.predict(window)
     assert windowed_regime == Regime.EXPANSION.value
+
+
+def test_window_length_invariance() -> None:
+    """The same constant window classifies identically at every length.
+
+    Direct regression test for the parity bug that made the shipped artifact's
+    regime a function of window-length parity rather than the macro data:
+    tail(89) and tail(90) on the same real window returned different regimes.
+    """
+    classifier = _fit_synthetic_classifier()
+
+    regimes = {classifier.predict(pd.DataFrame([_EXPANSION_POINT] * n))[0] for n in range(5, 15)}
+
+    assert regimes == {Regime.EXPANSION.value}
+
+
+def test_discrimination_crash_and_boom_windows_produce_different_labels() -> None:
+    """A crash-like window and a boom-like window must not collapse to the same label.
+
+    Regression test for the labelling bug where _map_states always assigned
+    CONTRACTION to *some* state regardless of whether a genuinely contractionary
+    state existed, which is what let a boom period read as CONTRACTION.
+    """
+    classifier = _fit_synthetic_classifier()
+
+    boom_regime, _ = classifier.predict(pd.DataFrame([_EXPANSION_POINT] * 10))
+    crash_regime, _ = classifier.predict(pd.DataFrame([_CONTRACTION_POINT] * 10))
+
+    assert boom_regime == Regime.EXPANSION.value
+    assert crash_regime == Regime.CONTRACTION.value
+
+
+def test_contraction_reachable_from_a_single_observation() -> None:
+    """CONTRACTION must be decodable from one observation with no window context.
+
+    Regression test for the pre-fix bug: fitting one long training sequence
+    leaves startprob_ a near one-hot pointing at whichever state the sequence
+    happened to start in, making some states — including CONTRACTION, since
+    training always starts on the expansion block — provably unreachable from a
+    cold start. RegimeClassifier.load replaces startprob_ with the transition
+    matrix's stationary distribution to fix this; _fit_synthetic_classifier
+    routes through save()/load() rather than hand-patching startprob_, so this
+    test exercises the real fix.
+    """
+    classifier = _fit_synthetic_classifier()
+
+    regime, _ = classifier.predict(dict(_CONTRACTION_POINT))
+    assert regime == Regime.CONTRACTION.value
+
+
+def test_fit_raises_when_all_restarts_are_degenerate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """fit() raises rather than silently accepting a degenerate model.
+
+    Regression test for the shipped-artifact bug: two of its three states were
+    the same distribution (|Δμ|max = 0.00097). Reproducing that exact EM
+    collapse needs the same non-stationary daily forward-filled data that
+    caused it; here GaussianHMM.fit is patched to always converge every state
+    to identical means regardless of seed, so the test exercises fit()'s own
+    degeneracy-rejection logic deterministically instead of hoping a
+    synthetic dataset happens to degenerate under EM.
+    """
+
+    def _collapse_to_one_state(self, X, lengths=None):
+        n_components = self.n_components
+        n_features = X.shape[1]
+        self.startprob_ = np.full(n_components, 1.0 / n_components)
+        self.transmat_ = np.full((n_components, n_components), 1.0 / n_components)
+        self.means_ = np.tile(X.mean(axis=0), (n_components, 1))
+        cov = np.cov(X, rowvar=False) + np.eye(n_features) * 1e-3
+        self.covars_ = np.tile(cov, (n_components, 1, 1))
+        return self
+
+    monkeypatch.setattr(GaussianHMM, "fit", _collapse_to_one_state)
+
+    classifier = RegimeClassifier(n_components=3)
+    with pytest.raises(ValueError, match="degenerate"):
+        classifier.fit(_synthetic_history())
+
+
+def test_validation_failures_flags_unfitted_classifier() -> None:
+    """An unfitted classifier fails validation with a specific, non-empty reason."""
+    classifier = RegimeClassifier()
+    assert classifier.validation_failures() == ["classifier is not fitted"]
+
+
+def test_validation_failures_flags_missing_contraction_enrichment() -> None:
+    """Without a recession_series, fit() can't clear the CONTRACTION-enrichment gate."""
+    classifier = RegimeClassifier(n_components=3)
+    classifier.fit(_synthetic_history())
+
+    failures = classifier.validation_failures()
+    assert any("CONTRACTION enrichment" in f for f in failures)
+
+
+def test_discrimination_scenarios_cover_all_feature_columns() -> None:
+    """Every canned scenario supplies all FEATURE_COLUMNS.
+
+    A scenario missing a key would have predict() silently substitute
+    _FEATURE_DEFAULTS for it, weakening validation_failures()'s discrimination
+    check without failing loudly.
+    """
+    for name, scenario in DISCRIMINATION_SCENARIOS.items():
+        assert set(scenario.keys()) == set(FEATURE_COLUMNS), name
+    assert len(DISCRIMINATION_SCENARIOS) >= 2
 
 
 class _WindowAssemblyFailureMarketData:

--- a/tests/test_macro_features.py
+++ b/tests/test_macro_features.py
@@ -1,0 +1,76 @@
+"""
+Tests for shared macro feature construction (argus/data/macro_features.py).
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from argus.data.macro_features import build_macro_feature_frame
+
+
+class _PointInTimeStubProvider:
+    """A MarketDataProvider stub with a controlled FEDFUNDS release, for testing
+    build_macro_feature_frame's publication-lag shift.
+
+    All series are otherwise flat/smooth so cpi_yoy, d_fed_funds_6m, d_unemp_12m
+    and vix_pctile all come out non-NaN across the test window without needing
+    to hand-construct realistic macro trajectories.
+    """
+
+    _MONTHS = pd.date_range("2019-01-01", "2022-12-01", freq="MS")
+
+    def fred_series(self, series_id: str, start: str = "2018-01-01") -> pd.Series:
+        """Returns a controlled monthly series for the given FRED series ID."""
+        if series_id == "FEDFUNDS":
+            values = pd.Series(1.0, index=self._MONTHS)
+            # The one non-flat print: this is the value the point-in-time test
+            # checks is absent from the frame until its real publication month.
+            values.loc["2021-06-01"] = 99.0
+            return values
+        if series_id == "UNRATE":
+            return pd.Series(5.0, index=self._MONTHS)
+        if series_id == "CPIAUCSL":
+            return pd.Series(100.0 + np.arange(len(self._MONTHS)) * 0.2, index=self._MONTHS)
+        if series_id == "T10Y2Y":
+            return pd.Series(1.0, index=self._MONTHS)
+        raise KeyError(series_id)
+
+    def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame:
+        """Returns a fixed-seed daily close series, long enough for the 5-year
+        VIX-percentile rolling window to warm up within the test range."""
+        dates = pd.bdate_range("2019-01-01", "2022-12-31")
+        closes = 20.0 + np.random.default_rng(0).normal(0, 3.0, len(dates))
+        return pd.DataFrame({"close": closes}, index=dates)
+
+
+def test_publication_lag_delays_a_release_to_its_actual_publication_month() -> None:
+    """A FEDFUNDS print doesn't appear in the frame until after its real release date.
+
+    Direct regression test for the look-ahead bug: FRED indexes FEDFUNDS by
+    reference date, not publication date, so a naive frame would show the
+    2021-06-01 print in the June row. The real publication lag (32 days) pushes
+    it to the July row instead.
+    """
+    provider = _PointInTimeStubProvider()
+    frame = build_macro_feature_frame(provider, start="2019-01-01")
+
+    assert frame.loc["2021-06-30", "fed_funds"] != pytest.approx(99.0)
+    assert frame.loc["2021-07-31", "fed_funds"] == pytest.approx(99.0)
+
+
+def test_build_macro_feature_frame_is_deterministic_across_call_sites() -> None:
+    """Two calls against the same provider and start date produce identical frames.
+
+    Regression test for the pre-fix design where RegimeClassifier's fit path
+    (fit_on_history) and predict path (analyze) built features through two
+    independent code paths with nothing asserting they agreed. Both now
+    delegate to this single function (see agents/macro.py), so this pins down
+    that it is a pure function of (provider, start) with no hidden state.
+    """
+    provider = _PointInTimeStubProvider()
+
+    train_frame = build_macro_feature_frame(provider, start="2019-01-01")
+    serve_frame = build_macro_feature_frame(provider, start="2019-01-01")
+
+    pd.testing.assert_frame_equal(train_frame, serve_frame)


### PR DESCRIPTION
## Summary
- `RegimeClassifier.fit` now tries `MACRO.hmm_n_init` (20) random restarts and rejects any that fall below the Mahalanobis state-separation floor or the per-state occupancy floor, raising if every restart is degenerate — a single fixed seed was previously trusted, and 3 of 5 seeds collapse two states on this data.
- `_map_states` labels CONTRACTION by NBER (USREC) recession-frequency enrichment (≥2.0x over the sample base rate) instead of a VIX-percentile heuristic that always assigned CONTRACTION to *some* state regardless of whether a contractionary state existed; EXPANSION is the remaining state with the lowest `d_unemp_12m`.
- New `RegimeClassifier.validation_failures()` checks separation, occupancy, dwell time (3–120 months), CONTRACTION enrichment, and a 5-scenario discrimination smoke test; all metrics are persisted into the artifact's metadata.
- `scripts/train_macro_hmm.py` now hard-fails (no artifact written) when the gate doesn't pass, and its `--start-date` default changes to `1990-01-01` to match the documented training window.
- New/updated tests: window-length invariance, discrimination, CONTRACTION reachable from a single observation, degeneracy rejection, validation-gate checks, plus a new `tests/test_macro_features.py` covering point-in-time publication-lag shifting and train/serve frame parity.

Covers Stages 3–5 of #10. Stages 1–2 landed in #11; Stage 6 (retrain + ChromaDB remediation) is intentionally out of scope here — the shipped `argus/models/macro_hmm.joblib` still needs a retrain against this gate before it reflects these changes.

## Test plan
- [x] `.venv/bin/pytest tests/test_macro.py tests/test_macro_features.py -v`
- [x] `.venv/bin/pytest` (full suite, 177 passed)
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/mypy argus`