### PR TITLE
fix: record node degradation in graph state

### DIFF
--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -272,7 +272,11 @@ class FundamentalAgent:
         self.cache = FundamentalCache()
 
     def analyze(
-        self, ticker: str, backtest_mode: bool = False, session_seed: Optional[int] = None
+        self,
+        ticker: str,
+        backtest_mode: bool = False,
+        session_seed: Optional[int] = None,
+        errors: Optional[list[str]] = None,
     ) -> Optional[FundamentalSignal]:
         """Audits fundamentals for a single ticker and returns a validated Pydantic signal.
 
@@ -284,6 +288,9 @@ class FundamentalAgent:
             backtest_mode: When True, anonymizes the ticker to prevent LLM parametric recall.
             session_seed: Integer date seed for deterministic anonymization; required when
                 backtest_mode is True.
+            errors: If given, a reason is appended here on every path that
+                returns None, so callers can surface the failure instead of
+                only logging it.
 
         Returns:
             A validated FundamentalSignal, or None if all attempts fail.
@@ -298,12 +305,16 @@ class FundamentalAgent:
             logger.warning(
                 "[Fundamental] Low capacity for llama-3.3-70b-versatile, skipping %s", ticker
             )
+            if errors is not None:
+                errors.append(f"fundamental_analysis[{ticker}]: governor capacity too low, skipped")
             return None
 
         try:
             fundamentals = self.market_data.fundamentals(ticker)
         except Exception as e:
             logger.warning("[Fundamental] Failed to fetch fundamentals for %s: %s", ticker, e)
+            if errors is not None:
+                errors.append(f"fundamental_analysis[{ticker}]: failed to fetch fundamentals: {e}")
             return None
 
         pit_data: dict[str, Any] = {
@@ -359,6 +370,10 @@ class FundamentalAgent:
                     "[Fundamental] Attempt %d parse error for %s: %s", attempt + 1, ticker, e
                 )
                 if attempt == 2:
+                    if errors is not None:
+                        errors.append(
+                            f"fundamental_analysis[{ticker}]: parse error after 3 attempts: {e}"
+                        )
                     return None
                 time.sleep(2**attempt)
             except Exception as e:
@@ -366,6 +381,10 @@ class FundamentalAgent:
                     "[Fundamental] Attempt %d API error for %s: %s", attempt + 1, ticker, e
                 )
                 if attempt == 2:
+                    if errors is not None:
+                        errors.append(
+                            f"fundamental_analysis[{ticker}]: API error after 3 attempts: {e}"
+                        )
                     return None
                 time.sleep(2**attempt)
 
@@ -373,7 +392,7 @@ class FundamentalAgent:
 
     def batch_analyze(
         self, tickers: list[str], backtest_mode: bool = False, session_seed: Optional[int] = None
-    ) -> dict[str, FundamentalSignal]:
+    ) -> tuple[dict[str, FundamentalSignal], list[str]]:
         """Performs fundamental evaluations sequentially across a set of tickers.
 
         Args:
@@ -382,11 +401,14 @@ class FundamentalAgent:
             session_seed: Passed through to each ``analyze`` call for anonymization.
 
         Returns:
-            Mapping of ticker → FundamentalSignal for each successfully analyzed ticker.
+            Tuple of (signals, errors). ``signals`` maps ticker → FundamentalSignal
+            for each successfully analyzed ticker. ``errors`` names each ticker
+            omitted and why.
         """
         results = {}
+        errors: list[str] = []
         for ticker in tickers:
-            res = self.analyze(ticker, backtest_mode, session_seed)
+            res = self.analyze(ticker, backtest_mode, session_seed, errors=errors)
             if res is not None:
                 results[ticker] = res
-        return results
+        return results, errors

--- a/argus/agents/sentiment.py
+++ b/argus/agents/sentiment.py
@@ -361,12 +361,20 @@ class SentimentAgent:
         self.market_data = market_data or LiveMarketDataProvider()
         self.cache = SentimentDailyCache()
 
-    def analyze(self, ticker: str, company_name: Optional[str] = None) -> Optional[SentimentSignal]:
+    def analyze(
+        self,
+        ticker: str,
+        company_name: Optional[str] = None,
+        errors: Optional[list[str]] = None,
+    ) -> Optional[SentimentSignal]:
         """Generates a SentimentSignal for a single ticker using FinBERT + LLM synthesis.
 
         Args:
             ticker: Equity ticker symbol.
             company_name: Optional display name used in news queries (defaults to ticker).
+            errors: If given, a reason is appended here on every path that
+                returns None, so callers can surface the failure instead of
+                only logging it.
 
         Returns:
             A validated SentimentSignal, or None if all retry attempts fail.
@@ -439,17 +447,23 @@ class SentimentAgent:
             except (json.JSONDecodeError, ValidationError) as e:
                 logger.warning("[Sentiment] Attempt %d parse error: %s", attempt + 1, e)
                 if attempt == 2:
+                    if errors is not None:
+                        errors.append(
+                            f"sentiment_analysis[{ticker}]: parse error after 3 attempts: {e}"
+                        )
                     return None
                 time.sleep(2**attempt)
             except Exception as e:
                 logger.warning("[Sentiment] Attempt %d failed: %s", attempt + 1, e)
                 if attempt == 2:
+                    if errors is not None:
+                        errors.append(f"sentiment_analysis[{ticker}]: failed after 3 attempts: {e}")
                     return None
                 time.sleep(2**attempt)
 
         return None
 
-    def batch_analyze(self, tickers: list[str]) -> dict[str, SentimentSignal]:
+    def batch_analyze(self, tickers: list[str]) -> tuple[dict[str, SentimentSignal], list[str]]:
         """Generates SentimentSignals sequentially for a list of tickers.
 
         Against a live market-data provider, paces each ticker's scraper calls
@@ -465,15 +479,17 @@ class SentimentAgent:
             tickers: List of equity ticker symbols.
 
         Returns:
-            Mapping of ticker → SentimentSignal for each successfully analyzed ticker.
-            Failed tickers are omitted silently (already logged inside analyze).
+            Tuple of (signals, errors). ``signals`` maps ticker → SentimentSignal
+            for each successfully analyzed ticker. ``errors`` names each ticker
+            omitted and why.
         """
         pace = isinstance(self.market_data, LiveMarketDataProvider)
         results = {}
+        errors: list[str] = []
         for i, ticker in enumerate(tickers):
             if pace and i > 0:
                 time.sleep(_FANOUT_PACE_SECONDS_PER_TICKER)
-            res = self.analyze(ticker)
+            res = self.analyze(ticker, errors=errors)
             if res is not None:
                 results[ticker] = res
-        return results
+        return results, errors

--- a/argus/agents/technical.py
+++ b/argus/agents/technical.py
@@ -342,7 +342,9 @@ class TechnicalStatisticalAgent:
             timestamp=datetime.now(),
         )
 
-    def batch_analyze(self, session_states: dict[str, dict]) -> dict[str, TechnicalSignal]:
+    def batch_analyze(
+        self, session_states: dict[str, dict]
+    ) -> tuple[dict[str, TechnicalSignal], list[str]]:
         """Evaluates technical indicators sequentially across a set of tickers.
 
         Tickers that return None from analyze() (missing required fields) or raise
@@ -352,15 +354,19 @@ class TechnicalStatisticalAgent:
             session_states: Mapping of ticker → session state dict.
 
         Returns:
-            Mapping of ticker → TechnicalSignal for each successfully analyzed ticker.
-            Tickers with missing data or errors are omitted and logged as warnings.
+            Tuple of (signals, errors). ``signals`` maps ticker → TechnicalSignal
+            for each successfully analyzed ticker. ``errors`` names each ticker
+            omitted for missing data or a raised exception.
         """
         results: dict[str, TechnicalSignal] = {}
+        errors: list[str] = []
         for ticker, state in session_states.items():
             try:
                 signal = self.analyze(ticker, state)
                 if signal is not None:
                     results[ticker] = signal
+                else:
+                    errors.append(f"technical_analysis[{ticker}]: missing required indicator fields")
             except Exception as exc:
                 logger.warning(
                     "batch_analyze: %s failed — %s: %s",
@@ -368,9 +374,10 @@ class TechnicalStatisticalAgent:
                     type(exc).__name__,
                     exc,
                 )
+                errors.append(f"technical_analysis[{ticker}]: {type(exc).__name__}: {exc}")
         logger.debug(
             "batch_analyze: %d/%d tickers produced valid signals",
             len(results),
             len(session_states),
         )
-        return results
+        return results, errors

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -165,7 +165,10 @@ def build_graph(
                 "node_macro_analysis: MacroStatisticalAgent returned None (FRED data unavailable). "
                 "Routing to END — no downstream agents will run this session."
             )
-            return {"macro_context": None}
+            return {
+                "macro_context": None,
+                "errors": ["macro_analysis: MacroStatisticalAgent returned None (FRED data unavailable)"],
+            }
         return {"macro_context": macro_ctx}
 
     def node_technical_analysis(state: ARGUSState) -> dict:
@@ -178,8 +181,8 @@ def build_graph(
             Partial state update with ``technical_signals``.
         """
         session_states = state.get("session_states", {})
-        signals = tech_agent.batch_analyze(session_states)
-        return {"technical_signals": signals}
+        signals, errors = tech_agent.batch_analyze(session_states)
+        return {"technical_signals": signals, "errors": errors}
 
     def node_fundamental_analysis(state: ARGUSState) -> dict:
         """Audits corporate health metrics and qualitative economic moat vectors.
@@ -190,12 +193,12 @@ def build_graph(
         Returns:
             Partial state update with ``fundamental_signals``.
         """
-        signals = fund_agent.batch_analyze(
+        signals, errors = fund_agent.batch_analyze(
             state["universe"],
             backtest_mode=state.get("backtest_mode", False),
             session_seed=state.get("session_seed"),
         )
-        return {"fundamental_signals": signals}
+        return {"fundamental_signals": signals, "errors": errors}
 
     def node_sentiment_analysis(state: ARGUSState) -> dict:
         """Scores news articles and social media sentiment signals.
@@ -206,8 +209,8 @@ def build_graph(
         Returns:
             Partial state update with ``sentiment_signals``.
         """
-        signals = sent_agent.batch_analyze(state["universe"])
-        return {"sentiment_signals": signals}
+        signals, errors = sent_agent.batch_analyze(state["universe"])
+        return {"sentiment_signals": signals, "errors": errors}
 
     def node_retrieve_cultural_memory(state: ARGUSState) -> dict:
         """Retrieves semantic trading wisdom and historical trade patterns matching the current regime.
@@ -375,7 +378,7 @@ def build_graph(
 
         macro = state.get("macro_context")
         if not macro:
-            return {}
+            return {"errors": ["portfolio_allocation: skipped, no macro_context in state"]}
 
         mem = state.get("cultural_memory", {})
         wisdom = mem.get("wisdom", [])
@@ -387,7 +390,11 @@ def build_graph(
                 "node_portfolio_allocation: PortfolioManagerAgent returned None (LLM API failure). "
                 "Skipping portfolio_allocation to allow graceful exit."
             )
-            return {}
+            return {
+                "errors": [
+                    "portfolio_allocation: PortfolioManagerAgent returned None (LLM API failure)"
+                ]
+            }
         return {"portfolio_allocation": alloc}
 
     def route_after_macro(state: ARGUSState):

--- a/argus/orchestration/state.py
+++ b/argus/orchestration/state.py
@@ -14,7 +14,8 @@ Not responsible for:
 
 from __future__ import annotations
 
-from typing import Any, Optional, TypedDict
+import operator
+from typing import Annotated, Any, Optional, TypedDict
 
 import pandas as pd
 
@@ -96,9 +97,16 @@ class ARGUSState(TypedDict):
 
     # ── Node 7: log_decisions ────────────────────────────────────────────────
     decisions: list[Any]
-    """List of completed ARGUSDecision snapshots for this session, accumulated
-    into the LangGraph checkpoint (argus_graph.db) and readable later by
-    orchestration/reconciliation.py's load_decisions_from_checkpoints()."""
+    """List of completed ARGUSDecision snapshots for this session, written once
+    by log_decisions and persisted into the LangGraph checkpoint
+    (argus_graph.db). Single writer, no reducer: readable later by
+    orchestration/reconciliation.py's load_decisions_from_checkpoints(), which
+    keeps each thread's own checkpointed list rather than expecting one to
+    accumulate across nodes."""
 
-    errors: list[str]
-    """Accumulated error messages from all nodes, used for diagnostics and alerting."""
+    errors: Annotated[list[str], operator.add]
+    """Accumulated error messages from all nodes, used for diagnostics and
+    alerting. Needs the operator.add reducer: technical_analysis,
+    fundamental_analysis, sentiment_analysis, and retrieve_cultural_memory
+    write this key concurrently in the macro_analysis fan-out, and LangGraph
+    raises InvalidUpdateError on concurrent writes to a key without one."""

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -175,10 +175,44 @@ def test_golden_dag_runs_offline_and_produces_a_valid_allocation():
     assert final_state.get("sentiment_signals")
     assert final_state.get("risk_assessments")
     assert final_state.get("aggregated_signals")
+    assert final_state.get("errors") == []
 
     alloc = final_state.get("portfolio_allocation")
     assert alloc is not None
     assert len(alloc.portfolio) == len(UNIVERSE)
+
+
+def test_missing_indicator_is_reported_in_errors_not_silently_dropped():
+    """A ticker missing a required indicator is excluded from technical_signals
+
+    and named in state["errors"], rather than vanishing with no trace.
+    """
+    with open(FIXTURES_DIR / "market_data" / "session_states.json") as f:
+        session_states = json.load(f)
+    del session_states["NVDA"]["adx_14"]
+
+    state = _initial_state()
+    state["session_states"] = session_states
+
+    graph = build_graph(
+        market_data=FixtureMarketDataProvider(),
+        fundamental_llm=_per_ticker_llm("fundamental.json"),
+        sentiment_llm=_per_ticker_llm("sentiment.json"),
+        portfolio_llm=_portfolio_llm(),
+    )
+    config = {"configurable": {"thread_id": str(uuid4())}}
+
+    with mock.patch("argus.orchestration.graph.get_cultural_memory") as mock_get_cultural_memory:
+        mock_get_cultural_memory.return_value = mock.Mock(
+            retrieve_wisdom=mock.Mock(return_value=[]),
+            retrieve_warnings=mock.Mock(return_value=[]),
+            get_agent_accuracy=mock.Mock(return_value=0.5),
+            store_decision_snapshot=mock.Mock(),
+        )
+        final_state = graph.invoke(state, config)
+
+    assert "NVDA" not in final_state["technical_signals"]
+    assert any("NVDA" in e for e in final_state["errors"])
 
 
 def test_golden_dag_output_is_stable_across_runs():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -110,13 +110,14 @@ class TestEndToEnd:
             store_decision_snapshot=mock.Mock(),
         )
 
-        def fund_side_effect(ticker, backtest_mode=False, session_seed=None):
+        def fund_side_effect(ticker, backtest_mode=False, session_seed=None, errors=None):
             """Stand in for FundamentalAgent.analyze, matching its real signature.
 
             Args:
                 ticker: Ticker to build a signal for.
                 backtest_mode: Unused; accepted to match the real signature.
                 session_seed: Unused; accepted to match the real signature.
+                errors: Unused; accepted to match the real signature.
 
             Returns:
                 A fixed BULLISH FundamentalSignal for the given ticker.

--- a/tests/test_technical.py
+++ b/tests/test_technical.py
@@ -86,3 +86,25 @@ def test_zero_api_calls(agent: TechnicalStatisticalAgent) -> None:
     }
     result = agent.analyze("TEST", session_state)
     assert result.api_calls_used == 0
+
+
+def test_batch_analyze_reports_dropped_tickers_in_errors(agent: TechnicalStatisticalAgent) -> None:
+    """A ticker missing a required indicator is omitted from signals and named in errors."""
+    complete_state = {
+        "rsi_14": 50.0,
+        "macd_histogram": 0.0,
+        "bb_percent_b": 0.5,
+        "adx_14": 20.0,
+        "vwap_distance": 0.0,
+        "volume_ratio": 1.0,
+        "momentum_30m": 0.0,
+        "momentum_1d": 0.0,
+        "close": 100.0,
+    }
+    incomplete_state = {k: v for k, v in complete_state.items() if k != "adx_14"}
+
+    signals, errors = agent.batch_analyze({"GOOD": complete_state, "BAD": incomplete_state})
+
+    assert "GOOD" in signals
+    assert "BAD" not in signals
+    assert any("BAD" in e for e in errors)


### PR DESCRIPTION
## Summary
- `state["errors"]` had no writer and no reducer, so every degraded path (FRED-unavailable macro, tickers dropped by a specialist agent, failed portfolio LLM call) vanished silently instead of surfacing anywhere.
- Adds an `operator.add` reducer to `errors` (required now that technical/fundamental/sentiment/retrieve_cultural_memory write it concurrently in the macro fan-out) and has every node, plus each agent's `batch_analyze`, report what it dropped and why.
- Corrects the `decisions` field docstring, which claimed accumulation it doesn't have (single writer, intentionally no reducer).

This is PR 1 of the plan in #15 (fixes X2, X6) — it's the prerequisite for verifying PRs 2–7, since it's what makes downstream degradation visible.

## Test plan
- [x] `.venv/bin/pytest` — 179 passed
- [x] `.venv/bin/ruff check` on touched files — clean
- [x] New regression test: deleting NVDA's `adx_14` from the fixture DAG excludes it from `technical_signals` and names it in `final_state["errors"]` (previously `[]`)
- [x] New unit test: `TechnicalStatisticalAgent.batch_analyze` reports dropped tickers in its errors list