### PR TITLE
fix: stop fabricating uncomputable technical indicators

### DIFF
--- a/argus/agents/technical.py
+++ b/argus/agents/technical.py
@@ -40,6 +40,8 @@ _REQUIRED_INDICATOR_KEYS: frozenset[str] = frozenset({
     "bb_percent_b",
     "adx_14",
     "vwap_distance",
+    "volume_ratio",
+    "atr_pct",
     "momentum_30m",
     "momentum_1d",
     "close",
@@ -208,17 +210,18 @@ class TechnicalStatisticalAgent:
     def analyze(self, ticker: str, session_state: dict) -> Optional[TechnicalSignal]:
         """Analyzes a single ticker's session state parameters to generate a TechnicalSignal.
 
-        Returns None if any required indicator key is absent or None in session_state,
-        preventing signal computation from fabricated defaults.
+        Returns None if any required indicator key is absent, None, or non-finite in
+        session_state, preventing signal computation from fabricated defaults.
 
         Args:
             ticker: Equity ticker symbol (e.g. 'AAPL').
             session_state: Dict of pre-computed technical indicator values. Required keys:
                 rsi_14, macd_histogram, bb_percent_b, adx_14, vwap_distance,
-                volume_ratio, momentum_30m, momentum_1d, close.
+                volume_ratio, atr_pct, momentum_30m, momentum_1d, close.
 
         Returns:
-            A validated TechnicalSignal, or None if required fields are missing.
+            A validated TechnicalSignal, or None if required fields are missing or
+            non-finite.
         """
         missing = [
             k for k in _REQUIRED_INDICATOR_KEYS
@@ -229,6 +232,17 @@ class TechnicalStatisticalAgent:
                 "analyze[%s]: missing required indicator fields %s — skipping to avoid fake signal",
                 ticker,
                 sorted(missing),
+            )
+            return None
+
+        required_values = np.array(
+            [float(session_state[k]) for k in _REQUIRED_INDICATOR_KEYS]
+        )
+        if not np.isfinite(required_values).all():
+            logger.warning(
+                "analyze[%s]: non-finite indicator value(s) in %s — skipping to avoid fake signal",
+                ticker,
+                sorted(_REQUIRED_INDICATOR_KEYS),
             )
             return None
 

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -400,6 +400,9 @@ class MFTDataPipeline:
         Returns:
             Dict with keys: rsi_14, macd_histogram, bb_percent_b, atr_pct, adx_14,
             vwap_distance, volume_ratio, momentum_30m, momentum_1d, close, timestamp.
+            rsi_14, bb_percent_b, atr_pct, adx_14, vwap_distance, and volume_ratio
+            are None when pandas_ta cannot compute them; close and timestamp are
+            always populated.
         """
         import pandas_ta as ta  # Lazy import to avoid heavy C extension load on startup
 
@@ -407,7 +410,7 @@ class MFTDataPipeline:
 
         rsi_series = ta.rsi(ind_df["close"], length=14)
         rsi_14 = (
-            float(rsi_series.iloc[-1]) if rsi_series is not None and not rsi_series.empty else 50.0
+            float(rsi_series.iloc[-1]) if rsi_series is not None and not rsi_series.empty else None
         )
 
         macd_df = ta.macd(ind_df["close"], fast=12, slow=26, signal=9)
@@ -421,7 +424,7 @@ class MFTDataPipeline:
                 logger.warning("_compress_candles: MACD histogram column not found in %s", list(macd_df.columns))
 
         bb_df = ta.bbands(ind_df["close"], length=20, std=2)
-        bb_pct_b = 0.5
+        bb_pct_b = None
         if bb_df is not None and not bb_df.empty:
             # pandas_ta names the %B column with a 'BBP_' prefix, e.g. BBP_20_2.0
             pct_col = [c for c in bb_df.columns if c.upper().startswith("BBP_")]
@@ -435,17 +438,17 @@ class MFTDataPipeline:
         atr_pct = (
             (float(atr_series.iloc[-1]) / close_last)
             if (atr_series is not None and not atr_series.empty and close_last)
-            else 0.0
+            else None
         )
 
         adx_df = ta.adx(ind_df["high"], ind_df["low"], ind_df["close"], length=14)
-        adx_14 = 20.0
+        adx_14 = None
         if adx_df is not None and not adx_df.empty:
             adx_col = [c for c in adx_df.columns if c.upper().startswith("ADX_")]
             if adx_col:
                 adx_14 = float(adx_df[adx_col[0]].iloc[-1])
 
-        vwap_distance = 0.0
+        vwap_distance = None
         try:
             vwap_series = ta.vwap(ind_df["high"], ind_df["low"], ind_df["close"], ind_df["volume"])
             if vwap_series is not None and not vwap_series.empty:
@@ -453,7 +456,7 @@ class MFTDataPipeline:
                 if vwap_val and close_last:
                     vwap_distance = (close_last - vwap_val) / vwap_val
         except Exception:
-            # pandas_ta raises on zero-volume days; default to 0.0 (no VWAP deviation)
+            # pandas_ta raises on zero-volume days; leave unset rather than fabricate 0.0
             pass
 
         vol_series = ind_df["volume"]
@@ -462,7 +465,7 @@ class MFTDataPipeline:
             if len(vol_series) >= 20
             else float(vol_series.mean())
         )
-        volume_ratio = (float(vol_series.iloc[-1]) / vol_mean) if vol_mean else 1.0
+        volume_ratio = (float(vol_series.iloc[-1]) / vol_mean) if vol_mean else None
 
         close_s = df["close"]
         n = len(close_s)
@@ -476,13 +479,13 @@ class MFTDataPipeline:
         ) - 1.0
 
         return {
-            "rsi_14": round(rsi_14, 4),
+            "rsi_14": round(rsi_14, 4) if rsi_14 is not None else None,
             "macd_histogram": round(macd_hist, 6),
-            "bb_percent_b": round(bb_pct_b, 4),
-            "atr_pct": round(atr_pct, 6),
-            "adx_14": round(adx_14, 4),
-            "vwap_distance": round(vwap_distance, 6),
-            "volume_ratio": round(volume_ratio, 4),
+            "bb_percent_b": round(bb_pct_b, 4) if bb_pct_b is not None else None,
+            "atr_pct": round(atr_pct, 6) if atr_pct is not None else None,
+            "adx_14": round(adx_14, 4) if adx_14 is not None else None,
+            "vwap_distance": round(vwap_distance, 6) if vwap_distance is not None else None,
+            "volume_ratio": round(volume_ratio, 4) if volume_ratio is not None else None,
             "momentum_30m": round(momentum_30m, 6),
             "momentum_1d": round(momentum_1d, 6),
             "close": round(close_last, 4),

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -188,7 +188,7 @@ class TechnicalSignal(BaseModel):
     ticker: str = Field(..., description="Equity ticker symbol, e.g. 'AAPL'")
 
     current_price: float = Field(..., ge=0.0, description="Latest closing price")
-    rsi_14: float = Field(..., description="14-period RSI value [0, 100]")
+    rsi_14: float = Field(..., ge=0.0, le=100.0, description="14-period RSI value [0, 100]")
     macd_histogram: float = Field(..., description="MACD histogram value")
     bb_percent_b: float = Field(..., description="Bollinger %B [0, 1] (>1 or <0 = breach)")
     atr_pct: float = Field(..., ge=0.0, description="ATR as % of price (volatility proxy)")

--- a/tests/test_technical.py
+++ b/tests/test_technical.py
@@ -2,7 +2,11 @@
 Tests for the Technical Analysis Agent (argus/agents/technical.py).
 """
 
+import math
+
 import pytest
+from pydantic import ValidationError
+
 from argus.agents.technical import TechnicalStatisticalAgent
 from argus.schemas.signals import Signal
 
@@ -24,6 +28,7 @@ def test_bullish_signal(agent: TechnicalStatisticalAgent) -> None:
         "adx_14": 35.0,
         "vwap_distance": 0.008,
         "volume_ratio": 1.8,
+        "atr_pct": 0.02,
         "momentum_30m": 0.012,
         "momentum_1d": 0.025,
         "close": 100.0,
@@ -43,6 +48,7 @@ def test_bearish_signal(agent: TechnicalStatisticalAgent) -> None:
         "adx_14": 35.0,  # Trend strength
         "vwap_distance": -0.008,  # Opposite
         "volume_ratio": 1.8,  # High volume confirming the move
+        "atr_pct": 0.02,
         "momentum_30m": -0.012,  # Opposite
         "momentum_1d": -0.025,  # Opposite
         "close": 100.0,
@@ -62,6 +68,7 @@ def test_neutral_signal(agent: TechnicalStatisticalAgent) -> None:
         "adx_14": 15.0,  # Weak trend
         "vwap_distance": 0.0,
         "volume_ratio": 1.0,
+        "atr_pct": 0.01,
         "momentum_30m": 0.0,
         "momentum_1d": 0.0,
         "close": 100.0,
@@ -80,6 +87,7 @@ def test_zero_api_calls(agent: TechnicalStatisticalAgent) -> None:
         "adx_14": 20.0,
         "vwap_distance": 0.0,
         "volume_ratio": 1.0,
+        "atr_pct": 0.01,
         "momentum_30m": 0.0,
         "momentum_1d": 0.0,
         "close": 100.0,
@@ -97,6 +105,7 @@ def test_batch_analyze_reports_dropped_tickers_in_errors(agent: TechnicalStatist
         "adx_14": 20.0,
         "vwap_distance": 0.0,
         "volume_ratio": 1.0,
+        "atr_pct": 0.01,
         "momentum_30m": 0.0,
         "momentum_1d": 0.0,
         "close": 100.0,
@@ -108,3 +117,51 @@ def test_batch_analyze_reports_dropped_tickers_in_errors(agent: TechnicalStatist
     assert "GOOD" in signals
     assert "BAD" not in signals
     assert any("BAD" in e for e in errors)
+
+
+def _complete_state(**overrides: float) -> dict:
+    """Returns:
+        A fully-populated session state dict, overridden per-field by kwargs.
+    """
+    base = {
+        "rsi_14": 50.0,
+        "macd_histogram": 0.0,
+        "bb_percent_b": 0.5,
+        "adx_14": 20.0,
+        "vwap_distance": 0.0,
+        "volume_ratio": 1.0,
+        "atr_pct": 0.01,
+        "momentum_30m": 0.0,
+        "momentum_1d": 0.0,
+        "close": 100.0,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize("bad_rsi", [-50.0, 150.0, 1e9])
+def test_out_of_range_rsi_raises_instead_of_producing_a_signal(
+    agent: TechnicalStatisticalAgent, bad_rsi: float
+) -> None:
+    """An RSI outside [0, 100] fails TechnicalSignal validation rather than scoring."""
+    with pytest.raises(ValidationError):
+        agent.analyze("TEST", _complete_state(rsi_14=bad_rsi))
+
+
+@pytest.mark.parametrize("bad_value", [math.nan, math.inf, -math.inf])
+def test_non_finite_macd_histogram_is_rejected_at_the_missing_key_gate(
+    agent: TechnicalStatisticalAgent, bad_value: float
+) -> None:
+    """A NaN/inf MACD histogram is skipped, the same as a missing required key."""
+    result = agent.analyze("TEST", _complete_state(macd_histogram=bad_value))
+    assert result is None
+
+
+def test_absent_volume_ratio_skips_rather_than_applying_the_floor(
+    agent: TechnicalStatisticalAgent,
+) -> None:
+    """A missing volume_ratio drops the ticker instead of silently applying the 0.7 floor."""
+    state = _complete_state()
+    del state["volume_ratio"]
+    result = agent.analyze("TEST", state)
+    assert result is None


### PR DESCRIPTION
## Summary

PR 2 of the plan in #15 (fixes T2, T3, T4).

- `argus/data/pipeline.py::_compress_candles` now returns `None` per indicator pandas_ta couldn't compute (`rsi_14`, `bb_percent_b`, `atr_pct`, `adx_14`, `volume_ratio`) instead of substituting `rsi=50`, `adx=20`, `bb=0.5`, `atr=0`, `volume_ratio=1`. The VWAP `except: pass` branch now leaves the value unset instead of defaulting to `0.0`. `close` and `timestamp` stay mandatory.
- `argus/agents/technical.py` adds `volume_ratio` and `atr_pct` to `_REQUIRED_INDICATOR_KEYS`, and adds a finiteness guard (mirroring `RegimeClassifier.predict`'s `np.isfinite(arr).all()`) so a NaN/inf value is rejected at the same gate as a missing key, instead of reaching Pydantic (NaN) or surviving `np.clip` into an ordinary signal (inf).
- `argus/schemas/signals.py` bounds `rsi_14` to `[0, 100]`, matching its own docstring and sibling `adx_14`.

**Checkpoint safety:** scanned all 2,323 stored `TechnicalSignal.rsi_14` values in `argus_graph.db` read-only before adding the bound — none violate `[0, 100]` (min 49.41, max 80.03), so no migration is needed.

## Test plan

- [x] `tests/test_technical.py` extended with the audit's repro cases: `rsi_14 ∈ {-50, 150, 1e9}` raises `ValidationError` instead of producing a signal; `macd_histogram ∈ {nan, inf, -inf}` is rejected at the missing-key gate; absent `volume_ratio` skips instead of applying the 0.7 floor.
- [x] `.venv/bin/pytest` — 186 passed
- [x] `.venv/bin/ruff check .` and `.venv/bin/mypy argus api scripts` — clean
- [x] `scripts/replay_backtest.py` over `tests/fixtures/` — `final_state["errors"]` empty, all 6 tickers reach `technical_signals`