### PR TITLE
fix: gate allocation on evidence, not on the technical signal alone

### DIFF
--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -109,9 +109,10 @@ def build_signal_table(all_signals: dict[str, dict], macro: MacroContext) -> str
             stop = f"{stop:.2f}"
         else:
             stop = "N/A"
+        evidence = f"{len(agg.agents_present)}/3" if agg else "0/3"
 
         line = (
-            f"{ticker}: FUND={fsig} TECH={tsig} SENT={ssig} AGG={asig} "
+            f"{ticker}: FUND={fsig} TECH={tsig} SENT={ssig} AGG={asig} Evidence={evidence} "
             f"VaR={risk.var_99:.2%} Beta={risk.portfolio_beta:.2f} Stop={stop} Cap={risk.approved_weight:.1%}"
         )
         lines.append(line)
@@ -151,6 +152,9 @@ SYSTEM_PROMPT = (
     "  10. Before returning: verify cash_reserve_pct = 1.0 − sum(allocation_pct), "
     "      all allocation_pct values are decimals in [0.0, 0.15], "
     "      and every approved ticker is present.\n"
+    "  11. Evidence is agents_present/3 for that ticker's AGG signal. When Evidence is "
+    "      1/3, allocation_pct must not exceed half the ticker's Cap — thin evidence "
+    "      warrants a smaller position, not a skip.\n"
     "\n"
     "OUTPUT: Return ONLY a valid JSON object — no preamble, no markdown, no trailing text."
 )
@@ -260,6 +264,7 @@ class PortfolioManagerAgent:
             "<signal_table>\n"
             "Columns: FUND=fundamental_signal(conviction) TECH=technical_signal(conviction) "
             "SENT=sentiment_signal(conviction) AGG=aggregated_signal(conviction) "
+            "Evidence=agents_present/3 (specialists that actually voted into AGG) "
             "VaR=99%_VaR Beta=portfolio_beta Stop=ATR_stop_loss Cap=risk_engine_ceiling\n"
             f"{signal_table}\n"
             "</signal_table>\n"
@@ -275,7 +280,7 @@ class PortfolioManagerAgent:
             f"{warnings_text if warnings_text else 'None available.'}\n"
             "\n"
             "Step 1 — For each approved ticker: compare AGG signal against Half-Kelly anchor and Cap.\n"
-            "Step 2 — Assign allocation_pct respecting all 10 ALLOCATION RULES from the system prompt.\n"
+            "Step 2 — Assign allocation_pct respecting all 11 ALLOCATION RULES from the system prompt.\n"
             "Step 3 — Compute cash_reserve_pct = 1.0 − sum(allocation_pct). Do not set it independently.\n"
             "Step 4 — Verify: (1) all allocation_pct values are decimals in [0.0, Cap], "
             "(2) cash_reserve_pct + sum(allocation_pct) = 1.0, "

--- a/argus/orchestration/aggregator.py
+++ b/argus/orchestration/aggregator.py
@@ -98,6 +98,7 @@ class HybridSignalAggregator:
         bear_pool: float = 0.0
         neutral_pool: float = 0.0
         weighted_votes: dict[str, float] = {}
+        agents_present: list[str] = [name for name, signal in sources.items() if signal is not None]
 
         for name, signal in sources.items():
             if signal is None:
@@ -128,16 +129,18 @@ class HybridSignalAggregator:
                 signal=Signal.NEUTRAL,
                 conviction=0.0,
                 weighted_votes=weighted_votes,
+                agents_present=agents_present,
             )
 
         bull_pct = bull_pool / total
         bear_pct = bear_pool / total
         neutral_pct = neutral_pool / total
 
-        if bull_pct >= bear_pct and bull_pct >= neutral_pct:
+        # A directional call needs a strict majority; an exact tie resolves NEUTRAL
+        if bull_pct > bear_pct and bull_pct > neutral_pct:
             consensus = Signal.BULLISH
             conviction = bull_pct
-        elif bear_pct > bull_pct and bear_pct >= neutral_pct:
+        elif bear_pct > bull_pct and bear_pct > neutral_pct:
             consensus = Signal.BEARISH
             conviction = bear_pct
         else:
@@ -172,4 +175,5 @@ class HybridSignalAggregator:
             signal=consensus,
             conviction=conviction,
             weighted_votes=weighted_votes,
+            agents_present=agents_present,
         )

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -260,10 +260,10 @@ def build_graph(
 
         for ticker in state["universe"]:
             tech = state.get("technical_signals", {}).get(ticker)
-            if not tech:
-                continue
             fund = state.get("fundamental_signals", {}).get(ticker)
             sent = state.get("sentiment_signals", {}).get(ticker)
+            if tech is None and fund is None and sent is None:
+                continue
             aggs[ticker] = aggregator.aggregate(tech, macro, fund, sent, reliability=reliability)
         return {"aggregated_signals": aggs}
 

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -388,6 +388,14 @@ class AggregatedSignal(BaseModel):
             "by orchestration/reconciliation.py's leave-one-out credit assignment."
         ),
     )
+    agents_present: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Agent names that supplied a non-None signal into this aggregation. "
+            "Distinguishes an agent that was absent from one that voted zero — "
+            "weighted_votes alone cannot tell the two apart."
+        ),
+    )
 
 
 class PositionAllocation(BaseModel):

--- a/tests/test_aggregator_properties.py
+++ b/tests/test_aggregator_properties.py
@@ -138,3 +138,17 @@ def test_aggregated_conviction_never_exceeds_cap(
     )
     assert result.conviction <= AGGREGATOR.max_conviction + 1e-9
     assert 0.0 <= result.conviction
+
+
+def test_exact_tie_between_bull_and_bear_resolves_neutral():
+    """An exact bull/bear vote tie resolves NEUTRAL rather than defaulting BULLISH."""
+    aggregator = HybridSignalAggregator()
+    result = aggregator.aggregate(
+        technical=_technical(Signal.BULLISH, 0.8),
+        macro=_macro(Regime.EXPANSION, 1.0, 1.0, 1.0),
+        fundamental=_fundamental(Signal.BEARISH, 0.8),
+        sentiment=None,
+    )
+    assert result.signal == Signal.NEUTRAL
+    assert result.conviction == 0.0
+    assert result.agents_present == ["fundamental", "technical"]

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -215,6 +215,56 @@ def test_missing_indicator_is_reported_in_errors_not_silently_dropped():
     assert any("NVDA" in e for e in final_state["errors"])
 
 
+def test_missing_indicator_still_reaches_aggregation_with_evidence_surfaced():
+    """A ticker missing one specialist still reaches aggregated_signals
+
+    with the gap named in agents_present, and the allocator's prompt shows
+    the reduced evidence rather than treating the ticker as fully evidenced.
+    """
+    with open(FIXTURES_DIR / "market_data" / "session_states.json") as f:
+        session_states = json.load(f)
+    del session_states["NVDA"]["adx_14"]
+
+    state = _initial_state()
+    state["session_states"] = session_states
+
+    with open(FIXTURES_DIR / "llm_responses" / "portfolio.json") as f:
+        portfolio_response = json.load(f)
+    captured_prompts = []
+
+    def _capture_key_fn(user_prompt: str) -> str:
+        captured_prompts.append(user_prompt)
+        return "only"
+
+    portfolio_llm = FixtureLLMClient(
+        {"only": json.dumps(portfolio_response)}, key_fn=_capture_key_fn
+    )
+
+    graph = build_graph(
+        market_data=FixtureMarketDataProvider(),
+        fundamental_llm=_per_ticker_llm("fundamental.json"),
+        sentiment_llm=_per_ticker_llm("sentiment.json"),
+        portfolio_llm=portfolio_llm,
+    )
+    config = {"configurable": {"thread_id": str(uuid4())}}
+
+    with mock.patch("argus.orchestration.graph.get_cultural_memory") as mock_get_cultural_memory:
+        mock_get_cultural_memory.return_value = mock.Mock(
+            retrieve_wisdom=mock.Mock(return_value=[]),
+            retrieve_warnings=mock.Mock(return_value=[]),
+            get_agent_accuracy=mock.Mock(return_value=0.5),
+            store_decision_snapshot=mock.Mock(),
+        )
+        final_state = graph.invoke(state, config)
+
+    agg = final_state["aggregated_signals"]["NVDA"]
+    assert agg.agents_present == ["fundamental", "sentiment"]
+
+    assert len(captured_prompts) == 1
+    assert "NVDA:" in captured_prompts[0]
+    assert "Evidence=2/3" in captured_prompts[0]
+
+
 def test_golden_dag_output_is_stable_across_runs():
     """Two independent invocations of the same fixture-backed graph are byte-identical."""
     first = _run_fixture_graph()

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -35,9 +35,10 @@ class MockSignal:
         conviction: Confidence score for the signal.
     """
 
-    def __init__(self, signal, conviction):
+    def __init__(self, signal, conviction, agents_present=None):
         self.signal = signal
         self.conviction = conviction
+        self.agents_present = agents_present if agents_present is not None else []
 
 def test_build_signal_table():
     """Vetoed positions are excluded from the table; others render with their approved weight."""
@@ -66,7 +67,7 @@ def test_build_signal_table():
             "fundamental": MockSignal(Signal.BULLISH, 0.8),
             "technical": MockSignal(Signal.NEUTRAL, 0.5),
             "sentiment": MockSignal(Signal.BULLISH, 0.7),
-            "aggregated": MockSignal(Signal.BULLISH, 0.85),
+            "aggregated": MockSignal(Signal.BULLISH, 0.85, agents_present=["fundamental", "technical", "sentiment"]),
             "risk": RiskAssessment(verdict=RiskVerdict.APPROVE, proposed_weight=0.15, approved_weight=0.15, var_99=0.02, stop_loss=150.0, portfolio_beta=1.1, api_calls_used=0, timestamp=datetime.now()),
         },
         "TSLA": {
@@ -89,3 +90,5 @@ def test_build_signal_table():
     assert "FUND=BEARISH(0.90)" in table
     assert "TECH=N/A" in table # MSFT missing tech signal
     assert "Cap=5.0%" in table # MSFT reduced weight
+    assert "Evidence=3/3" in table # AAPL has all three specialists present
+    assert "Evidence=0/3" in table # MSFT has no aggregated signal


### PR DESCRIPTION
## Context

PR 3 of the issue #15 remediation plan (evidence completeness, fixes T1 and X5).

Verified defect: deleting `adx_14` from NVDA dropped it from `aggregated_signals` yet it still received an allocation (`0.075` / `$6,000`) from the portfolio LLM with `technical=None, aggregated=None` persisted — unreconcilable in both `credit_primary_driver` and `compute_realized_return`.

## Changes

- `argus/schemas/signals.py::AggregatedSignal` — new `agents_present: list[str]` field (default `[]`, existing checkpoints deserialize unchanged). `weighted_votes` already carries `0.0` for absent agents but can't distinguish "absent" from "voted zero".
- `argus/orchestration/aggregator.py` — populates `agents_present`; exact bull/bear ties now resolve NEUTRAL instead of defaulting to BULLISH (`>=` on the BULLISH branch previously won ties the BEARISH branch's strict `>` didn't).
- `argus/orchestration/graph.py::node_signal_aggregation` — dropped the `if not tech: continue` hard gate. Aggregates whenever at least one specialist is present; the aggregator already handles all-`None` correctly (`total == 0.0` → NEUTRAL at conviction 0.0).
- `argus/agents/portfolio.py::build_signal_table` — surfaces an `Evidence=N/3` column per ticker, and a new allocation rule (11) caps thin-evidence (`1/3`) tickers to half their risk-engine `Cap`. Real fundamental/sentiment evidence is still used for allocation — the gap is no longer invisible to the allocator, per the plan's Q2 decision.

## Test plan

- [x] `tests/test_aggregator_properties.py` — pinned regression: exact bull/bear tie resolves NEUTRAL, conviction 0.0, `agents_present` correct.
- [x] `tests/test_portfolio.py` — `build_signal_table` renders `Evidence=N/3` for both a fully-evidenced and a zero-evidence ticker.
- [x] `tests/test_golden_dag.py` — reproduces the NVDA repro end-to-end: missing `adx_14` still reaches `aggregated_signals` with `agents_present == ["fundamental", "sentiment"]`, and the captured portfolio-LLM prompt shows `Evidence=2/3` for NVDA.
- [x] Full suite: `.venv/bin/python -m pytest -q` — 188 passed.
- [x] `.venv/bin/python -m ruff check` clean on touched files.
- [x] `.venv/bin/python -m mypy argus api scripts` — no new errors (4 pre-existing errors in `scripts/remediate_macro_regime_tags.py` / `api/main.py`, untouched by this change).