### PR TITLE
fix: stop persisting LLM-echoed ratios as measured data

### DIFF
--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -54,6 +54,51 @@ _SECTOR_PE_MEDIANS: dict[str, float] = {
 }
 _DEFAULT_PE_MEDIAN = 20.0
 
+# Ratios fetched from market_data.fundamentals(ticker): measured data, never
+# LLM output. The LLM only ever supplies signal/conviction/moat_score/reasoning.
+_MEASURED_FUNDAMENTAL_FIELDS = (
+    "sector",
+    "industry",
+    "marketCap",
+    "pe_ttm",
+    "p_fcf",
+    "revenue_growth_yoy",
+    "operating_margin",
+    "net_margin",
+    "fcf_yield",
+    "debt_to_equity",
+    "current_ratio",
+    "roe",
+    "roic",
+)
+
+
+def _use_backtest_seed(backtest_mode: bool, session_seed: Optional[int]) -> bool:
+    """Decides whether a session should anonymize and derive as_of_date from session_seed.
+
+    Args:
+        backtest_mode: Whether the caller requested backtest anonymization.
+        session_seed: Session seed, if any. ``0`` is a legal seed — checked via
+            ``is not None``, not truthiness, since ``bool(0)`` is False.
+
+    Returns:
+        True if backtest anonymization/date-seeding should apply.
+    """
+    return backtest_mode and session_seed is not None
+
+
+def _session_seed_to_date(session_seed: int) -> date:
+    """Parses a session_seed integer date stamp into a calendar date.
+
+    Args:
+        session_seed: Integer date stamp (e.g. 20240115), as documented on
+            ``anonymize_ticker``.
+
+    Returns:
+        The corresponding calendar date.
+    """
+    return datetime.strptime(str(session_seed), "%Y%m%d").date()
+
 
 def anonymize_ticker(ticker: str, session_seed: int) -> str:
     """Generates a deterministic hash-based identifier to mask real tickers during backtesting.
@@ -195,44 +240,53 @@ class FundamentalCache:
 
     Fundamental data changes infrequently; caching avoids redundant LLM calls
     within a week-long window without meaningfully degrading signal quality.
+
+    Keyed on (ticker, session_seed) rather than ticker alone: two backtest
+    sessions replaying the same ticker on different simulated dates must not
+    serve each other's cached signal, and a live call (session_seed=None)
+    must not be conflated with either.
     """
 
     def __init__(self) -> None:
-        """Initializes an empty per-ticker cache."""
-        self._cache: dict[str, tuple[FundamentalSignal, datetime]] = {}
+        """Initializes an empty per-(ticker, session_seed) cache."""
+        self._cache: dict[tuple[str, Optional[int]], tuple[FundamentalSignal, datetime]] = {}
         self._ttl_days = 7
 
-    def get(self, ticker: str) -> Optional[FundamentalSignal]:
+    def get(self, ticker: str, session_seed: Optional[int] = None) -> Optional[FundamentalSignal]:
         """Returns a cached signal if it exists and has not exceeded the TTL.
 
         Args:
             ticker: Equity ticker symbol.
+            session_seed: Session scope the signal was cached under.
 
         Returns:
             Cached FundamentalSignal, or None if absent or expired.
         """
-        if ticker in self._cache:
-            signal, cached_at = self._cache[ticker]
+        key = (ticker, session_seed)
+        if key in self._cache:
+            signal, cached_at = self._cache[key]
             if (datetime.now() - cached_at).days < self._ttl_days:
                 return signal
         return None
 
-    def set(self, ticker: str, signal: FundamentalSignal) -> None:
+    def set(self, ticker: str, signal: FundamentalSignal, session_seed: Optional[int] = None) -> None:
         """Stores a fundamental signal coupled with the current timestamp.
 
         Args:
             ticker: Equity ticker symbol.
             signal: Validated FundamentalSignal to cache.
+            session_seed: Session scope to cache the signal under.
         """
-        self._cache[ticker] = (signal, datetime.now())
+        self._cache[(ticker, session_seed)] = (signal, datetime.now())
 
-    def is_stale(self, ticker: str) -> bool:
-        """Returns True if the ticker has no valid cached signal.
+    def is_stale(self, ticker: str, session_seed: Optional[int] = None) -> bool:
+        """Returns True if the (ticker, session_seed) has no valid cached signal.
 
         Args:
             ticker: Equity ticker symbol.
+            session_seed: Session scope to check.
         """
-        return self.get(ticker) is None
+        return self.get(ticker, session_seed) is None
 
 
 class FundamentalAgent:
@@ -295,8 +349,8 @@ class FundamentalAgent:
         Returns:
             A validated FundamentalSignal, or None if all attempts fail.
         """
-        if not self.cache.is_stale(ticker):
-            cached = self.cache.get(ticker)
+        if not self.cache.is_stale(ticker, session_seed):
+            cached = self.cache.get(ticker, session_seed)
             if cached:
                 logger.debug("FundamentalAgent.analyze: Cache hit for %s", ticker)
                 return cached
@@ -317,17 +371,30 @@ class FundamentalAgent:
                 errors.append(f"fundamental_analysis[{ticker}]: failed to fetch fundamentals: {e}")
             return None
 
+        as_of_date = date.today()
+        anon_id = None
+        if _use_backtest_seed(backtest_mode, session_seed):
+            assert session_seed is not None
+            as_of_date = _session_seed_to_date(session_seed)
+            anon_id = anonymize_ticker(ticker, session_seed)
+
         pit_data: dict[str, Any] = {
             "fundamentals": fundamentals,
-            "as_of_date": date.today().isoformat(),
+            "as_of_date": as_of_date.isoformat(),
         }
-
-        anon_id = anonymize_ticker(ticker, session_seed) if backtest_mode and session_seed else None
         prompt = build_compact_prompt(ticker, pit_data, anon_id)
 
+        last_error: Optional[str] = None
         for attempt in range(3):
             try:
-                raw = self.llm_client.complete(SYSTEM_PROMPT, prompt).strip()
+                user_prompt = prompt
+                if last_error is not None:
+                    user_prompt = (
+                        f"{prompt}\n\n"
+                        f"Your previous response was invalid: {last_error}\n"
+                        "Return a corrected JSON object satisfying the schema above."
+                    )
+                raw = self.llm_client.complete(SYSTEM_PROMPT, user_prompt).strip()
 
                 if raw.startswith("```"):
                     parts = raw.split("```")
@@ -346,20 +413,19 @@ class FundamentalAgent:
                 data["timestamp"] = datetime.now().isoformat()
                 data["api_calls_used"] = 1
 
+                # All measured ratios come from the fetched payload, never the LLM
+                # echo — the LLM only supplies signal/conviction/moat_score/reasoning.
                 f = pit_data.get("fundamentals", {})
-                data["sector"] = f.get("sector", "Unknown") or "Unknown"
-                data["industry"] = f.get("industry", "Unknown") or "Unknown"
-                data["marketCap"] = f.get("marketCap")
-                data["p_fcf"] = f.get("p_fcf")
-                data["net_margin"] = f.get("net_margin")
-                data["current_ratio"] = f.get("current_ratio")
-                data["roe"] = f.get("roe")
+                for key in _MEASURED_FUNDAMENTAL_FIELDS:
+                    data[key] = f.get(key)
+                data["sector"] = data["sector"] or "Unknown"
+                data["industry"] = data["industry"] or "Unknown"
 
                 if "reasoning" in data and isinstance(data["reasoning"], str):
                     data["reasoning"] = data["reasoning"][:400]
 
                 signal = FundamentalSignal.model_validate(data)
-                self.cache.set(ticker, signal)
+                self.cache.set(ticker, signal, session_seed)
                 logger.debug(
                     "[Fundamental] Analysis complete for %s -> %s", ticker, signal.signal.value
                 )
@@ -369,6 +435,7 @@ class FundamentalAgent:
                 logger.warning(
                     "[Fundamental] Attempt %d parse error for %s: %s", attempt + 1, ticker, e
                 )
+                last_error = str(e)
                 if attempt == 2:
                     if errors is not None:
                         errors.append(

--- a/tests/test_fundamental.py
+++ b/tests/test_fundamental.py
@@ -2,11 +2,42 @@
 Tests for the Fundamental Agent and its pure-Python helpers.
 """
 
+import json
 from datetime import datetime, timedelta
 
 
-from argus.agents.fundamental import anonymize_ticker, build_compact_prompt, FundamentalCache
+from argus.agents.fundamental import (
+    FundamentalAgent,
+    FundamentalCache,
+    _session_seed_to_date,
+    _use_backtest_seed,
+    anonymize_ticker,
+    build_compact_prompt,
+)
 from argus.schemas.signals import FundamentalSignal, Signal
+from argus.seams import FixtureLLMClient
+
+
+class _StubMarketData:
+    """Returns a fixed fundamentals payload regardless of ticker."""
+
+    def __init__(self, fundamentals: dict) -> None:
+        self._fundamentals = fundamentals
+
+    def fundamentals(self, ticker: str) -> dict:
+        return dict(self._fundamentals)
+
+
+class _RecordingLLMClient:
+    """Stub LLMClient returning a fixed response while recording the prompt it received."""
+
+    def __init__(self, response_text: str) -> None:
+        self._response_text = response_text
+        self.last_user_prompt: str | None = None
+
+    def complete(self, system_prompt: str, user_prompt: str) -> str:
+        self.last_user_prompt = user_prompt
+        return self._response_text
 
 def test_anonymize_ticker():
     """Anonymized IDs are deterministic per (ticker, seed) and vary if either input changes."""
@@ -70,6 +101,122 @@ def test_fundamental_cache():
     assert cache.get("AAPL") == signal
 
     # Backdate the entry past the 7-day TTL rather than waiting for it to expire
-    cache._cache["AAPL"] = (signal, datetime.now() - timedelta(days=8))
+    cache._cache[("AAPL", None)] = (signal, datetime.now() - timedelta(days=8))
     assert cache.is_stale("AAPL")
     assert cache.get("AAPL") is None
+
+def test_fundamental_cache_keys_on_session_seed():
+    """Two backtest sessions with different session_seed must not share a cached signal."""
+    cache = FundamentalCache()
+
+    def make_signal(reasoning: str) -> FundamentalSignal:
+        return FundamentalSignal(
+            ticker="AAPL",
+            sector="Technology",
+            industry="Consumer Electronics",
+            data_as_of_date=datetime.now().date(),
+            signal=Signal.BULLISH,
+            conviction=0.9,
+            moat_score=8,
+            reasoning=reasoning,
+            api_calls_used=0,
+            timestamp=datetime.now(),
+        )
+
+    sig_session_1 = make_signal("session 1")
+    sig_session_2 = make_signal("session 2")
+
+    cache.set("AAPL", sig_session_1, session_seed=20240101)
+    cache.set("AAPL", sig_session_2, session_seed=20240102)
+
+    assert cache.get("AAPL", session_seed=20240101) == sig_session_1
+    assert cache.get("AAPL", session_seed=20240102) == sig_session_2
+    assert cache.get("AAPL") is None
+
+def test_use_backtest_seed_treats_zero_as_a_valid_seed():
+    """session_seed=0 is a legal Optional[int] and must not be treated as falsy."""
+    assert _use_backtest_seed(True, 0) is True
+    assert _use_backtest_seed(True, None) is False
+    assert _use_backtest_seed(False, 20240101) is False
+
+def test_session_seed_to_date_parses_yyyymmdd_stamp():
+    """session_seed is an integer date stamp, e.g. 20240115 -> 2024-01-15."""
+    assert _session_seed_to_date(20240115) == datetime(2024, 1, 15).date()
+
+def test_analyze_overwrites_llm_echoed_ratios_with_measured_data():
+    """Every measured ratio in the persisted signal comes from the fetched payload, never the LLM's echo."""
+    measured = {
+        "pe_ttm": 31.5,
+        "revenue_growth_yoy": 0.02,
+        "operating_margin": 0.30,
+        "net_margin": 0.25,
+        "fcf_yield": 0.02,
+        "debt_to_equity": 0.8,
+        "current_ratio": 1.1,
+        "roe": 0.4,
+        "roic": 0.2,
+        "sector": "Technology",
+        "industry": "Consumer Electronics",
+        "marketCap": 3_000_000_000_000,
+        "p_fcf": 45.0,
+    }
+    market_data = _StubMarketData(measured)
+
+    # A wrong numeric echo: e.g. as if the model misread 31.5x/2% growth as 12x/45% growth.
+    llm_response = json.dumps(
+        {
+            "signal": "BULLISH",
+            "conviction": 0.7,
+            "pe_ttm": 12.0,
+            "revenue_growth_yoy": 0.45,
+            "operating_margin": 0.99,
+            "fcf_yield": 0.99,
+            "debt_to_equity": 0.01,
+            "roic": 0.99,
+            "moat_score": 8,
+            "reasoning": "Test",
+        }
+    )
+    llm = FixtureLLMClient({"only": llm_response}, key_fn=lambda _p: "only")
+
+    agent = FundamentalAgent(llm_client=llm, market_data=market_data)
+    signal = agent.analyze("AAPL")
+
+    assert signal is not None
+    for key, value in measured.items():
+        assert getattr(signal, key) == value
+
+def test_analyze_anonymizes_and_derives_as_of_date_from_session_seed():
+    """A seeded backtest call anonymizes the ticker and stamps data_as_of_date from session_seed, not today."""
+    market_data = _StubMarketData({"sector": "Technology", "industry": "Consumer Electronics"})
+    llm = _RecordingLLMClient(
+        json.dumps({"signal": "NEUTRAL", "conviction": 0.5, "moat_score": 5, "reasoning": "r"})
+    )
+    agent = FundamentalAgent(llm_client=llm, market_data=market_data)
+
+    signal = agent.analyze("AAPL", backtest_mode=True, session_seed=20240115)
+
+    assert signal is not None
+    assert "AAPL" not in llm.last_user_prompt
+    assert signal.data_as_of_date == _session_seed_to_date(20240115)
+
+def test_analyze_retries_with_the_prior_validation_error_in_the_prompt():
+    """A malformed first response's error is carried into the retry prompt, not silently re-sent."""
+    market_data = _StubMarketData({"sector": "Technology", "industry": "Consumer Electronics"})
+    prompts: list[str] = []
+
+    class _FlakyThenValidLLMClient:
+        def complete(self, system_prompt: str, user_prompt: str) -> str:
+            prompts.append(user_prompt)
+            if len(prompts) == 1:
+                return "not valid json"
+            return json.dumps(
+                {"signal": "NEUTRAL", "conviction": 0.5, "moat_score": 5, "reasoning": "r"}
+            )
+
+    agent = FundamentalAgent(llm_client=_FlakyThenValidLLMClient(), market_data=market_data)
+    signal = agent.analyze("AAPL")
+
+    assert signal is not None
+    assert len(prompts) == 2
+    assert "Your previous response was invalid" in prompts[1]


### PR DESCRIPTION
## Summary

Plan PR 4 of the issue #15 remediation (`gh issue view 15`). Fixes F1 (Critical), F2, F3, F4 in `argus/agents/fundamental.py`.

- **F1** — `analyze()` overwrote only 7 of the 13 measured fields from the fetched payload after the LLM call; the other 6 (`pe_ttm`, `revenue_growth_yoy`, `operating_margin`, `fcf_yield`, `debt_to_equity`, `roic`) kept whatever the LLM echoed back. All measured ratios are now overwritten from `market_data.fundamentals(ticker)`; the LLM supplies only `signal`, `conviction`, `moat_score`, `reasoning`.
- **F2** — `FundamentalCache` keyed on `ticker` alone, so two backtest sessions replaying the same ticker on different simulated dates could serve each other's cached signal. Now keyed on `(ticker, session_seed)`. `pit_data["as_of_date"]` is now derived from `session_seed` in a seeded backtest instead of always being `date.today()`.
- **F3** — the anonymization/date-seeding gate used `if backtest_mode and session_seed`, silently disabling anonymization when `session_seed=0` (a legal `Optional[int]`). Now checked via `session_seed is not None`, extracted into `_use_backtest_seed` and unit-tested directly.
- **F4** — a malformed LLM response was retried by resending an identical prompt at `temperature=0.1`, reliably reproducing the same failure for all 3 attempts. The prior `ValidationError`/`JSONDecodeError` is now carried into the retry prompt.
- `docs/limitations.md` (untracked, reference-only per `.gitignore`) gets a residual note: `market_data.fundamentals` has no point-in-time source, so a backtest's correct `as_of_date` still scores against today's ratios.

## Test plan

- [x] `tests/test_fundamental.py` — new regression tests: LLM-echoed ratios get overwritten by measured data; cache does not share entries across `session_seed`; `session_seed=0` is treated as a valid seed; a retry prompt carries the prior validation error.
- [x] Existing `test_fundamental_cache` updated for the new `(ticker, session_seed)` cache key.
- [x] Full suite: `.venv/bin/python -m pytest -q` — 194 passed.
- [x] `.venv/bin/python -m ruff check .` — clean on changed files.
- [x] `.venv/bin/python -m mypy argus api scripts` — no new errors (4 pre-existing, unrelated).