### PR TITLE
fix: correct sentiment weighting, availability, and catalyst detection

### DIFF
--- a/argus/agents/sentiment.py
+++ b/argus/agents/sentiment.py
@@ -44,6 +44,33 @@ logger = logging.getLogger("argus.sentiment")
 # actual per-ticker duration diverges enough to reintroduce burst risk.
 _FANOUT_PACE_SECONDS_PER_TICKER = 2.5
 
+# Covers config.py's default ARGUS_UNIVERSE so fetch_news's "TICKER OR company_name"
+# query has a real second term — for short tickers like "V" it otherwise becomes
+# "V OR V", which barely narrows the search versus the ticker alone. Unmapped
+# tickers fall back to the ticker itself.
+_TICKER_COMPANY_NAMES: dict[str, str] = {
+    "AAPL": "Apple",
+    "MSFT": "Microsoft",
+    "NVDA": "Nvidia",
+    "GOOGL": "Alphabet",
+    "AMZN": "Amazon",
+    "META": "Meta Platforms",
+    "TSLA": "Tesla",
+    "JPM": "JPMorgan Chase",
+    "V": "Visa",
+    "UNH": "UnitedHealth Group",
+    "XOM": "Exxon Mobil",
+    "JNJ": "Johnson & Johnson",
+    "PG": "Procter & Gamble",
+    "MA": "Mastercard",
+    "HD": "Home Depot",
+    "MRK": "Merck",
+    "ABBV": "AbbVie",
+    "LLY": "Eli Lilly",
+    "AVGO": "Broadcom",
+    "CVX": "Chevron",
+}
+
 # Module-level singleton prevents repeated model initialization (~30s first load)
 _FINBERT_PIPELINE = None
 
@@ -72,26 +99,32 @@ def get_finbert():
     return _FINBERT_PIPELINE
 
 
-def score_headlines_with_finbert(headlines: list[str]) -> list[dict]:
-    """Classifies headlines using FinBERT and returns signed numeric scores.
+def score_headlines_with_finbert(articles: list[dict]) -> list[dict]:
+    """Classifies headline articles using FinBERT and returns signed numeric scores.
 
-    Processes up to 25 headlines to bound CPU blocking time on large fetches.
-    Positive labels map to +score, negative to -score, neutral to 0.0.
+    Processes up to 25 articles, in the order given, to bound CPU blocking time
+    on large fetches. Positive labels map to +score, negative to -score, neutral
+    to 0.0.
 
     Args:
-        headlines: List of raw news headline strings.
+        articles: List of article dicts with ``title`` and ``published_at`` keys
+            (as returned by ``MarketDataProvider.news``), in relevance order —
+            the caller decides ordering before truncation.
 
     Returns:
-        List of dicts with keys ``headline``, ``label``, ``raw_score``, ``numeric``.
-        Returns an empty list if headlines is empty.
+        List of dicts with keys ``headline``, ``published_at``, ``label``,
+        ``raw_score``, ``numeric``. Returns an empty list if articles is empty.
     """
-    if not headlines:
+    if not articles:
         return []
 
     finbert = get_finbert()
     results = []
     # Cap at 25 to limit CPU blocking duration on large fetches
-    for headline in headlines[:25]:
+    for article in articles[:25]:
+        headline = article.get("title", "")
+        if not headline:
+            continue
         try:
             out = finbert(headline[:512])[0]
             if out["label"] == "positive":
@@ -104,6 +137,7 @@ def score_headlines_with_finbert(headlines: list[str]) -> list[dict]:
             results.append(
                 {
                     "headline": headline[:100],
+                    "published_at": article.get("published_at", ""),
                     "label": out["label"],
                     "raw_score": out["score"],
                     "numeric": numeric,
@@ -118,11 +152,14 @@ def aggregate_finbert_scores(scored: list[dict], decay_rate: float = 0.95) -> di
     """Aggregates FinBERT headline scores using exponential recency decay.
 
     Exponential decay prioritizes recent context over stale news; articles
-    earlier in the list are weighted less than later ones. Confidence is
-    capped at 10 articles to normalize behavior on small datasets.
+    earlier in the list are weighted less than later ones. Callers must sort
+    ``scored`` chronologically (oldest first) before calling this — the
+    decay is positional, not date-aware. Confidence is capped at 10 articles
+    to normalize behavior on small datasets.
 
     Args:
-        scored: List of scored dicts from ``score_headlines_with_finbert``.
+        scored: List of scored dicts from ``score_headlines_with_finbert``,
+            sorted oldest to newest.
         decay_rate: Decay factor applied per position from oldest to newest.
 
     Returns:
@@ -216,11 +253,11 @@ def _check_earnings_calendar(ticker: str) -> bool:
             earnings_dates = cal.loc["Earnings Date"]
             if not earnings_dates.empty:
                 dt = pd.to_datetime(earnings_dates.iloc[0])
-                if (dt.tz_localize(None) - datetime.now()).days <= 14:
+                if 0 <= (dt.tz_localize(None) - datetime.now()).days <= 14:
                     return True
         elif isinstance(cal, dict) and "Earnings Date" in cal:
             dt = pd.to_datetime(cal["Earnings Date"][0])
-            if (dt.tz_localize(None) - datetime.now()).days <= 14:
+            if 0 <= (dt.tz_localize(None) - datetime.now()).days <= 14:
                 return True
     except Exception as e:
         logger.debug("[EarningsCalendar] %s check failed: %s", ticker, e)
@@ -238,6 +275,8 @@ _SENTIMENT_METRIC_LABELS: dict[str, str] = {
     "finbert_confidence": "[0.0 to 1.0]    confidence proxy based on article volume "
     "(caps at 1.0 when ≥10 articles)",
     "news_volume_7d": "[integer]        total news articles fetched in the last 7 days",
+    "news_scored_count": "[integer]        of those, how many were actually scored by FinBERT "
+    "(<=25) — the denominator behind pct_positive/pct_negative",
     "news_data_available": "[bool]           False means the news fetch failed or hit its daily "
     "quota — news_volume_7d is a placeholder 0, not a real zero",
     "social_mention_surge": "[bool]           True if social mention volume is unusually high",
@@ -384,13 +423,25 @@ class SentimentAgent:
             if cached:
                 return cached
 
-        news = self.market_data.news(ticker, company_name or ticker, days_back=7)
-        social = self.market_data.social_sentiment(ticker)
+        try:
+            news = self.market_data.news(ticker, company_name or ticker, days_back=7)
+        except Exception as e:
+            logger.warning("[Sentiment] %s news fetch raised: %s", ticker, e)
+            news = None
+        try:
+            social = self.market_data.social_sentiment(ticker)
+        except Exception as e:
+            logger.warning("[Sentiment] %s social fetch raised: %s", ticker, e)
+            social = {"social_data_available": False}
 
         news_available = news is not None
         news_list = news or []
-        headlines = [a.get("title", "") for a in news_list if a.get("title")]
-        scored = score_headlines_with_finbert(headlines)
+        # Keep news_list in its fetched (relevance) order for the [:25] truncation,
+        # then sort the scored subset chronologically so aggregate_finbert_scores's
+        # positional decay actually favors the newest articles
+        articles = [a for a in news_list if a.get("title")]
+        scored = score_headlines_with_finbert(articles)
+        scored.sort(key=lambda s: s["published_at"] or "")
         agg = aggregate_finbert_scores(scored)
 
         metrics = {
@@ -399,6 +450,7 @@ class SentimentAgent:
             "pct_negative": agg["pct_neg"],
             "finbert_confidence": agg["confidence"],
             "news_volume_7d": len(news_list),
+            "news_scored_count": len(scored),
             "news_data_available": news_available,
             "social_mention_surge": social.get("mention_surge", False),
             "social_volume_change_pct": social.get("volume_change_pct", 0.0),
@@ -427,12 +479,17 @@ class SentimentAgent:
 
                 signal = SentimentSignal(
                     ticker=ticker,
-                    finbert_net_score=metrics["net_finbert_score"],
+                    # A failed fetch's 0.0 is indistinguishable from a real neutral
+                    # read; persist None rather than fabricate a measured score
+                    finbert_net_score=metrics["net_finbert_score"] if news_available else None,
                     pct_positive=metrics["pct_positive"],
                     pct_negative=metrics["pct_negative"],
                     news_volume_7d=metrics["news_volume_7d"],
+                    news_scored_count=metrics["news_scored_count"],
+                    news_data_available=metrics["news_data_available"],
                     social_volume_change_pct=metrics["social_volume_change_pct"],
                     social_mention_surge=metrics["social_mention_surge"],
+                    social_data_available=metrics["social_data_available"],
                     upcoming_catalyst=metrics["upcoming_catalyst"],
                     signal=data["signal"],
                     conviction=float(data["conviction"]),
@@ -475,6 +532,9 @@ class SentimentAgent:
         cutting 429 risk on the scrapers. Fixture-backed providers skip pacing:
         there's no live burst to smooth, and it would only slow down tests.
 
+        Looks up each ticker's company name (see ``_TICKER_COMPANY_NAMES``) so the
+        news query isn't just the ticker duplicated against itself.
+
         Args:
             tickers: List of equity ticker symbols.
 
@@ -489,7 +549,15 @@ class SentimentAgent:
         for i, ticker in enumerate(tickers):
             if pace and i > 0:
                 time.sleep(_FANOUT_PACE_SECONDS_PER_TICKER)
-            res = self.analyze(ticker, errors=errors)
+            company_name = _TICKER_COMPANY_NAMES.get(ticker, ticker)
+            try:
+                res = self.analyze(ticker, company_name=company_name, errors=errors)
+            except Exception as exc:
+                logger.warning(
+                    "batch_analyze: %s failed — %s: %s", ticker, type(exc).__name__, exc
+                )
+                errors.append(f"sentiment_analysis[{ticker}]: {type(exc).__name__}: {exc}")
+                continue
             if res is not None:
                 results[ticker] = res
         return results, errors

--- a/argus/memory/cultural.py
+++ b/argus/memory/cultural.py
@@ -110,9 +110,7 @@ class CulturalMemoryManager:
         fund_sig = decision.fundamental.signal.value if decision.fundamental else "N/A"
         fund_moat = decision.fundamental.moat_score if decision.fundamental else "N/A"
         sent_sig = decision.sentiment.signal.value if decision.sentiment else "N/A"
-        sent_finbert = (
-            getattr(decision.sentiment, "finbert_net_score", 0.0) if decision.sentiment else "N/A"
-        )
+        sent_finbert = decision.sentiment.finbert_net_score if decision.sentiment else None
         agg_conv = decision.aggregated.conviction if decision.aggregated else "N/A"
 
         document = f"""{prefix} PATTERN:
@@ -123,7 +121,7 @@ Technical signal: {tech_sig}
 Fundamental signal: {fund_sig}
   (Moat={fund_moat})
 Sentiment signal: {sent_sig}
-  (FinBERT={sent_finbert if isinstance(sent_finbert, str) else f"{sent_finbert:.2f}"})
+  (FinBERT={"N/A" if sent_finbert is None else f"{sent_finbert:.2f}"})
 Aggregated conviction: {agg_conv}
 Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_reason}"""
 

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -23,7 +23,7 @@ import uuid
 import warnings
 from datetime import date, datetime
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 from pydantic import (
     BaseModel,
@@ -270,8 +270,11 @@ class SentimentSignal(BaseModel):
 
     ticker: str = Field(..., description="Equity ticker symbol")
 
-    finbert_net_score: float = Field(
-        ..., ge=-1.0, le=1.0, description="FinBERT weighted net score [-1, +1]"
+    finbert_net_score: Optional[float] = Field(
+        None,
+        ge=-1.0,
+        le=1.0,
+        description="FinBERT weighted net score [-1, +1]; None if the news fetch failed",
     )
     pct_positive: float = Field(
         ..., ge=0.0, le=1.0, description="Fraction of articles scored positive"
@@ -282,9 +285,22 @@ class SentimentSignal(BaseModel):
     news_volume_7d: int = Field(
         ..., ge=0, description="Total news articles ingested (7-day window)"
     )
+    news_scored_count: int = Field(
+        0,
+        ge=0,
+        description="Articles actually scored by FinBERT (<=25, after per-headline "
+        "failures) — the denominator behind pct_positive/pct_negative. 0 for signals "
+        "persisted before this field existed.",
+    )
+    news_data_available: bool = Field(
+        True, description="False means the news fetch failed; news metrics are placeholders"
+    )
     social_volume_change_pct: float = Field(..., description="Change in social volume (%)")
     social_mention_surge: bool = Field(
         ..., description="True if social mentions > 2× 30-day average"
+    )
+    social_data_available: bool = Field(
+        True, description="False means the social fetch failed; social metrics are placeholders"
     )
     upcoming_catalyst: bool = Field(..., description="True if earnings / FDA / FOMC within 14 days")
 

--- a/argus/seams.py
+++ b/argus/seams.py
@@ -180,8 +180,15 @@ class FixtureMarketDataProvider:
         return list(self._load("news").get(ticker, []))
 
     def social_sentiment(self, ticker: str) -> dict:
-        """Returns cached social sentiment metrics from the social_sentiment fixture."""
-        return dict(self._load("social_sentiment").get(ticker, {}))
+        """Returns cached social sentiment metrics from the social_sentiment fixture.
+
+        A ticker absent from the fixture reports unavailability rather than an
+        empty dict, which would otherwise default to social_data_available=True.
+        """
+        fixture = self._load("social_sentiment").get(ticker)
+        if fixture is None:
+            return {"social_data_available": False}
+        return dict(fixture)
 
     def vix(self) -> float:
         """Returns the cached VIX level from the macro_bundle fixture."""

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -5,7 +5,12 @@ Tests for the Sentiment Agent and its pure-Python helpers.
 from datetime import datetime, timedelta
 
 
-from argus.agents.sentiment import SentimentAgent, aggregate_finbert_scores, SentimentDailyCache
+from argus.agents.sentiment import (
+    SentimentAgent,
+    aggregate_finbert_scores,
+    SentimentDailyCache,
+    _check_earnings_calendar,
+)
 from argus.schemas.signals import SentimentSignal, Signal
 
 def test_aggregate_finbert_scores_empty():
@@ -14,12 +19,17 @@ def test_aggregate_finbert_scores_empty():
     assert res == {"net": 0.0, "pct_pos": 0.0, "pct_neg": 0.0, "confidence": 0.3}
 
 def test_aggregate_finbert_scores_decay():
-    """A newer negative article outweighs an equal-magnitude older positive one."""
+    """A later-position negative article outweighs an equal-magnitude earlier positive one.
+
+    aggregate_finbert_scores itself only knows position, not real dates — callers
+    are responsible for sorting ``scored`` chronologically before calling it.
+    """
     scored = [
-        {"numeric": 1.0, "label": "positive"}, # Oldest
-        {"numeric": -1.0, "label": "negative"}, # Newest
+        {"numeric": 1.0, "label": "positive"},  # earlier position
+        {"numeric": -1.0, "label": "negative"},  # later position
     ]
-    # decay_rate 0.95 weights oldest at 0.95^1, newest at 0.95^0, so recency wins the net score
+    # decay_rate 0.95 weights the earlier position at 0.95^1, the later at 0.95^0,
+    # so the later position wins the net score
     res = aggregate_finbert_scores(scored)
     assert res["net"] < 0.0
     assert res["pct_pos"] == 0.5
@@ -131,6 +141,12 @@ def test_analyze_flags_unavailable_news_and_social_in_the_llm_prompt(monkeypatch
 
     assert signal is not None
     assert signal.news_volume_7d == 0
+    assert signal.news_scored_count == 0
+    assert signal.news_data_available is False
+    assert signal.social_data_available is False
+    # A failed fetch's 0.0 is indistinguishable from a real neutral read;
+    # the persisted signal must not fabricate a measured score
+    assert signal.finbert_net_score is None
     assert "news_data_available: False" in llm.last_user_prompt
     assert "social_data_available: False" in llm.last_user_prompt
 
@@ -142,7 +158,16 @@ def test_analyze_reports_availability_true_with_real_data(monkeypatch):
     # pipeline; stub it out since this test only cares about the availability flags.
     monkeypatch.setattr(
         "argus.agents.sentiment.score_headlines_with_finbert",
-        lambda headlines: [{"headline": h[:100], "label": "neutral", "raw_score": 0.5, "numeric": 0.0} for h in headlines],
+        lambda articles: [
+            {
+                "headline": a["title"][:100],
+                "published_at": a.get("published_at", ""),
+                "label": "neutral",
+                "raw_score": 0.5,
+                "numeric": 0.0,
+            }
+            for a in articles
+        ],
     )
 
     market_data = _StubMarketData(
@@ -164,6 +189,10 @@ def test_analyze_reports_availability_true_with_real_data(monkeypatch):
 
     assert signal is not None
     assert signal.news_volume_7d == 1
+    assert signal.news_scored_count == 1
+    assert signal.news_data_available is True
+    assert signal.social_data_available is True
+    assert signal.finbert_net_score == 0.0
     assert "news_data_available: True" in llm.last_user_prompt
     assert "social_data_available: True" in llm.last_user_prompt
 
@@ -184,3 +213,138 @@ def test_batch_analyze_paces_only_against_a_live_market_data_provider(monkeypatc
     agent.batch_analyze(["AAPL", "MSFT", "GOOGL"])
 
     assert sleep_calls == []
+
+
+def test_scored_articles_are_sorted_by_published_at_before_aggregation(monkeypatch):
+    """Recency decay follows publish date, not NewsAPI's relevance rank.
+
+    NewsAPI is queried with sort_by="relevancy", so the fetched article order is a
+    relevance rank, not a timeline. Feeding that order straight into the
+    position-based decay would let a highly-relevant-but-stale article dominate.
+    Here the most relevant (first) article is old and negative; the least
+    relevant (last) article is new and positive. Decay must favor the new one.
+    """
+    monkeypatch.setattr("argus.agents.sentiment._check_earnings_calendar", lambda ticker: False)
+
+    def stub_score(articles):
+        polarity = {"stale bad news": -1.0, "fresh good news": 1.0}
+        return [
+            {
+                "headline": a["title"],
+                "published_at": a["published_at"],
+                "label": "negative" if polarity[a["title"]] < 0 else "positive",
+                "raw_score": 1.0,
+                "numeric": polarity[a["title"]],
+            }
+            for a in articles
+        ]
+
+    monkeypatch.setattr("argus.agents.sentiment.score_headlines_with_finbert", stub_score)
+
+    market_data = _StubMarketData(
+        # Relevance order (as NewsAPI returns it): stale/negative ranks first.
+        news=[
+            {"title": "stale bad news", "published_at": "2024-01-01T00:00:00Z"},
+            {"title": "fresh good news", "published_at": "2024-06-01T00:00:00Z"},
+        ],
+        social={"social_data_available": False},
+    )
+    llm = _RecordingLLMClient(
+        '{"signal": "NEUTRAL", "conviction": 0.3, "sentiment_decay_risk": "LOW", "reasoning": "n/a"}'
+    )
+    agent = SentimentAgent(llm_client=llm, market_data=market_data)
+
+    signal = agent.analyze("AAPL")
+
+    assert signal is not None
+    assert signal.finbert_net_score > 0.0
+
+
+def test_analyze_tolerates_a_raising_news_provider(monkeypatch):
+    """A news provider that raises mid-fetch degrades to unavailable rather than crashing."""
+    monkeypatch.setattr("argus.agents.sentiment._check_earnings_calendar", lambda ticker: False)
+
+    class _RaisingNewsMarketData(_StubMarketData):
+        def news(self, ticker, company_name, days_back=7):
+            raise RuntimeError("provider outage")
+
+    market_data = _RaisingNewsMarketData(news=None, social={"social_data_available": False})
+    llm = _RecordingLLMClient(
+        '{"signal": "NEUTRAL", "conviction": 0.3, "sentiment_decay_risk": "LOW", "reasoning": "n/a"}'
+    )
+    agent = SentimentAgent(llm_client=llm, market_data=market_data)
+
+    signal = agent.analyze("AAPL")
+
+    assert signal is not None
+    assert signal.news_data_available is False
+    assert signal.finbert_net_score is None
+
+
+def test_batch_analyze_tolerates_a_single_ticker_raising(monkeypatch):
+    """One ticker's uncaught exception must not abort the batch; the rest still complete."""
+    monkeypatch.setattr("argus.agents.sentiment._check_earnings_calendar", lambda ticker: False)
+
+    market_data = _StubMarketData(news=[], social={"social_data_available": False})
+    llm = _RecordingLLMClient(
+        '{"signal": "NEUTRAL", "conviction": 0.3, "sentiment_decay_risk": "LOW", "reasoning": "n/a"}'
+    )
+    agent = SentimentAgent(llm_client=llm, market_data=market_data)
+    original_analyze = agent.analyze
+
+    def flaky_analyze(ticker, company_name=None, errors=None):
+        if ticker == "MSFT":
+            raise RuntimeError("boom")
+        return original_analyze(ticker, company_name=company_name, errors=errors)
+
+    monkeypatch.setattr(agent, "analyze", flaky_analyze)
+
+    results, errors = agent.batch_analyze(["AAPL", "MSFT", "GOOGL"])
+
+    assert "MSFT" not in results
+    assert "AAPL" in results
+    assert "GOOGL" in results
+    assert any("MSFT" in e for e in errors)
+
+
+def test_batch_analyze_passes_company_name_for_known_tickers(monkeypatch):
+    """A short ticker like 'V' gets its full company name so the news query isn't 'V OR V'."""
+    monkeypatch.setattr("argus.agents.sentiment._check_earnings_calendar", lambda ticker: False)
+
+    received = {}
+
+    class _RecordingMarketData(_StubMarketData):
+        def news(self, ticker, company_name, days_back=7):
+            received[ticker] = company_name
+            return []
+
+    market_data = _RecordingMarketData(news=[], social={"social_data_available": False})
+    llm = _RecordingLLMClient(
+        '{"signal": "NEUTRAL", "conviction": 0.3, "sentiment_decay_risk": "LOW", "reasoning": "n/a"}'
+    )
+    agent = SentimentAgent(llm_client=llm, market_data=market_data)
+
+    agent.batch_analyze(["V", "ZZZZ"])
+
+    assert received["V"] == "Visa"
+    assert received["ZZZZ"] == "ZZZZ"  # unmapped ticker falls back to itself
+
+
+def test_check_earnings_calendar_past_date_is_not_upcoming(monkeypatch):
+    """An earnings date in the past must not report an upcoming catalyst."""
+    past_date = datetime.now() - timedelta(days=15)
+    monkeypatch.setattr(
+        "argus.agents.sentiment.fetchers.fetch_ticker_calendar",
+        lambda ticker: {"Earnings Date": [past_date]},
+    )
+    assert _check_earnings_calendar("AAPL") is False
+
+
+def test_check_earnings_calendar_future_date_within_window_is_upcoming(monkeypatch):
+    """An earnings date within the next 14 days reports an upcoming catalyst."""
+    future_date = datetime.now() + timedelta(days=5)
+    monkeypatch.setattr(
+        "argus.agents.sentiment.fetchers.fetch_ticker_calendar",
+        lambda ticker: {"Earnings Date": [future_date]},
+    )
+    assert _check_earnings_calendar("AAPL") is True


### PR DESCRIPTION
## Summary

PR 5 of the 28-defect remediation plan in #15. Fixes S1–S6, all in `sentiment_analysis`.

- **S1** — `aggregate_finbert_scores`'s recency decay was applied positionally over NewsAPI's `sort_by="relevancy"` order, so a highly-relevant-but-stale article could dominate a fresh one. Headlines are now scored in relevance order (preserving the `[:25]` truncation), then the scored list is sorted by `published_at` before aggregation so decay actually favors the newest article.
- **S2** — a failed news/social fetch persisted `finbert_net_score=0.0` / `pct_positive=0.0` etc., indistinguishable from a real neutral read. `SentimentSignal` gains `news_data_available`, `social_data_available`, and `news_scored_count` (all defaulted so existing checkpoints deserialize), and `finbert_net_score` is now `Optional[float]`, persisted as `None` rather than fabricated when the news fetch failed. Also fixes `FixtureMarketDataProvider.social_sentiment` reporting `social_data_available=True` for a ticker absent from the fixture.
- **S3** — `market_data.news`/`social_sentiment` calls are now wrapped so a raising provider degrades that ticker to "unavailable" instead of raising; `batch_analyze`'s per-ticker call is also wrapped, mirroring `TechnicalStatisticalAgent.batch_analyze`, so one ticker's failure doesn't abort the run.
- **S4** — `_check_earnings_calendar` used `delta.days <= 14` with no lower bound, so an earnings date up to 15 days in the past still reported `upcoming_catalyst=True`. Now bounded `0 <= delta.days <= 14`.
- **S5** — `batch_analyze` called `analyze(ticker)` with no `company_name`, so `fetch_news` built queries like `"V OR V"` for single-letter/short tickers. Added a ticker→company-name map covering the default `ARGUS_UNIVERSE` and threaded it through.
- **S6** — `SentimentSignal.news_scored_count` reports how many articles were actually scored (≤25, after per-headline failures), giving `pct_positive`/`pct_negative` a stated denominator alongside the full-fetch `news_volume_7d`.

`argus/memory/cultural.py`'s trade-outcome document builder is updated to handle `finbert_net_score=None` (was a hard `TypeError` on format) — a direct consequence of making the field optional; full cultural-memory work is PR 6.

## Test plan
- [x] `tests/test_sentiment.py` — rewrote the decay test (removed the misleading `# Oldest`/`# Newest` framing on the pure positional-decay unit test) and added: chronological-sort-before-aggregation, a raising news provider degrading gracefully, `batch_analyze` tolerating one raising ticker, company-name threading for short tickers, and past/future earnings-date bounds.
- [x] `.venv/bin/pytest` — 200 passed
- [x] `.venv/bin/ruff check .` — clean
- [x] `.venv/bin/mypy argus/agents/sentiment.py argus/schemas/signals.py argus/seams.py argus/memory/cultural.py` — clean