### PR TITLE
fix: correct cultural memory volatility tagging, retrieval scope, and degradation

### DIFF
--- a/argus/agents/macro.py
+++ b/argus/agents/macro.py
@@ -790,11 +790,15 @@ class MacroStatisticalAgent:
         except Exception as exc:
             logger.warning("Failed to fetch VIX history for percentile: %s", exc)
 
-        if vix_percentile < 30:
+        # Bucketed from the absolute VIX level per VixRegime's own thresholds, not
+        # vix_percentile — a low-VIX regime can still sit at a high trailing
+        # percentile (e.g. VIX 11 at its 85th percentile), and EXTREME is the
+        # governor's kill-switch zone, which only the absolute level defines
+        if vix < 15:
             vix_regime = VixRegime.LOW
-        elif vix_percentile < 60:
+        elif vix < 25:
             vix_regime = VixRegime.MEDIUM
-        elif vix_percentile < 80:
+        elif vix < 35:
             vix_regime = VixRegime.HIGH
         else:
             vix_regime = VixRegime.EXTREME

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -85,8 +85,8 @@ def build_signal_table(all_signals: dict[str, dict], macro: MacroContext) -> str
     lines = []
     lines.append(
         f"MACRO: {macro.macro_regime.value} | "
-        f"VIX {macro.vix_level:.2f} ({macro.vix_regime}) | "
-        f"{macro.sector_rotation_signal}"
+        f"VIX {macro.vix_level:.2f} ({macro.vix_regime.value}) | "
+        f"{macro.sector_rotation_signal.value}"
     )
     lines.append("")
 

--- a/argus/memory/cultural.py
+++ b/argus/memory/cultural.py
@@ -26,12 +26,18 @@ from __future__ import annotations
 
 import logging
 import os
+from datetime import datetime
 from typing import Any, Optional
 
 from argus.params import MEMORY, RECONCILIATION
 from argus.schemas.signals import ARGUSDecision, MacroContext
 
 logger = logging.getLogger("argus.cultural_memory")
+
+
+def _where(conditions: list[dict[str, Any]]) -> dict[str, Any]:
+    """Combines metadata filter conditions into a single ChromaDB ``where`` clause."""
+    return conditions[0] if len(conditions) == 1 else {"$and": conditions}
 
 
 class CulturalMemoryManager:
@@ -51,7 +57,18 @@ class CulturalMemoryManager:
         import chromadb
         from chromadb.utils import embedding_functions
 
+        # Resolved to an absolute path so a caller launching from an unexpected
+        # working directory gets a loud warning instead of a silent, empty store
+        persist_dir = os.path.abspath(persist_dir)
+        is_fresh = not os.path.isdir(persist_dir)
         os.makedirs(persist_dir, exist_ok=True)
+        if is_fresh:
+            logger.warning(
+                "[Memory] %s did not exist; created a fresh, empty cultural memory "
+                "store there. If this is unexpected, check the process's working directory.",
+                persist_dir,
+            )
+
         self.client = chromadb.PersistentClient(
             path=persist_dir,
             settings=chromadb.config.Settings(anonymized_telemetry=False),
@@ -67,6 +84,7 @@ class CulturalMemoryManager:
             embedding_function=self.ef,  # type: ignore[arg-type]  # chromadb/sentence-transformers stub mismatch
             metadata={"hnsw:space": "cosine"},
         )
+        self.persist_dir = persist_dir
         logger.info("[Memory] Cultural Memory Manager initialized at %s", persist_dir)
 
     def store_trade_outcome(
@@ -77,10 +95,14 @@ class CulturalMemoryManager:
         exit_reason: str,
         primary_driver: str,
     ) -> None:
-        """Persists successful or failed trade outcomes to index trading history patterns.
+        """Persists trade outcomes to index trading history patterns.
 
-        Excludes flat or minor return trades (|return| ≤ 1%) to prevent signal dilution
-        from low-information outcomes in the similarity index.
+        Flat or minor return trades (|return| ≤ 1%) are stored as "FLAT" rather than
+        excluded: get_agent_accuracy's win rate is P(win | stored), so dropping flat
+        trades from storage would have conditioned that rate on |return| > 1% while
+        still reporting it as a plain win rate. FLAT documents don't match either
+        retrieve_wisdom's or retrieve_warnings' outcome filter, so they only affect
+        the accuracy denominator.
 
         Args:
             decision: Completed ARGUSDecision containing all agent signals.
@@ -98,10 +120,10 @@ class CulturalMemoryManager:
         elif actual_return_pct < -RECONCILIATION.min_abs_return_for_storage:
             prefix = "FAILED"
         else:
-            return
+            prefix = "FLAT"
 
         macro_regime = decision.macro.macro_regime.value if decision.macro else "unknown"
-        vix_regime = decision.macro.vix_regime if decision.macro else "unknown"
+        vix_regime = decision.macro.vix_regime.value if decision.macro else "unknown"
         tech_sig = decision.technical.signal.value if decision.technical else "N/A"
         tech_rsi = getattr(decision.technical, "rsi_14", 0.0) if decision.technical else 0.0
         tech_macd = (
@@ -144,14 +166,30 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
         logger.info("[Memory] Stored %s trade pattern. Total: %d", prefix, self.collection.count())
 
     def retrieve_wisdom(
-        self, current_macro: MacroContext, current_technical_summary: str, n_results: int = 5
+        self,
+        current_macro: MacroContext,
+        current_technical_summary: str,
+        n_results: int = 5,
+        as_of: Optional[datetime] = None,
     ) -> list[str]:
         """Queries the vector collection to retrieve successful historic patterns similar to the current posture.
 
+        Filters on the current regime, symmetrically with retrieve_warnings — both
+        land in the same portfolio prompt, so successes shouldn't be drawn from every
+        regime while failures are confined to this one. Rows stored with
+        regime="unknown" (from scripts/remediate_macro_regime_tags.py) never match,
+        since current_macro.macro_regime is always one of Regime's three live values —
+        remediated rows are deliberately not credited to today's regime.
+
         Args:
-            current_macro: MacroContext used to construct the similarity query.
+            current_macro: MacroContext used to construct the similarity query and
+                to scope the regime filter.
             current_technical_summary: Free-text description of current technical posture.
             n_results: Maximum number of similar patterns to return.
+            as_of: When given, excludes documents stored after this timestamp. Must
+                be naive, matching the naive datetime.now() this module stores
+                (see pyproject.toml's DTZ tracking comment). None (default) applies
+                no filtering.
 
         Returns:
             List of matching document strings from the SUCCESSFUL outcome filter.
@@ -159,30 +197,38 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
         if self.collection.count() == 0:
             return []
 
-        regime_clause = (
-            f"Macro regime {current_macro.macro_regime.value}, "
-            if current_macro.macro_regime.value != "unknown"
-            else ""
-        )
-        query = f"{regime_clause}VIX {current_macro.vix_regime}, {current_technical_summary}"
+        regime = current_macro.macro_regime.value
+        query = f"Macro regime {regime}, VIX {current_macro.vix_regime.value}, {current_technical_summary}"
+
+        conditions: list[dict[str, Any]] = [{"outcome": "SUCCESSFUL"}, {"regime": regime}]
+        if as_of is not None:
+            conditions.append({"timestamp": {"$lte": as_of.isoformat()}})
 
         try:
             results = self.collection.query(
                 query_texts=[query],
                 n_results=min(n_results, self.collection.count()),
-                where={"outcome": "SUCCESSFUL"},
+                where=_where(conditions),
             )
             return results["documents"][0] if results and results["documents"] else []
         except Exception as e:
             logger.warning("[Memory] Failed to retrieve wisdom: %s", e)
             return []
 
-    def retrieve_warnings(self, current_macro: MacroContext, n_results: int = 3) -> list[str]:
+    def retrieve_warnings(
+        self,
+        current_macro: MacroContext,
+        n_results: int = 3,
+        as_of: Optional[datetime] = None,
+    ) -> list[str]:
         """Retrieves failed historic patterns within the current macro regime to serve as warnings.
 
         Args:
             current_macro: MacroContext used to scope the regime filter.
             n_results: Maximum number of warning documents to return.
+            as_of: When given, excludes documents stored after this timestamp. Must
+                be naive, matching the naive datetime.now() this module stores.
+                None (default) applies no filtering.
 
         Returns:
             List of matching document strings from the FAILED outcome filter for the current regime.
@@ -190,37 +236,47 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
         if self.collection.count() == 0:
             return []
 
+        regime = current_macro.macro_regime.value
+        conditions: list[dict[str, Any]] = [{"outcome": "FAILED"}, {"regime": regime}]
+        if as_of is not None:
+            conditions.append({"timestamp": {"$lte": as_of.isoformat()}})
+
         try:
-            query = f"Failed trades in {current_macro.macro_regime.value} regime"
-            where_clause: dict[str, Any] = (
-                {"outcome": "FAILED"}
-                if current_macro.macro_regime.value == "unknown"
-                else {
-                    "$and": [{"outcome": "FAILED"}, {"regime": current_macro.macro_regime.value}]
-                }
-            )
+            query = f"Failed trades in {regime} regime"
             results = self.collection.query(
                 query_texts=[query],
                 n_results=min(n_results, self.collection.count()),
-                where=where_clause,
+                where=_where(conditions),
             )
             return results["documents"][0] if results and results["documents"] else []
         except Exception as e:
             logger.warning("[Memory] Failed to retrieve warnings: %s", e)
             return []
 
-    def get_agent_accuracy(self, agent_name: str, regime: Optional[str] = None) -> float:
+    def get_agent_accuracy(
+        self,
+        agent_name: str,
+        regime: Optional[str] = None,
+        as_of: Optional[datetime] = None,
+    ) -> float:
         """Computes shrunk statistical win rates for trades driven primarily by a specific specialist agent.
 
         Win rate is shrunk toward the 0.5 neutral prior by
         MEMORY.accuracy_shrinkage_k pseudo-observations (wins + k*0.5) / (n + k),
         so an agent with 3 observations isn't trusted like one with 300 — it
         converges to the raw win rate as n grows and collapses to 0.5 as
-        n -> 0. Feeds orchestration/aggregator.py's reliability weighting.
+        n -> 0. Feeds orchestration/aggregator.py's reliability weighting. n
+        includes FLAT outcomes (store_trade_outcome's |return| ≤ 1% bucket) as
+        non-wins, so this is a true win rate over all stored trades, not one
+        conditioned on |return| > 1%.
 
         Args:
             agent_name: Agent identifier string (e.g. 'technical', 'fundamental', 'sentiment').
             regime: Optional regime filter (e.g. 'EXPANSION'); queries all regimes if None.
+            as_of: When given, excludes trades stored after this timestamp. Must be
+                naive, matching the naive datetime.now() this module stores. None
+                (default) applies no filtering; replay's closed-loop evaluation
+                passes it to avoid reading future outcomes.
 
         Returns:
             Shrunk win rate as a float in [0, 1]. Returns 0.5 (neutral prior) when no data exists.
@@ -229,13 +285,13 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
             return 0.5
 
         try:
-            where_clause: dict[str, Any] = {"primary_driver": agent_name.lower()}
+            conditions: list[dict[str, Any]] = [{"primary_driver": agent_name.lower()}]
             if regime:
-                where_clause = {
-                    "$and": [{"primary_driver": agent_name.lower()}, {"regime": regime}]
-                }
+                conditions.append({"regime": regime})
+            if as_of is not None:
+                conditions.append({"timestamp": {"$lte": as_of.isoformat()}})
 
-            results = self.collection.get(where=where_clause)  # type: ignore[arg-type]
+            results = self.collection.get(where=_where(conditions))  # type: ignore[arg-type]
             metadatas = results.get("metadatas", [])
             if not metadatas:
                 return 0.5
@@ -366,7 +422,9 @@ def get_cultural_memory(persist_dir: str = "./chroma_db") -> CulturalMemoryManag
 
     Args:
         persist_dir: Filesystem directory backing the ChromaDB PersistentClient,
-            used only on the first call that constructs the manager.
+            used only on the first call that constructs the manager — a later
+            call with a different persist_dir cannot reconfigure the singleton
+            and is logged rather than silently ignored.
 
     Returns:
         The process-wide CulturalMemoryManager singleton.
@@ -374,4 +432,11 @@ def get_cultural_memory(persist_dir: str = "./chroma_db") -> CulturalMemoryManag
     global _cultural_memory
     if _cultural_memory is None:
         _cultural_memory = CulturalMemoryManager(persist_dir)
+    elif os.path.abspath(persist_dir) != _cultural_memory.persist_dir:
+        logger.warning(
+            "[Memory] get_cultural_memory(persist_dir=%r) ignored; the process-wide "
+            "singleton is already initialized at %s.",
+            persist_dir,
+            _cultural_memory.persist_dir,
+        )
     return _cultural_memory

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -225,8 +225,16 @@ def build_graph(
         if not macro:
             return {"cultural_memory": {"wisdom": [], "warnings": []}}
 
-        wisdom = get_cultural_memory().retrieve_wisdom(macro, "mixed technicals")
-        warnings = get_cultural_memory().retrieve_warnings(macro)
+        try:
+            memory = get_cultural_memory()
+        except ImportError as exc:
+            # sentence-transformers/torch are an optional [models] extra; their
+            # absence degrades to the same empty result as no macro context
+            logger.warning("node_retrieve_cultural_memory: cultural memory unavailable: %s", exc)
+            return {"cultural_memory": {"wisdom": [], "warnings": []}}
+
+        wisdom = memory.retrieve_wisdom(macro, "mixed technicals")
+        warnings = memory.retrieve_warnings(macro)
 
         return {
             "cultural_memory": {
@@ -253,10 +261,17 @@ def build_graph(
         # Per-regime reliability doesn't depend on ticker, so compute it once per
         # session rather than once per ticker.
         regime = macro.macro_regime.value
-        reliability = {
-            name: get_cultural_memory().get_agent_accuracy(name, regime=regime)
-            for name in ("technical", "fundamental", "sentiment")
-        }
+        try:
+            memory = get_cultural_memory()
+            reliability = {
+                name: memory.get_agent_accuracy(name, regime=regime)
+                for name in ("technical", "fundamental", "sentiment")
+            }
+        except ImportError as exc:
+            # Same optional-dependency guard as node_retrieve_cultural_memory;
+            # degrade every agent to the 0.5 neutral prior rather than crash
+            logger.warning("node_signal_aggregation: cultural memory unavailable: %s", exc)
+            reliability = {name: 0.5 for name in ("technical", "fundamental", "sentiment")}
 
         for ticker in state["universe"]:
             tech = state.get("technical_signals", {}).get(ticker)

--- a/argus/params.py
+++ b/argus/params.py
@@ -285,8 +285,8 @@ class ReconciliationParams:
     min_abs_return_for_storage: float = p(
         0.01,
         Provenance.ARBITRARY,
-        "matches cultural.store_trade_outcome's existing |return| > 1% "
-        "storage filter; kept here so both live in one place",
+        "matches cultural.store_trade_outcome's SUCCESSFUL/FAILED/FLAT |return| "
+        "classification threshold; kept here so both live in one place",
     )
 
 

--- a/tests/test_cultural.py
+++ b/tests/test_cultural.py
@@ -1,17 +1,25 @@
 """
 tests/test_cultural.py
 
-Unit tests for CulturalMemoryManager.get_agent_accuracy's shrinkage-toward-prior
-behavior. Builds the manager via object.__new__ plus a stub .collection rather
-than the real constructor, which pulls in chromadb + sentence-transformers
-(the optional [models] extra) just to exercise arithmetic over already-stored
-metadata.
+Unit tests for CulturalMemoryManager. Builds the manager via object.__new__ plus a
+stub .collection rather than the real constructor, which pulls in chromadb +
+sentence-transformers (the optional [models] extra) just to exercise arithmetic
+and query-shaping over already-stored metadata.
 """
 
+from datetime import datetime
 from unittest import mock
 
-from argus.memory.cultural import CulturalMemoryManager
-from argus.params import MEMORY
+from argus.memory.cultural import CulturalMemoryManager, get_cultural_memory
+from argus.params import MEMORY, RECONCILIATION
+from argus.schemas.signals import (
+    ARGUSDecision,
+    MacroContext,
+    Regime,
+    SectorSignal,
+    VixRegime,
+    YieldCurve,
+)
 
 
 def _manager_with_metadatas(metadatas: list[dict]) -> CulturalMemoryManager:
@@ -20,6 +28,36 @@ def _manager_with_metadatas(metadatas: list[dict]) -> CulturalMemoryManager:
     manager.collection.count.return_value = len(metadatas)
     manager.collection.get.return_value = {"metadatas": metadatas}
     return manager
+
+
+def _manager_with_query_collection() -> CulturalMemoryManager:
+    manager = object.__new__(CulturalMemoryManager)
+    manager.collection = mock.Mock()
+    manager.collection.count.return_value = 5
+    manager.collection.query.return_value = {"documents": [["doc"]]}
+    return manager
+
+
+def _macro(regime: Regime = Regime.EXPANSION, vix_regime: VixRegime = VixRegime.MEDIUM) -> MacroContext:
+    return MacroContext(
+        fed_funds=4.0,
+        cpi_yoy=3.0,
+        unemployment=4.0,
+        t10y2y=0.1,
+        consumer_sentiment=60.0,
+        vix_level=18.0,
+        macro_regime=regime,
+        regime_confidence=0.7,
+        model_healthy=True,
+        interest_rate_trend="STABLE",
+        yield_curve_shape=YieldCurve.NORMAL,
+        vix_regime=vix_regime,
+        vix_percentile=40.0,
+        inflation_trajectory="STABLE",
+        sector_rotation_signal=SectorSignal.GROWTH_FAVORED,
+        agent_multipliers={"fundamental": 1.0, "technical": 1.0, "sentiment": 1.0},
+        timestamp=datetime.now(),
+    )
 
 
 def test_zero_observations_returns_prior():
@@ -51,3 +89,143 @@ def test_large_sample_converges_to_the_raw_win_rate():
     manager = _manager_with_metadatas(metadatas)
 
     assert abs(manager.get_agent_accuracy("technical") - 0.9) < 0.01
+
+
+def test_flat_outcomes_count_as_non_wins_in_the_denominator():
+    """A FLAT-tagged trade lowers accuracy, not vanishes from the sample.
+
+    Regression test for C7: get_agent_accuracy's win rate must be P(win | stored),
+    not P(win | |return| > 1%) — a FLAT trade must inflate n without inflating wins.
+    """
+    metadatas = [
+        {"outcome": "SUCCESSFUL", "primary_driver": "technical"},
+        {"outcome": "FLAT", "primary_driver": "technical"},
+    ]
+    manager = _manager_with_metadatas(metadatas)
+
+    accuracy = manager.get_agent_accuracy("technical")
+    k = MEMORY.accuracy_shrinkage_k
+    expected = (1 + k * 0.5) / (2 + k)
+
+    assert accuracy == expected
+
+
+def test_get_agent_accuracy_as_of_filters_on_timestamp():
+    """as_of adds a timestamp upper bound to the metadata filter, alongside regime."""
+    manager = _manager_with_metadatas([{"outcome": "SUCCESSFUL", "primary_driver": "technical"}])
+    as_of = datetime(2026, 1, 1)
+
+    manager.get_agent_accuracy("technical", regime="EXPANSION", as_of=as_of)
+
+    where = manager.collection.get.call_args.kwargs["where"]
+    assert where == {
+        "$and": [
+            {"primary_driver": "technical"},
+            {"regime": "EXPANSION"},
+            {"timestamp": {"$lte": as_of.isoformat()}},
+        ]
+    }
+
+
+def test_store_trade_outcome_persists_flat_returns_instead_of_dropping_them():
+    """A |return| <= 1% trade is stored as FLAT, not silently discarded.
+
+    Regression test for C7.
+    """
+    manager = _manager_with_metadatas([])
+    decision = ARGUSDecision(ticker="AAPL", session_timestamp=datetime.now())
+
+    manager.store_trade_outcome(
+        decision,
+        actual_return_pct=RECONCILIATION.min_abs_return_for_storage / 2,
+        holding_days=3,
+        exit_reason="time_stop",
+        primary_driver="technical",
+    )
+
+    manager.collection.upsert.assert_called_once()
+    metadata = manager.collection.upsert.call_args.kwargs["metadatas"][0]
+    assert metadata["outcome"] == "FLAT"
+
+
+def test_store_trade_outcome_writes_vix_regime_value_not_enum_repr():
+    """The stored document text uses VixRegime's .value, not its str(Enum) repr.
+
+    Regression test for C6: Python >= 3.11 includes the class name in a
+    str-Enum's default __format__, so an f-string without .value would write
+    "VixRegime.HIGH" into the document instead of "HIGH".
+    """
+    manager = _manager_with_metadatas([])
+    decision = ARGUSDecision(
+        ticker="AAPL",
+        session_timestamp=datetime.now(),
+        macro=_macro(vix_regime=VixRegime.HIGH),
+    )
+
+    manager.store_trade_outcome(
+        decision,
+        actual_return_pct=0.05,
+        holding_days=3,
+        exit_reason="target_hit",
+        primary_driver="technical",
+    )
+
+    document = manager.collection.upsert.call_args.kwargs["documents"][0]
+    assert "VIX regime: HIGH" in document
+    assert "VixRegime" not in document
+
+
+def test_retrieve_wisdom_and_retrieve_warnings_apply_a_symmetric_regime_filter():
+    """retrieve_wisdom filters on regime exactly like retrieve_warnings does.
+
+    Regression test for C5: successes shouldn't be drawn from every regime while
+    failures are confined to the current one.
+    """
+    macro = _macro(regime=Regime.CONTRACTION)
+
+    wisdom_manager = _manager_with_query_collection()
+    wisdom_manager.retrieve_wisdom(macro, "mixed technicals")
+    wisdom_where = wisdom_manager.collection.query.call_args.kwargs["where"]
+    assert wisdom_where == {"$and": [{"outcome": "SUCCESSFUL"}, {"regime": "CONTRACTION"}]}
+
+    warnings_manager = _manager_with_query_collection()
+    warnings_manager.retrieve_warnings(macro)
+    warnings_where = warnings_manager.collection.query.call_args.kwargs["where"]
+    assert warnings_where == {"$and": [{"outcome": "FAILED"}, {"regime": "CONTRACTION"}]}
+
+
+def test_retrieve_wisdom_as_of_filters_on_timestamp():
+    """as_of adds a timestamp upper bound to retrieve_wisdom's where clause."""
+    manager = _manager_with_query_collection()
+    as_of = datetime(2026, 1, 1)
+
+    manager.retrieve_wisdom(_macro(regime=Regime.EXPANSION), "mixed technicals", as_of=as_of)
+
+    where = manager.collection.query.call_args.kwargs["where"]
+    assert where == {
+        "$and": [
+            {"outcome": "SUCCESSFUL"},
+            {"regime": "EXPANSION"},
+            {"timestamp": {"$lte": as_of.isoformat()}},
+        ]
+    }
+
+
+def test_get_cultural_memory_ignores_a_later_persist_dir_and_warns(
+    monkeypatch, caplog, tmp_path
+):
+    """A second get_cultural_memory() call with a different persist_dir cannot
+
+    reconfigure the already-constructed singleton, and now logs instead of
+    silently ignoring it. Regression test for C8.
+    """
+    import argus.memory.cultural as cultural_module
+
+    fake_manager = mock.Mock(persist_dir=str(tmp_path / "first"))
+    monkeypatch.setattr(cultural_module, "_cultural_memory", fake_manager)
+
+    with caplog.at_level("WARNING", logger="argus.cultural_memory"):
+        returned = get_cultural_memory(str(tmp_path / "second"))
+
+    assert returned is fake_manager
+    assert any("ignored" in r.message for r in caplog.records)

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -265,6 +265,30 @@ def test_missing_indicator_still_reaches_aggregation_with_evidence_surfaced():
     assert "Evidence=2/3" in captured_prompts[0]
 
 
+def test_cultural_memory_import_error_degrades_instead_of_crashing_the_run():
+    """A missing sentence-transformers/torch [models] extra must not abort the session.
+
+    Regression test for C1: get_cultural_memory() raising ImportError must degrade
+    retrieve_cultural_memory to an empty result and signal_aggregation's reliability
+    lookup to the 0.5 prior, rather than crashing the whole graph run.
+    """
+    graph = build_graph(
+        market_data=FixtureMarketDataProvider(),
+        fundamental_llm=_per_ticker_llm("fundamental.json"),
+        sentiment_llm=_per_ticker_llm("sentiment.json"),
+        portfolio_llm=_portfolio_llm(),
+    )
+    config = {"configurable": {"thread_id": str(uuid4())}}
+
+    with mock.patch("argus.orchestration.graph.get_cultural_memory") as mock_get_cultural_memory:
+        mock_get_cultural_memory.side_effect = ImportError("sentence-transformers not installed")
+        final_state = graph.invoke(_initial_state(), config)
+
+    assert final_state.get("cultural_memory") == {"wisdom": [], "warnings": []}
+    assert final_state.get("portfolio_allocation") is not None
+    assert len(final_state["portfolio_allocation"].portfolio) == len(UNIVERSE)
+
+
 def test_golden_dag_output_is_stable_across_runs():
     """Two independent invocations of the same fixture-backed graph are byte-identical."""
     first = _run_fixture_graph()

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -19,7 +19,7 @@ from argus.agents.macro import (
     MacroStatisticalAgent,
     RegimeClassifier,
 )
-from argus.schemas.signals import Regime
+from argus.schemas.signals import Regime, VixRegime
 
 
 class _StubMarketData:
@@ -82,6 +82,63 @@ def test_agent_multipliers_expansion(monkeypatch: pytest.MonkeyPatch) -> None:
     assert ctx.agent_multipliers["fundamental"] == 1.3
     # VIX percentile < 50 maps to a 0.9 sentiment multiplier
     assert ctx.agent_multipliers["sentiment"] == 0.9
+
+
+class _VixLevelStubMarketData:
+    """MarketDataProvider stub with a configurable VIX level and percentile history."""
+
+    def __init__(self, vix: float, historical_closes: list[float]) -> None:
+        self._vix = vix
+        self._closes = historical_closes
+
+    def macro_bundle(self) -> dict:
+        """Returns fixed macro indicators with the configured VIX level."""
+        return {
+            "vix": self._vix,
+            "fed_funds": 2.0,
+            "t10y2y": 1.5,
+            "cpi_yoy": 2.0,
+            "unemployment": 3.5,
+        }
+
+    def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame:
+        """Returns the configured historical closes for the VIX percentile calc."""
+        return pd.DataFrame({"close": self._closes})
+
+    def fred_series(self, series_id: str, start: str = "2018-01-01") -> pd.Series:
+        """Returns a fixed series regardless of the FRED series ID or start date."""
+        return pd.Series([1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0])
+
+
+def test_vix_regime_buckets_from_level_not_percentile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """vix_regime is bucketed from the absolute VIX level, not its trailing percentile.
+
+    Regression test for C3: a low VIX level sitting at a high trailing percentile
+    must still bucket LOW, and a high VIX level at a low trailing percentile must
+    still bucket HIGH.
+    """
+    # VIX 11, at its 85th trailing percentile (17 of 20 historical closes are lower)
+    low_vix_agent = MacroStatisticalAgent(
+        market_data=_VixLevelStubMarketData(11.0, [10.0] * 17 + [50.0] * 3)
+    )
+    monkeypatch.setattr(
+        low_vix_agent.classifier, "predict", lambda current_values: (Regime.EXPANSION.value, 0.9)
+    )
+    low_vix_ctx = low_vix_agent.analyze()
+    assert low_vix_ctx.vix_percentile == pytest.approx(85.0)
+    assert low_vix_ctx.vix_regime == VixRegime.LOW
+
+    # VIX 28, at its 25th trailing percentile (5 of 20 historical closes are lower).
+    # VixRegime buckets HIGH as 25 <= VIX < 35, so 28 lands HIGH despite the low percentile.
+    high_vix_agent = MacroStatisticalAgent(
+        market_data=_VixLevelStubMarketData(28.0, [10.0] * 5 + [60.0] * 15)
+    )
+    monkeypatch.setattr(
+        high_vix_agent.classifier, "predict", lambda current_values: (Regime.EXPANSION.value, 0.9)
+    )
+    high_vix_ctx = high_vix_agent.analyze()
+    assert high_vix_ctx.vix_percentile == pytest.approx(25.0)
+    assert high_vix_ctx.vix_regime == VixRegime.HIGH
 
 
 def test_cache(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -84,7 +84,8 @@ def test_build_signal_table():
     assert "AAPL:" in table
     assert "MSFT:" in table
     assert "TSLA:" not in table
-    assert "MACRO: EXPANSION | VIX 12.50 (VixRegime.LOW) | SectorSignal.GROWTH_FAVORED" in table
+    # .value, not str(Enum) — py>=3.11 would otherwise leak the class name into the prompt
+    assert "MACRO: EXPANSION | VIX 12.50 (LOW) | GROWTH_FAVORED" in table
     assert "FUND=BULLISH(0.80)" in table
     assert "TECH=NEUTRAL(0.50)" in table
     assert "FUND=BEARISH(0.90)" in table


### PR DESCRIPTION
## Summary

PR 6 of #15's 7-PR remediation plan. Fixes C1, C2, C3, C5, C6, C7, C8 in `argus/memory/cultural.py` and their call sites.

- **C1** — `node_retrieve_cultural_memory` and `node_signal_aggregation`'s reliability lookup now guard `get_cultural_memory()` against `ImportError` (sentence-transformers/torch are an optional `[models]` extra), degrading to an empty result / the 0.5 prior instead of crashing the whole session.
- **C3** — `vix_regime` now buckets from the absolute VIX level, matching `VixRegime`'s own documented thresholds, instead of the trailing percentile.
- **C5** — `retrieve_wisdom` now applies the same regime filter as `retrieve_warnings`, rather than leaning on embedding similarity alone.
- **C6** — `VixRegime`/`SectorSignal` are written via `.value` everywhere (`cultural.py`, `portfolio.py`'s `build_signal_table`), fixing the Python ≥3.11 class-qualified `str(Enum)` leak into stored documents and the allocator prompt.
- **C7** — `store_trade_outcome` now stores flat-return trades (|return| ≤ 1%) tagged `FLAT` instead of dropping them, so `get_agent_accuracy`'s win rate is a true rate over all stored trades rather than one silently conditioned on |return| > 1%.
- **C2** — `retrieve_wisdom`, `retrieve_warnings`, and `get_agent_accuracy` take an optional `as_of` for point-in-time filtering (wired up by PR 7's replay work).
- **C8** — removed the dead query-side `macro_regime.value == "unknown"` branches (the live session's regime is never `"unknown"`; remediated rows stay excluded from regime-scoped queries, as documented in `retrieve_wisdom`'s docstring); `CulturalMemoryManager` resolves `persist_dir` to an absolute path and warns when it creates a fresh store or when a later `get_cultural_memory()` call's `persist_dir` is ignored.

No remediation script — the `chroma_db` corpus is 207 `PENDING` snapshots with no reconciled outcomes yet, per the parent issue's grounding notes.

## Test plan

- [x] `tests/test_cultural.py` — FLAT storage, `.value` document text, symmetric regime filtering, `as_of` filtering, persist_dir mismatch warning
- [x] `tests/test_macro.py` — level-based `vix_regime` bucketing (VIX 11 @ p85 → LOW, VIX 28 @ p25 → HIGH)
- [x] `tests/test_golden_dag.py` — `ImportError` from `get_cultural_memory()` degrades the run instead of crashing it
- [x] `tests/test_portfolio.py` — updated the pre-existing assertion that was pinning the `VixRegime.LOW`/`SectorSignal.GROWTH_FAVORED` leak
- [x] `.venv/bin/pytest` — 209 passed
- [x] `.venv/bin/ruff check .` — clean
- [x] `.venv/bin/mypy argus api scripts` — same 4 pre-existing errors as main, none in touched files