### PR TITLE
fix: decouple specialists from macro and correct credit assignment

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -388,6 +388,7 @@ async def analyze(req: AnalysisRequest):
         risk_tolerance=req.risk_tolerance,
         backtest_mode=False,
         session_seed=None,
+        as_of=None,
         price_history={},
         session_states=live_states,
         macro_context=None,

--- a/argus/agents/macro.py
+++ b/argus/agents/macro.py
@@ -6,7 +6,9 @@ Statistical macroeconomic regime analysis agent.
 Responsibilities:
   - Combine Federal Reserve (FRED) time series with the CBOE VIX using a Gaussian HMM
   - Classify hidden economic states (EXPANSION, CONTRACTION, TRANSITIONAL)
-  - Expose regime multipliers used by specialist agents to dynamically weight convictions
+  - Expose regime multipliers consumed once, by orchestration/aggregator.py, as a
+    per-agent vote-weight scalar during signal aggregation — never by the
+    specialist agents' own analysis, which runs independently of this agent
 
 Not responsible for:
   - Feature construction (see data/macro_features.py)

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -68,7 +68,7 @@ def half_kelly_weight(
     return float(np.clip(half_kelly, 0.0, max_position))
 
 
-def build_signal_table(all_signals: dict[str, dict], macro: MacroContext) -> str:
+def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContext]) -> str:
     """Constructs a consolidated prompt table mapping approved specialist signal values.
 
     Only includes tickers with APPROVE or REDUCE risk verdicts. Signal values are
@@ -77,17 +77,23 @@ def build_signal_table(all_signals: dict[str, dict], macro: MacroContext) -> str
 
     Args:
         all_signals: Mapping of ticker → dict of signal objects keyed by agent name.
-        macro: Current macroeconomic context used for the table header.
+        macro: Current macroeconomic context used for the table header, or None
+            when MacroStatisticalAgent's data source was unavailable this session —
+            the specialist signals in all_signals don't depend on it (see
+            orchestration/graph.py's topology).
 
     Returns:
         Newline-delimited string suitable for direct insertion into an LLM prompt.
     """
     lines = []
-    lines.append(
-        f"MACRO: {macro.macro_regime.value} | "
-        f"VIX {macro.vix_level:.2f} ({macro.vix_regime.value}) | "
-        f"{macro.sector_rotation_signal.value}"
-    )
+    if macro is not None:
+        lines.append(
+            f"MACRO: {macro.macro_regime.value} | "
+            f"VIX {macro.vix_level:.2f} ({macro.vix_regime.value}) | "
+            f"{macro.sector_rotation_signal.value}"
+        )
+    else:
+        lines.append("MACRO: unavailable this session (data source failure) — allocate on specialist signals alone")
     lines.append("")
 
     for ticker, sigs in all_signals.items():
@@ -195,7 +201,7 @@ class PortfolioManagerAgent:
         self,
         user_profile: dict,
         all_signals: dict[str, dict],
-        macro: MacroContext,
+        macro: Optional[MacroContext],
         cultural_wisdom: Optional[list[str]] = None,
         cultural_warnings: Optional[list[str]] = None,
     ) -> Optional[PortfolioAllocation]:
@@ -210,7 +216,8 @@ class PortfolioManagerAgent:
         Args:
             user_profile: Dict with keys ``total_wealth``, ``invest_pct``, ``risk_tolerance``.
             all_signals: Mapping of ticker → dict of signal objects keyed by agent name.
-            macro: Current macroeconomic context.
+            macro: Current macroeconomic context, or None when it was unavailable
+                this session — allocation proceeds on the specialist signals alone.
             cultural_wisdom: Optional list of historical wisdom strings from cultural memory.
             cultural_warnings: Optional list of failed-trade pattern strings from
                 cultural memory, scoped to the current macro regime.

--- a/argus/backtesting/replay.py
+++ b/argus/backtesting/replay.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import tempfile
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -126,20 +127,17 @@ def replay_session(
             fixture-replay candidate — so reliability weighting is fixed at
             the 0.5 prior. When True, the real `get_cultural_memory()` is
             used, so `wisdom`/`warnings`/reliability weighting read
-            whatever outcome history actually exists in `chroma_db`. The
-            evaluation runs both so it can compare the two conditions.
+            whatever outcome history actually exists in `chroma_db`, scoped
+            via `as_of` to what existed as of this session's own capture
+            date — never outcomes from sessions replayed "later" in this
+            call. The evaluation runs both so it can compare the two
+            conditions.
 
     Returns:
         SessionResult with the session's universe and the graph's final state.
     """
     universe, session_states = _load_session_states(session_dir)
-
-    graph = build_graph(
-        market_data=FixtureMarketDataProvider(fixtures_dir=session_dir / "market_data"),
-        fundamental_llm=_per_ticker_llm(session_dir, "fundamental.json", universe),
-        sentiment_llm=_per_ticker_llm(session_dir, "sentiment.json", universe),
-        portfolio_llm=_portfolio_llm(session_dir),
-    )
+    session_date = datetime.fromisoformat(next(iter(session_states.values()))["timestamp"])
 
     state = ARGUSState(
         ticker=universe[0],
@@ -149,6 +147,7 @@ def replay_session(
         risk_tolerance=risk_tolerance,
         backtest_mode=False,
         session_seed=None,
+        as_of=session_date if closed_loop else None,
         price_history={},
         session_states=session_states,
         macro_context=None,
@@ -164,18 +163,31 @@ def replay_session(
     )
     config = {"configurable": {"thread_id": str(uuid4())}}
 
-    with contextlib.ExitStack() as stack:
-        if not closed_loop:
-            mock_get_cultural_memory = stack.enter_context(
-                mock.patch("argus.orchestration.graph.get_cultural_memory")
-            )
-            mock_get_cultural_memory.return_value = mock.Mock(
-                retrieve_wisdom=mock.Mock(return_value=[]),
-                retrieve_warnings=mock.Mock(return_value=[]),
-                get_agent_accuracy=mock.Mock(return_value=0.5),
-                store_decision_snapshot=mock.Mock(),
-            )
-        final_state = graph.invoke(state, config)
+    # A dedicated temp checkpoint db, never the production argus_graph.db: replay
+    # is a read-only simulation over fixtures, and writing into the store
+    # reconciliation.py's load_decisions_from_checkpoints() reads would make
+    # fabricated replay sessions indistinguishable from genuine live ones.
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        graph = build_graph(
+            market_data=FixtureMarketDataProvider(fixtures_dir=session_dir / "market_data"),
+            fundamental_llm=_per_ticker_llm(session_dir, "fundamental.json", universe),
+            sentiment_llm=_per_ticker_llm(session_dir, "sentiment.json", universe),
+            portfolio_llm=_portfolio_llm(session_dir),
+            checkpoint_db_path=str(Path(tmp_dir) / "replay_checkpoint.db"),
+        )
+
+        with contextlib.ExitStack() as stack:
+            if not closed_loop:
+                mock_get_cultural_memory = stack.enter_context(
+                    mock.patch("argus.orchestration.graph.get_cultural_memory")
+                )
+                mock_get_cultural_memory.return_value = mock.Mock(
+                    retrieve_wisdom=mock.Mock(return_value=[]),
+                    retrieve_warnings=mock.Mock(return_value=[]),
+                    get_agent_accuracy=mock.Mock(return_value=0.5),
+                    store_decision_snapshot=mock.Mock(),
+                )
+            final_state = graph.invoke(state, config)
 
     _rebase_decision_timestamps(final_state, session_states)
     return SessionResult(session_dir=session_dir, universe=universe, final_state=final_state)

--- a/argus/orchestration/aggregator.py
+++ b/argus/orchestration/aggregator.py
@@ -99,6 +99,7 @@ class HybridSignalAggregator:
         neutral_pool: float = 0.0
         weighted_votes: dict[str, float] = {}
         agents_present: list[str] = [name for name, signal in sources.items() if signal is not None]
+        reliability_used: dict[str, float] = dict(reliability) if reliability else {}
 
         for name, signal in sources.items():
             if signal is None:
@@ -130,6 +131,7 @@ class HybridSignalAggregator:
                 conviction=0.0,
                 weighted_votes=weighted_votes,
                 agents_present=agents_present,
+                reliability=reliability_used,
             )
 
         bull_pct = bull_pool / total
@@ -176,4 +178,5 @@ class HybridSignalAggregator:
             conviction=conviction,
             weighted_votes=weighted_votes,
             agents_present=agents_present,
+            reliability=reliability_used,
         )

--- a/argus/orchestration/collector.py
+++ b/argus/orchestration/collector.py
@@ -125,6 +125,7 @@ async def run_collection_cycle(
         risk_tolerance=risk_tolerance,
         backtest_mode=False,
         session_seed=None,
+        as_of=None,
         price_history={},
         session_states=session_states,
         macro_context=None,

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -38,7 +38,6 @@ from typing import Optional
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langgraph.graph import END, StateGraph
-from langgraph.types import Send
 
 from argus.agents.fundamental import FundamentalAgent
 from argus.agents.macro import MacroStatisticalAgent
@@ -49,7 +48,7 @@ from argus.agents.technical import TechnicalStatisticalAgent
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.aggregator import HybridSignalAggregator
 from argus.orchestration.state import ARGUSState
-from argus.schemas.signals import AggregatedSignal, ARGUSDecision, RiskVerdict
+from argus.schemas.signals import AggregatedSignal, ARGUSDecision, RiskVerdict, Signal
 from argus.seams import LiveMarketDataProvider, LLMClient, MarketDataProvider
 
 logger = logging.getLogger("argus.graph")
@@ -76,6 +75,31 @@ def build_checkpoint_serde() -> JsonPlusSerializer:
         allowed_msgpack_modules=[
             ("argus.schemas.signals", cls) for cls in _CHECKPOINT_MODEL_CLASSES
         ]
+    )
+
+
+def _summarize_technical_posture(aggregated_signals: dict[str, AggregatedSignal]) -> str:
+    """Builds retrieve_wisdom's free-text technical-posture argument from this session's own signals.
+
+    Replaces a hardcoded "mixed technicals" placeholder that never reflected the
+    session it was queried for.
+
+    Args:
+        aggregated_signals: This session's ticker → AggregatedSignal mapping.
+
+    Returns:
+        A short directional-breakdown summary, or a fixed string when empty.
+    """
+    if not aggregated_signals:
+        return "no aggregated signals available"
+
+    bullish = sum(1 for s in aggregated_signals.values() if s.signal == Signal.BULLISH)
+    bearish = sum(1 for s in aggregated_signals.values() if s.signal == Signal.BEARISH)
+    neutral = len(aggregated_signals) - bullish - bearish
+    avg_conviction = sum(s.conviction for s in aggregated_signals.values()) / len(aggregated_signals)
+    return (
+        f"{bullish} bullish, {bearish} bearish, {neutral} neutral across "
+        f"{len(aggregated_signals)} tickers (avg conviction {avg_conviction:.2f})"
     )
 
 
@@ -163,7 +187,8 @@ def build_graph(
         if macro_ctx is None:
             logger.error(
                 "node_macro_analysis: MacroStatisticalAgent returned None (FRED data unavailable). "
-                "Routing to END — no downstream agents will run this session."
+                "The three specialist agents run independently and will still produce a "
+                "degraded, macro-agnostic allocation this session."
             )
             return {
                 "macro_context": None,
@@ -215,8 +240,13 @@ def build_graph(
     def node_retrieve_cultural_memory(state: ARGUSState) -> dict:
         """Retrieves semantic trading wisdom and historical trade patterns matching the current regime.
 
+        Runs after signal_aggregation (not beside the specialist fan-out) so it can
+        summarize this session's own aggregated_signals into the similarity query,
+        rather than a hardcoded placeholder.
+
         Args:
-            state: ARGUSState with ``macro_context`` to scope the semantic similarity query.
+            state: ARGUSState with ``macro_context`` to scope the semantic similarity
+                query and ``aggregated_signals`` to summarize into it.
 
         Returns:
             Partial state update with ``cultural_memory`` dict containing 'wisdom' and 'warnings' lists.
@@ -233,8 +263,10 @@ def build_graph(
             logger.warning("node_retrieve_cultural_memory: cultural memory unavailable: %s", exc)
             return {"cultural_memory": {"wisdom": [], "warnings": []}}
 
-        wisdom = memory.retrieve_wisdom(macro, "mixed technicals")
-        warnings = memory.retrieve_warnings(macro)
+        as_of = state.get("as_of")
+        technical_summary = _summarize_technical_posture(state.get("aggregated_signals", {}))
+        wisdom = memory.retrieve_wisdom(macro, technical_summary, as_of=as_of)
+        warnings = memory.retrieve_warnings(macro, as_of=as_of)
 
         return {
             "cultural_memory": {
@@ -246,32 +278,40 @@ def build_graph(
     def node_signal_aggregation(state: ARGUSState) -> dict:
         """Consolidates specialized analyst signals into weighted consensus indicators.
 
+        Runs whenever at least one specialist produced a signal, independent of
+        whether macro_context is populated — HybridSignalAggregator.aggregate()
+        already handles macro=None (no multiplier scaling), so a macro data outage
+        must not suppress aggregation of the specialists that did succeed.
+
         Args:
             state: ARGUSState with ``technical_signals``, ``fundamental_signals``,
-                ``sentiment_signals``, and ``macro_context`` populated.
+                and ``sentiment_signals`` populated; ``macro_context`` optional.
 
         Returns:
             Partial state update with ``aggregated_signals``.
         """
         aggs: dict[str, AggregatedSignal] = {}
-        macro = state["macro_context"]
-        if not macro:
-            return {"aggregated_signals": aggs}
+        macro = state.get("macro_context")
+        as_of = state.get("as_of")
+        agent_names = ("technical", "fundamental", "sentiment")
 
-        # Per-regime reliability doesn't depend on ticker, so compute it once per
-        # session rather than once per ticker.
-        regime = macro.macro_regime.value
-        try:
-            memory = get_cultural_memory()
-            reliability = {
-                name: memory.get_agent_accuracy(name, regime=regime)
-                for name in ("technical", "fundamental", "sentiment")
-            }
-        except ImportError as exc:
-            # Same optional-dependency guard as node_retrieve_cultural_memory;
-            # degrade every agent to the 0.5 neutral prior rather than crash
-            logger.warning("node_signal_aggregation: cultural memory unavailable: %s", exc)
-            reliability = {name: 0.5 for name in ("technical", "fundamental", "sentiment")}
+        if macro is not None:
+            # Per-regime reliability doesn't depend on ticker, so compute it once
+            # per session rather than once per ticker.
+            regime = macro.macro_regime.value
+            try:
+                memory = get_cultural_memory()
+                reliability = {
+                    name: memory.get_agent_accuracy(name, regime=regime, as_of=as_of)
+                    for name in agent_names
+                }
+            except ImportError as exc:
+                # Same optional-dependency guard as node_retrieve_cultural_memory;
+                # degrade every agent to the 0.5 neutral prior rather than crash
+                logger.warning("node_signal_aggregation: cultural memory unavailable: %s", exc)
+                reliability = {name: 0.5 for name in agent_names}
+        else:
+            reliability = {name: 0.5 for name in agent_names}
 
         for ticker in state["universe"]:
             tech = state.get("technical_signals", {}).get(ticker)
@@ -392,8 +432,12 @@ def build_graph(
         }
 
         macro = state.get("macro_context")
-        if not macro:
-            return {"errors": ["portfolio_allocation: skipped, no macro_context in state"]}
+        errors: list[str] = []
+        if macro is None:
+            errors.append(
+                "portfolio_allocation: macro_context unavailable this session; "
+                "allocating on specialist signals alone"
+            )
 
         mem = state.get("cultural_memory", {})
         wisdom = mem.get("wisdom", [])
@@ -405,37 +449,11 @@ def build_graph(
                 "node_portfolio_allocation: PortfolioManagerAgent returned None (LLM API failure). "
                 "Skipping portfolio_allocation to allow graceful exit."
             )
-            return {
-                "errors": [
-                    "portfolio_allocation: PortfolioManagerAgent returned None (LLM API failure)"
-                ]
-            }
-        return {"portfolio_allocation": alloc}
-
-    def route_after_macro(state: ARGUSState):
-        """Fans out to the four parallel analyst nodes, or short-circuits to END.
-
-        A None macro_context means the core FRED data bundle was entirely
-        unavailable (see MacroStatisticalAgent.analyze's docstring) — every
-        downstream node depends on macro_context, so there is nothing useful
-        left for this session to do.
-
-        Args:
-            state: ARGUSState with ``macro_context`` populated by node_macro_analysis.
-
-        Returns:
-            END if macro_context is None, otherwise a list of Send calls fanning
-            out to technical_analysis, fundamental_analysis, sentiment_analysis,
-            and retrieve_cultural_memory.
-        """
-        if state.get("macro_context") is None:
-            return END
-        return [
-            Send("technical_analysis", state),
-            Send("fundamental_analysis", state),
-            Send("sentiment_analysis", state),
-            Send("retrieve_cultural_memory", state),
-        ]
+            errors.append(
+                "portfolio_allocation: PortfolioManagerAgent returned None (LLM API failure)"
+            )
+            return {"errors": errors}
+        return {"portfolio_allocation": alloc, "errors": errors}
 
     def node_log_decisions(state: ARGUSState) -> dict:
         """Persists structural decision profiles to vector database collections.
@@ -497,21 +515,29 @@ def build_graph(
     builder.add_node("log_decisions", node_log_decisions)
 
     builder.set_entry_point("fetch_price_history")
-    builder.add_edge("fetch_price_history", "macro_analysis")
 
-    builder.add_conditional_edges("macro_analysis", route_after_macro)
+    # macro_analysis runs in parallel with the three specialists, not ahead of
+    # them: none of them consumes macro_context (see state.py's docstring), so
+    # gating them behind it needlessly serializes fundamental's ~20 sequential
+    # Groq round-trips behind the HMM window and drops a whole session's output
+    # whenever only the FRED bundle is unavailable.
+    builder.add_edge("fetch_price_history", "macro_analysis")
+    builder.add_edge("fetch_price_history", "technical_analysis")
+    builder.add_edge("fetch_price_history", "fundamental_analysis")
+    builder.add_edge("fetch_price_history", "sentiment_analysis")
 
     builder.add_edge(
-        [
-            "technical_analysis",
-            "fundamental_analysis",
-            "sentiment_analysis",
-            "retrieve_cultural_memory",
-        ],
+        ["macro_analysis", "technical_analysis", "fundamental_analysis", "sentiment_analysis"],
         "signal_aggregation",
     )
+
+    # retrieve_cultural_memory runs after signal_aggregation (not beside it) so it
+    # can summarize this session's own aggregated_signals into its similarity
+    # query; wisdom/warnings are consumed only by portfolio_allocation, so this
+    # is safe to run in parallel with risk_evaluation.
+    builder.add_edge("signal_aggregation", "retrieve_cultural_memory")
     builder.add_edge("signal_aggregation", "risk_evaluation")
-    builder.add_edge("risk_evaluation", "portfolio_allocation")
+    builder.add_edge(["retrieve_cultural_memory", "risk_evaluation"], "portfolio_allocation")
     builder.add_edge("portfolio_allocation", "log_decisions")
     builder.add_edge("log_decisions", END)
 

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -82,6 +82,15 @@ def credit_primary_driver(
     ablation) was the bigger contributor. This avoids exact Shapley over the
     2^3 - 1 coalitions.
 
+    Each ablated rerun replays `decision.aggregated.reliability` — the same
+    reliability dict the baseline aggregation used — rather than an
+    unweighted aggregate() call. Without it, every ablation would silently
+    use reliability_mult=1.0, so the baseline (computed with reliability)
+    and every ablated rerun (computed without it) could disagree on
+    direction before any agent is even removed, spuriously flipping credit
+    to argmax(baseline_votes) for every agent regardless of which one was
+    actually removed.
+
     Args:
         decision: Completed ARGUSDecision with technical/fundamental/sentiment
             signals and its `aggregated` result already populated.
@@ -118,6 +127,7 @@ def credit_primary_driver(
             decision.macro,
             ablated["fundamental"],  # type: ignore[arg-type]
             ablated["sentiment"],  # type: ignore[arg-type]
+            reliability=decision.aggregated.reliability,
         )
         flipped = result.signal != baseline_signal
         score = (flipped, baseline_votes.get(name, 0.0))

--- a/argus/orchestration/state.py
+++ b/argus/orchestration/state.py
@@ -15,6 +15,7 @@ Not responsible for:
 from __future__ import annotations
 
 import operator
+from datetime import datetime
 from typing import Annotated, Any, Optional, TypedDict
 
 import pandas as pd
@@ -59,6 +60,13 @@ class ARGUSState(TypedDict):
     session_seed: Optional[int]
     """Integer date stamp used to deterministically seed anonymization in backtests."""
 
+    as_of: Optional[datetime]
+    """Point-in-time cutoff for cultural-memory reads: excludes trade outcomes and
+    decision documents stored after this timestamp (see memory.cultural's `as_of`
+    parameters). None (default) applies no filtering — the live production path.
+    Set by backtesting.replay.replay_session's closed_loop arm to the replayed
+    session's own capture date, so it can't read outcomes that hadn't happened yet."""
+
     # ── Node 1: fetch_price_history ───────────────────────────────────────────
     price_history: dict[str, pd.Series]
     """Mapping of ticker → daily close price Series, populated by fetch_price_history."""
@@ -68,7 +76,10 @@ class ARGUSState(TypedDict):
 
     # ── Node 2: macro_analysis ────────────────────────────────────────────────
     macro_context: Optional[MacroContext]
-    """Live MacroContext from MacroStatisticalAgent; used as multiplier source by specialist agents."""
+    """Live MacroContext from MacroStatisticalAgent. Runs in parallel with, not ahead
+    of, the three specialist agents below — none of them consumes it. Its
+    agent_multipliers are read once, by orchestration/aggregator.py, as a per-agent
+    vote-weight scalar at signal-aggregation time."""
 
     # ── Node 3: Parallel specialist agents ───────────────────────────────────
     technical_signals: dict[str, TechnicalSignal]
@@ -106,7 +117,8 @@ class ARGUSState(TypedDict):
 
     errors: Annotated[list[str], operator.add]
     """Accumulated error messages from all nodes, used for diagnostics and
-    alerting. Needs the operator.add reducer: technical_analysis,
-    fundamental_analysis, sentiment_analysis, and retrieve_cultural_memory
-    write this key concurrently in the macro_analysis fan-out, and LangGraph
-    raises InvalidUpdateError on concurrent writes to a key without one."""
+    alerting. Needs the operator.add reducer: macro_analysis,
+    technical_analysis, fundamental_analysis, and sentiment_analysis all run
+    in parallel off fetch_price_history and write this key concurrently, and
+    LangGraph raises InvalidUpdateError on concurrent writes to a key
+    without one."""

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -412,6 +412,16 @@ class AggregatedSignal(BaseModel):
             "weighted_votes alone cannot tell the two apart."
         ),
     )
+    reliability: dict[str, float] = Field(
+        default_factory=dict,
+        description=(
+            "Agent name → per-regime historical win rate used to scale that agent's "
+            "vote weight at aggregation time (see HybridSignalAggregator.aggregate's "
+            "reliability parameter). Persisted so orchestration/reconciliation.py's "
+            "leave-one-out ablation can replay the same weighting the baseline used, "
+            "instead of silently resetting every ablated rerun to the 1.0 unweighted default."
+        ),
+    )
 
 
 class PositionAllocation(BaseModel):

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -3,7 +3,10 @@ Tests for argus/backtesting/replay.py, which replaces the deleted walk-forward e
 See argus/backtesting/replay.py's docstring for what a "session" is.
 """
 
+import json
+from datetime import datetime
 from pathlib import Path
+from unittest import mock
 
 from argus.backtesting.replay import replay_session, replay_sessions
 
@@ -27,3 +30,43 @@ def test_replay_sessions_preserves_order():
 
     assert [r.session_dir for r in results] == [FIXTURES_DIR, FIXTURES_DIR]
     assert all(r.final_state.get("portfolio_allocation") is not None for r in results)
+
+
+def test_replay_session_never_touches_the_production_checkpoint_db(tmp_path, monkeypatch):
+    """Regression test for X4: replay must checkpoint into a temp db, never argus_graph.db.
+
+    build_graph()'s checkpoint_db_path defaults to the production store; replay
+    previously omitted the argument, so replayed sessions (with their rebased,
+    fake-looking-genuine timestamps) landed in the same store
+    reconciliation.load_decisions_from_checkpoints() reads.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    replay_session(FIXTURES_DIR)
+
+    assert not (tmp_path / "argus_graph.db").exists()
+
+
+def test_replay_session_closed_loop_scopes_cultural_memory_to_the_session_date():
+    """closed_loop=True must pass the fixture's own capture date as `as_of`.
+
+    Regression test for the PR 7 plan's closed-loop item: without it, replayed
+    sessions could read outcomes that, relative to the fixture's point in time,
+    haven't happened yet.
+    """
+    mock_memory = mock.Mock(
+        retrieve_wisdom=mock.Mock(return_value=[]),
+        retrieve_warnings=mock.Mock(return_value=[]),
+        get_agent_accuracy=mock.Mock(return_value=0.5),
+        store_decision_snapshot=mock.Mock(),
+    )
+    with mock.patch("argus.orchestration.graph.get_cultural_memory", return_value=mock_memory):
+        replay_session(FIXTURES_DIR, closed_loop=True)
+
+    with open(FIXTURES_DIR / "market_data" / "session_states.json") as f:
+        session_states = json.load(f)
+    expected_as_of = datetime.fromisoformat(next(iter(session_states.values()))["timestamp"])
+
+    assert mock_memory.retrieve_wisdom.call_args.kwargs["as_of"] == expected_as_of
+    assert mock_memory.retrieve_warnings.call_args.kwargs["as_of"] == expected_as_of
+    assert mock_memory.get_agent_accuracy.call_args.kwargs["as_of"] == expected_as_of

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -69,6 +69,7 @@ def _initial_state() -> ARGUSState:
         risk_tolerance="MODERATE",
         backtest_mode=False,
         session_seed=None,
+        as_of=None,
         price_history={},
         session_states=session_states,
         macro_context=None,
@@ -138,8 +139,14 @@ class _NoneMacroMarketData(FixtureMarketDataProvider):
         return {"vix": None, "fed_funds": None, "t10y2y": None}
 
 
-def test_macro_context_none_short_circuits_to_end():
-    """A None macro_context routes straight to END; no fan-out node runs."""
+def test_macro_context_none_still_produces_a_degraded_allocation():
+    """A None macro_context must not gate the three specialists or the allocator.
+
+    Regression test for X1: no specialist agent consumes MacroContext, so a FRED
+    outage must not zero out a session that needs no FRED data. The three
+    specialists, aggregation, risk evaluation, and portfolio allocation must all
+    still run, degraded rather than empty, with the gap named in errors.
+    """
     graph = build_graph(
         market_data=_NoneMacroMarketData(),
         fundamental_llm=_per_ticker_llm("fundamental.json"),
@@ -158,11 +165,17 @@ def test_macro_context_none_short_circuits_to_end():
         final_state = graph.invoke(_initial_state(), config)
 
     assert final_state.get("macro_context") is None
-    assert final_state.get("technical_signals") == {}
-    assert final_state.get("fundamental_signals") == {}
-    assert final_state.get("sentiment_signals") == {}
-    assert final_state.get("risk_assessments") == {}
-    assert final_state.get("portfolio_allocation") is None
+    assert final_state.get("technical_signals")
+    assert final_state.get("fundamental_signals")
+    assert final_state.get("sentiment_signals")
+    assert final_state.get("risk_assessments")
+    assert final_state.get("aggregated_signals")
+
+    alloc = final_state.get("portfolio_allocation")
+    assert alloc is not None
+    assert len(alloc.portfolio) == len(UNIVERSE)
+
+    assert any("macro_context unavailable" in e for e in final_state.get("errors", []))
 
 
 def test_golden_dag_runs_offline_and_produces_a_valid_allocation():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -173,6 +173,7 @@ class TestEndToEnd:
             universe=["AAPL", "MSFT"],
             backtest_mode=False,
             session_seed=None,
+            as_of=None,
             session_states={},
             price_history={},
             technical_signals={},

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -31,6 +31,7 @@ from argus.schemas.signals import (
     PositionAllocation,
     Regime,
     SectorSignal,
+    SentimentSignal,
     Signal,
     TechnicalSignal,
     VixRegime,
@@ -92,6 +93,34 @@ def _fundamental(signal: Signal, conviction: float, ticker: str = "TEST") -> Fun
         moat_score=5.0,
         reasoning="test",
         data_as_of_date=datetime.now().date(),
+        timestamp=datetime.now(),
+    )
+
+
+def _sentiment(signal: Signal, conviction: float, ticker: str = "TEST") -> SentimentSignal:
+    """Builds a SentimentSignal with fixed field values, varying only the given fields.
+
+    Args:
+        signal: Signal direction to assign.
+        conviction: Confidence score to assign.
+        ticker: Ticker symbol.
+
+    Returns:
+        A SentimentSignal fixture.
+    """
+    return SentimentSignal(
+        ticker=ticker,
+        finbert_net_score=0.0,
+        pct_positive=0.3,
+        pct_negative=0.3,
+        news_volume_7d=5,
+        social_volume_change_pct=0.0,
+        social_mention_surge=False,
+        upcoming_catalyst=False,
+        signal=signal,
+        conviction=conviction,
+        sentiment_decay_risk="LOW",
+        reasoning="test",
         timestamp=datetime.now(),
     )
 
@@ -250,6 +279,50 @@ def test_credit_primary_driver_is_symmetric_under_relabeling():
         aggregated=aggregated,
     )
     assert credit_primary_driver(decision) == "fundamental"
+
+
+def test_credit_primary_driver_replays_the_baseline_reliability_in_each_ablation():
+    """Ablation must reuse the exact reliability dict the baseline aggregation used.
+
+    Regression test for X3: without this, every ablated rerun silently falls
+    back to aggregate()'s unweighted reliability_mult=1.0 default, so the
+    baseline (computed WITH reliability) and each ablated rerun (computed
+    WITHOUT it) can disagree on consensus direction before any agent is even
+    removed — flipping credit to argmax(baseline_votes) regardless of which
+    agent was actually ablated.
+    """
+    technical = _technical(Signal.BULLISH, 0.9)
+    fundamental = _fundamental(Signal.BEARISH, 0.85)
+    sentiment = _sentiment(Signal.NEUTRAL, 0.3)
+    macro = _macro()
+    reliability = {"technical": 0.95, "fundamental": 0.20, "sentiment": 0.50}
+
+    real_aggregator = HybridSignalAggregator()
+    aggregated = real_aggregator.aggregate(
+        technical, macro, fundamental, sentiment, reliability=reliability
+    )
+
+    decision = ARGUSDecision(
+        ticker="TEST",
+        session_timestamp=datetime.now(),
+        technical=technical,
+        fundamental=fundamental,
+        sentiment=sentiment,
+        macro=macro,
+        aggregated=aggregated,
+    )
+
+    seen_reliability: list[object] = []
+
+    class _SpyAggregator(HybridSignalAggregator):
+        def aggregate(self, *args, **kwargs):
+            seen_reliability.append(kwargs.get("reliability"))
+            return super().aggregate(*args, **kwargs)
+
+    credit_primary_driver(decision, aggregator=_SpyAggregator())
+
+    assert seen_reliability
+    assert all(r == reliability for r in seen_reliability)
 
 
 # ---------------------------------------------------------------------------
@@ -437,6 +510,7 @@ def test_load_decisions_from_checkpoints_round_trips_a_real_graph_run(tmp_path):
         risk_tolerance="MODERATE",
         backtest_mode=False,
         session_seed=None,
+        as_of=None,
         price_history={},
         session_states=session_states,
         macro_context=None,


### PR DESCRIPTION
## Summary

PR 7 of #15's 7-PR remediation plan — the last PR, since it touches graph wiring PRs 3 and 6 also edited. Fixes X1, C4, X3, X4.

- **X1** — `macro_analysis` now runs in parallel with `technical_analysis`/`fundamental_analysis`/`sentiment_analysis` off `fetch_price_history`, instead of gating them behind `route_after_macro`/`END`. Verified: no specialist agent imports `MacroContext`, so a FRED outage was previously zeroing out a session that needed no FRED data, and needlessly serializing fundamental's ~20 sequential Groq round-trips behind the HMM window. `signal_aggregation` and `portfolio_allocation` both gained a degraded path for `macro_context=None` (the aggregator already tolerated it; the two node functions didn't). `portfolio.py`'s `allocate`/`build_signal_table` now accept `Optional[MacroContext]`. Corrected the stale `agent_multipliers` docstrings in `state.py` and `macro.py`.
- **C4** — `retrieve_cultural_memory` now runs after `signal_aggregation` (parallel with `risk_evaluation`, both joining into `portfolio_allocation`) instead of beside the specialist fan-out, so its similarity query can summarize this session's own `aggregated_signals` instead of a hardcoded `"mixed technicals"` placeholder.
- **X3** — `HybridSignalAggregator.aggregate()` now persists the `reliability` dict it used onto the returned `AggregatedSignal` (new optional field, defaulted so existing checkpoints deserialize unchanged). `credit_primary_driver`'s leave-one-out ablation replays that same dict instead of silently falling back to the unweighted `reliability_mult=1.0` default on every ablated rerun — which let the baseline (computed with reliability) and every ablation (computed without it) disagree on direction before any agent was even removed, spuriously flipping credit to `argmax(baseline_votes)`.
- **X4** — `backtesting.replay.replay_session` now checkpoints into a per-call temp directory instead of falling through to `build_graph`'s production `argus_graph.db` default. `closed_loop=True` now threads an `as_of` cutoff (the fixture's own capture date) through `retrieve_wisdom`/`retrieve_warnings`/`get_agent_accuracy`, so the closed-loop evaluation arm can't read outcomes from its own future.

**Audit note:** read-only inspection of the existing `argus_graph.db` found ~3,261 of its 3,268 stored decisions are on the fixture universe's tickers (AAPL/GOOGL/JPM/MSFT/NVDA/XOM) — i.e. the store is almost entirely test pollution from `test_golden_dag.py` and friends never overriding `checkpoint_db_path`, not genuine production history. Out of scope here (this PR only fixes `replay.py`'s instance of the same bug); flagging for a follow-up if the test suite's own checkpoint isolation is worth doing.

## Test plan

- [x] `.venv/bin/pytest` — 212 passed (209 baseline + 3 new regression tests)
- [x] `.venv/bin/ruff check .` — clean
- [x] `.venv/bin/mypy argus api scripts` — same 4 pre-existing errors as `main`, none new
- [x] Reverted each fix individually and confirmed its new regression test fails without it, then re-applied (X3's `test_credit_primary_driver_replays_the_baseline_reliability_in_each_ablation`, X4's `test_replay_session_never_touches_the_production_checkpoint_db`)
- [x] `scripts/replay_backtest.py` end-to-end against `tests/fixtures/` — valid allocation, `argus_graph.db` untouched
- [x] `scripts/run_evaluation.py` end-to-end (open-loop + closed-loop, real network market data) — 0 errors recorded, schema validity 6/6