### PR TITLE
Fix the optimizer's objective

### DIFF
--- a/argus/agents/risk.py
+++ b/argus/agents/risk.py
@@ -73,6 +73,30 @@ def get_sector(ticker: str) -> str:
         return "Unknown"
 
 
+def compute_asset_returns(
+    positions: list[dict], price_history: dict[str, pd.Series], lookback: int = RISK.returns_lookback_days
+) -> pd.DataFrame:
+    """Calculates raw (unweighted) daily historical returns per asset over a lookback window.
+
+    Args:
+        positions: List of dicts with key ``ticker``.
+        price_history: Mapping of ticker → daily close price Series.
+        lookback: Number of trading days to include (default 252 = 1 year).
+
+    Returns:
+        DataFrame of raw daily returns per ticker, with NaN rows dropped.
+    """
+    returns_dict = {}
+    for pos in positions:
+        ticker = pos["ticker"]
+        if ticker in price_history:
+            series = price_history[ticker].tail(lookback + 1)
+            returns_dict[ticker] = series.pct_change().dropna()
+
+    df = pd.DataFrame(returns_dict).dropna()
+    return df
+
+
 def compute_portfolio_returns(
     positions: list[dict], price_history: dict[str, pd.Series], lookback: int = RISK.returns_lookback_days
 ) -> pd.DataFrame:
@@ -86,16 +110,9 @@ def compute_portfolio_returns(
     Returns:
         DataFrame of weighted daily returns per ticker, with NaN rows dropped.
     """
-    returns_dict = {}
-    for pos in positions:
-        ticker = pos["ticker"]
-        weight = pos["weight"]
-        if ticker in price_history:
-            series = price_history[ticker].tail(lookback + 1)
-            returns_dict[ticker] = series.pct_change().dropna() * weight
-
-    df = pd.DataFrame(returns_dict).dropna()
-    return df
+    asset_returns = compute_asset_returns(positions, price_history, lookback)
+    weights = pd.Series({pos["ticker"]: pos["weight"] for pos in positions})
+    return asset_returns.mul(weights)
 
 
 def historical_var(portfolio_returns: pd.Series, confidence: float = RISK.var_confidence) -> float:
@@ -344,7 +361,7 @@ class RiskStatisticalEngine:
                 cvar=0.0,
                 marginal_var=0.0,
                 portfolio_beta=0.0,
-                avg_correlation=0.0,
+                avg_correlation=None,
                 stop_loss=0.0,
                 api_calls_used=0,
                 timestamp=datetime.now(),
@@ -361,7 +378,9 @@ class RiskStatisticalEngine:
 
         optimal_weights: dict[str, float] = {}
         if len(proposed_positions) > 1:
-            returns_df = compute_portfolio_returns(proposed_positions, price_history)
+            # Raw per-asset returns: the objective applies w itself, so cov must not
+            # already be weighted or w^T*cov*w double-applies it
+            returns_df = compute_asset_returns(proposed_positions, price_history)
             if not returns_df.empty:
                 cov = returns_df.cov() * 252
                 tickers = list(returns_df.columns)

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -45,10 +45,11 @@ from argus.agents.portfolio import PortfolioManagerAgent
 from argus.agents.risk import RiskStatisticalEngine
 from argus.agents.sentiment import SentimentAgent
 from argus.agents.technical import TechnicalStatisticalAgent
+from argus.config import settings
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.aggregator import HybridSignalAggregator
 from argus.orchestration.state import ARGUSState
-from argus.schemas.signals import AggregatedSignal, ARGUSDecision, RiskVerdict, Signal
+from argus.schemas.signals import AggregatedSignal, ARGUSDecision, RiskAssessment, RiskVerdict, Signal
 from argus.seams import LiveMarketDataProvider, LLMClient, MarketDataProvider
 
 logger = logging.getLogger("argus.graph")
@@ -354,8 +355,8 @@ def build_graph(
             for t, sig in aggs.items():
                 sign = (
                     1.0
-                    if sig.signal.value == "BULLISH"
-                    else (-1.0 if sig.signal.value == "BEARISH" else 0.0)
+                    if sig.signal == Signal.BULLISH
+                    else (-1.0 if sig.signal == Signal.BEARISH else 0.0)
                 )
                 convictions[t] = sig.conviction * sign
 
@@ -370,39 +371,44 @@ def build_graph(
         assessments = {}
 
         for ticker in universe:
-            single = risk_engine.evaluate([{"ticker": ticker, "weight": 0.15}], history, vix)
+            single = risk_engine.evaluate(
+                [{"ticker": ticker, "weight": settings.MAX_SINGLE_POSITION_PCT}], history, vix
+            )
 
-            # Propagate portfolio-level correlation stats for uniform telemetry
-            single = single.model_copy(update={"avg_correlation": portfolio_result.avg_correlation})
+            updates: dict = {}
+
+            # Propagate portfolio-level correlation stats for uniform telemetry, but only
+            # when the portfolio call actually measured them — a structural-violation
+            # short-circuit reports None, not a fabricated 0.0
+            if portfolio_result.avg_correlation is not None:
+                updates["avg_correlation"] = portfolio_result.avg_correlation
 
             if ticker in ticker_cap_map and not portfolio_vetoed:
                 cap = ticker_cap_map[ticker]
                 # Downgrade verdict monotonically: never upgrade a VETO to REDUCE or APPROVE
-                new_verdict = (
+                updates["verdict"] = (
                     single.verdict
                     if single.verdict == RiskVerdict.VETO
                     else (RiskVerdict.REDUCE if cap < single.approved_weight else single.verdict)
                 )
-                single = single.model_copy(
-                    update={
-                        "verdict": new_verdict,
-                        "approved_weight": min(cap, single.approved_weight),
-                        "veto_reasons": single.veto_reasons + [f"[Portfolio] SLSQP cap: {cap:.1%}"],
-                    }
-                )
+                updates["approved_weight"] = min(cap, single.approved_weight)
+                updates["veto_reasons"] = single.veto_reasons + [f"[Portfolio] SLSQP cap: {cap:.1%}"]
 
             # Portfolio-level veto overrides all individual verdicts to prevent partial allocation
             if portfolio_vetoed:
-                single = single.model_copy(
-                    update={
-                        "verdict": RiskVerdict.VETO,
-                        "approved_weight": 0.0,
-                        "veto_reasons": single.veto_reasons
-                        + [f"[Portfolio] {r}" for r in portfolio_result.veto_reasons],
-                    }
-                )
+                updates["verdict"] = RiskVerdict.VETO
+                updates["approved_weight"] = 0.0
+                updates["veto_reasons"] = single.veto_reasons + [
+                    f"[Portfolio] {r}" for r in portfolio_result.veto_reasons
+                ]
 
-            assessments[ticker] = single
+            # A single model_validate reconstruction, not sequential model_copy calls —
+            # model_copy skips validators, so it was bypassing approved_le_proposed
+            assessments[ticker] = (
+                RiskAssessment.model_validate({**single.model_dump(), **updates})
+                if updates
+                else single
+            )
 
         return {"risk_assessments": assessments}
 

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -6,7 +6,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from argus.agents.risk import RiskStatisticalEngine
+from argus.agents.risk import (
+    RiskStatisticalEngine,
+    compute_asset_returns,
+    compute_portfolio_returns,
+)
 from argus.schemas.signals import RiskVerdict
 
 
@@ -49,6 +53,9 @@ def test_vix_blackout(risk_engine: RiskStatisticalEngine, price_history: dict) -
 
     assert result.verdict == RiskVerdict.VETO
     assert any("blackout" in r.lower() for r in result.veto_reasons)
+    # RE-9: a structural-violation short-circuit never computed correlation, so
+    # it must report None ("not measured"), not a fabricated 0.0
+    assert result.avg_correlation is None
 
 
 def test_overweight_position(risk_engine: RiskStatisticalEngine, price_history: dict) -> None:
@@ -106,6 +113,34 @@ def test_approve_healthy_portfolio(risk_engine: RiskStatisticalEngine, price_his
     assert result.verdict == RiskVerdict.APPROVE
     assert result.var_99 <= 0.03
     assert not result.veto_reasons
+
+
+def test_slsqp_covariance_uses_unweighted_returns(price_history: dict) -> None:
+    """The optimizer's w^T*cov*w term is built from raw returns, not pre-weighted ones.
+
+    Regression test for RE-2: cov used to come from compute_portfolio_returns,
+    whose series are already multiplied by weight, so w^T*cov*w applied the
+    weight a second time — variance came out ~1/weight^2 too small.
+    """
+    tickers = ["AAPL", "MSFT", "GOOGL", "META", "AMZN", "TSLA", "JPM", "BAC"]
+    weight = 0.125
+    positions = [{"ticker": t, "weight": weight} for t in tickers]
+    w = np.full(len(tickers), weight)
+
+    asset_returns = compute_asset_returns(positions, price_history)
+    cov = asset_returns.cov() * 252
+    fixed_variance = float(np.dot(w, np.dot(cov, w)))
+
+    # Var(sum_i w_i * r_i) is the ground truth this must match
+    weighted_returns = compute_portfolio_returns(positions, price_history)
+    true_portfolio_variance = float(weighted_returns.sum(axis=1).var() * 252)
+    assert fixed_variance == pytest.approx(true_portfolio_variance, rel=0.05)
+
+    # Reproduce the pre-fix computation (cov from already-weighted returns) to
+    # prove this test would have failed against the old code
+    buggy_cov = weighted_returns.cov() * 252
+    buggy_variance = float(np.dot(w, np.dot(buggy_cov, w)))
+    assert fixed_variance / buggy_variance == pytest.approx(1.0 / (weight**2), rel=0.05)
 
 
 def test_zero_api_calls(risk_engine: RiskStatisticalEngine, price_history: dict) -> None:


### PR DESCRIPTION
PR 2 of #24's 9-PR remediation plan. Fixes RE-2 (Critical), RE-9, RE-11, RE-12.

## Summary

- **RE-2** — `compute_portfolio_returns` pre-multiplied each series by its weight, and `evaluate`'s SLSQP objective applied `w` again via `w^T·cov·w`, so variance came out weight²-too-small (~64× for an 8-asset equal-weighted book). Added `compute_asset_returns` returning raw returns as the single source of truth for the lookback/dropna logic; `compute_portfolio_returns` is now that × weight. The optimizer builds `cov` from the raw series; VaR/CVaR/beta/correlation keep using the weighted one, unchanged.
- **RE-9** — `node_risk_evaluation`'s sequential `model_copy(update=...)` calls bypass `RiskAssessment.approved_le_proposed` (`model_copy` skips validators). Collapsed into one `model_validate` reconstruction per ticker. Also stopped overwriting each ticker's own `avg_correlation` with a portfolio-level figure that is a fabricated `0.0` after a structural-violation short-circuit — that early VETO return now reports `avg_correlation=None` ("not measured"), and the per-ticker loop only propagates the portfolio figure when it isn't `None`.
- **RE-11** — replaced the hardcoded `weight: 0.15` single-ticker probe with `settings.MAX_SINGLE_POSITION_PCT`.
- **RE-12** — `sig.signal == Signal.BULLISH`/`BEARISH` instead of comparing `.value` strings.

## Test plan

- [x] `tests/test_risk.py::test_slsqp_covariance_uses_unweighted_returns` — new regression test for RE-2: proves the fixed variance matches `Var(Σ wᵢrᵢ)` and that the pre-fix computation was off by `1/weight²`.
- [x] `tests/test_risk.py::test_vix_blackout` — extended to assert `avg_correlation is None` on a structural-violation short-circuit (RE-9).
- [x] `.venv/bin/python -m pytest tests/ -q` — 213 passed (212 baseline + 1 new), no existing test broke.
- [x] `.venv/bin/ruff check .` — clean.
- [x] `.venv/bin/mypy argus api scripts` — same 4 pre-existing errors as `main` (unrelated files: `scripts/remediate_macro_regime_tags.py`, `api/main.py`), none introduced by this change.

Refs #24.