### PR TITLE
Give the optimizer a budget

### DIFF
--- a/argus/agents/risk.py
+++ b/argus/agents/risk.py
@@ -377,6 +377,7 @@ class RiskStatisticalEngine:
         has_sector_violation = any(w > self.max_sector_pct for w in sector_weights.values())
 
         optimal_weights: dict[str, float] = {}
+        optimizer_converged: Optional[bool] = None
         if len(proposed_positions) > 1:
             # Raw per-asset returns: the objective applies w itself, so cov must not
             # already be weighted or w^T*cov*w double-applies it
@@ -417,9 +418,9 @@ class RiskStatisticalEngine:
                             "fun": lambda w, idx=idxs, c=cap: c - sum(w[i] for i in idx),
                         }
                     )
-                # Require aggregate equity deployment of at least 50%
+                # A long-only book cannot deploy more capital than it has
                 cons.append(
-                    {"type": "ineq", "fun": lambda w: np.sum(w) - RISK.slsqp_min_equity_deployment}
+                    {"type": "ineq", "fun": lambda w: RISK.slsqp_max_total_deployment - np.sum(w)}
                 )
 
                 res = minimize(
@@ -430,12 +431,15 @@ class RiskStatisticalEngine:
                     constraints=cons,
                     options={"ftol": RISK.slsqp_ftol, "maxiter": RISK.slsqp_maxiter},
                 )
+                optimizer_converged = bool(res.success)
                 if res.success:
                     optimal_weights = {tickers[i]: float(res.x[i]) for i in range(n)}
                     logger.debug(
                         "[Risk] SLSQP optimal weights: %s",
                         {t: f"{w:.3f}" for t, w in optimal_weights.items()},
                     )
+                else:
+                    logger.warning("[Risk] SLSQP solve did not converge: %s", res.message)
 
         returns = compute_portfolio_returns(proposed_positions, price_history)
         port_returns = returns.sum(axis=1) if not returns.empty else pd.Series(dtype=float)
@@ -470,6 +474,7 @@ class RiskStatisticalEngine:
                 proposed_weight=total_weight,
                 veto_reasons=stat_violations,
                 optimal_weights=optimal_weights,
+                optimizer_converged=optimizer_converged,
                 var_99=var99,
                 cvar=cvar,
                 marginal_var=0.0,
@@ -494,6 +499,7 @@ class RiskStatisticalEngine:
             proposed_weight=total_weight,
             veto_reasons=[],
             optimal_weights=optimal_weights,
+            optimizer_converged=optimizer_converged,
             var_99=var99,
             cvar=cvar,
             marginal_var=mvar_val,

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -49,6 +49,7 @@ from argus.config import settings
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.aggregator import HybridSignalAggregator
 from argus.orchestration.state import ARGUSState
+from argus.params import RISK
 from argus.schemas.signals import AggregatedSignal, ARGUSDecision, RiskAssessment, RiskVerdict, Signal
 from argus.seams import LiveMarketDataProvider, LLMClient, MarketDataProvider
 
@@ -102,6 +103,43 @@ def _summarize_technical_posture(aggregated_signals: dict[str, AggregatedSignal]
         f"{bullish} bullish, {bearish} bearish, {neutral} neutral across "
         f"{len(aggregated_signals)} tickers (avg conviction {avg_conviction:.2f})"
     )
+
+
+def _apply_portfolio_cap(single: RiskAssessment, cap: float) -> dict:
+    """Maps an SLSQP-derived per-ticker cap onto a single-ticker risk verdict.
+
+    Args:
+        single: The ticker's own (non-portfolio) risk assessment.
+        cap: SLSQP-optimal weight ceiling for this ticker.
+
+    Returns:
+        Partial RiskAssessment field updates: ``verdict``, ``approved_weight``,
+        ``veto_reasons``.
+    """
+    if cap < RISK.slsqp_zero_cap_epsilon:
+        # A cap this small is no room to allocate, not a REDUCE — REDUCE
+        # still counts as approved (portfolio.py:236) and the prompt would
+        # demand invest_pct deployment against a 0% cap
+        return {
+            "verdict": RiskVerdict.VETO,
+            "approved_weight": 0.0,
+            "veto_reasons": single.veto_reasons
+            + [
+                f"[Portfolio] SLSQP cap {cap:.2%} below the "
+                f"{RISK.slsqp_zero_cap_epsilon:.2%} allocation floor"
+            ],
+        }
+    # Downgrade verdict monotonically: never upgrade a VETO to REDUCE or APPROVE
+    verdict = (
+        single.verdict
+        if single.verdict == RiskVerdict.VETO
+        else (RiskVerdict.REDUCE if cap < single.approved_weight else single.verdict)
+    )
+    return {
+        "verdict": verdict,
+        "approved_weight": min(cap, single.approved_weight),
+        "veto_reasons": single.veto_reasons + [f"[Portfolio] SLSQP cap: {cap:.1%}"],
+    }
 
 
 def build_graph(
@@ -335,7 +373,7 @@ def build_graph(
                 and ``aggregated_signals`` populated.
 
         Returns:
-            Partial state update with ``risk_assessments``.
+            Partial state update with ``risk_assessments`` and ``errors``.
         """
         import pandas as pd
 
@@ -368,6 +406,13 @@ def build_graph(
         portfolio_vetoed = portfolio_result.verdict == RiskVerdict.VETO
         ticker_cap_map: dict[str, float] = portfolio_result.optimal_weights
 
+        errors: list[str] = []
+        if portfolio_result.optimizer_converged is False:
+            errors.append(
+                "risk_evaluation: SLSQP solve did not converge; portfolio-level caps "
+                "were not applied to any ticker"
+            )
+
         assessments = {}
 
         for ticker in universe:
@@ -384,15 +429,7 @@ def build_graph(
                 updates["avg_correlation"] = portfolio_result.avg_correlation
 
             if ticker in ticker_cap_map and not portfolio_vetoed:
-                cap = ticker_cap_map[ticker]
-                # Downgrade verdict monotonically: never upgrade a VETO to REDUCE or APPROVE
-                updates["verdict"] = (
-                    single.verdict
-                    if single.verdict == RiskVerdict.VETO
-                    else (RiskVerdict.REDUCE if cap < single.approved_weight else single.verdict)
-                )
-                updates["approved_weight"] = min(cap, single.approved_weight)
-                updates["veto_reasons"] = single.veto_reasons + [f"[Portfolio] SLSQP cap: {cap:.1%}"]
+                updates.update(_apply_portfolio_cap(single, ticker_cap_map[ticker]))
 
             # Portfolio-level veto overrides all individual verdicts to prevent partial allocation
             if portfolio_vetoed:
@@ -410,7 +447,7 @@ def build_graph(
                 else single
             )
 
-        return {"risk_assessments": assessments}
+        return {"risk_assessments": assessments, "errors": errors}
 
     def node_portfolio_allocation(state: ARGUSState) -> dict:
         """Determines capital allocations using specialist ratings, risk targets, and memory heuristics.

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 6
+PARAMS_VERSION = 7
 
 
 class Provenance(str, Enum):
@@ -197,7 +197,8 @@ class RiskParams:
     min_positions_diversification: int = p(5, Provenance.ARBITRARY, "no basis for this specific minimum")
     max_positions: int = p(20, Provenance.ARBITRARY, "no basis for this specific maximum")
     slsqp_risk_aversion: float = p(1.0, Provenance.ARBITRARY, "equal weighting of conviction return vs variance; not tuned")
-    slsqp_min_equity_deployment: float = p(0.50, Provenance.ARBITRARY, "no basis for this specific floor")
+    slsqp_max_total_deployment: float = p(1.0, Provenance.CONVENTION, "a long-only book cannot exceed its capital")
+    slsqp_zero_cap_epsilon: float = p(1e-3, Provenance.ARBITRARY, "cap below this is treated as no room to allocate, not a real position")
     slsqp_ftol: float = p(1e-9, Provenance.CONVENTION, "typical SciPy SLSQP convergence tolerance")
     slsqp_maxiter: int = p(300, Provenance.CONVENTION, "typical SciPy SLSQP iteration cap")
     var_limit: float = p(0.03, Provenance.ARBITRARY, "no basis for this specific daily VaR ceiling")

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -371,6 +371,14 @@ class RiskAssessment(BaseModel):
             "Populated for multi-asset portfolio-level calls; empty for single-ticker calls."
         ),
     )
+    optimizer_converged: bool | None = Field(
+        None,
+        description=(
+            "Whether the SLSQP solve reported success. None when the solver was never "
+            "invoked (single-asset call). False means optimal_weights is empty and no "
+            "portfolio-level cap was applied."
+        ),
+    )
 
     api_calls_used: int = Field(0, ge=0)
     timestamp: datetime = Field(..., description="UTC timestamp of signal production")

--- a/tests/test_risk_properties.py
+++ b/tests/test_risk_properties.py
@@ -17,6 +17,11 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from argus.agents.risk import RiskStatisticalEngine
+from argus.orchestration.graph import _apply_portfolio_cap
+from argus.params import RISK
+from argus.schemas.signals import RiskVerdict
+
+_UNIVERSE = ["AAPL", "MSFT", "GOOGL", "META", "AMZN", "TSLA", "JPM", "BAC"]
 
 
 def _price_history() -> dict[str, pd.Series]:
@@ -24,6 +29,17 @@ def _price_history() -> dict[str, pd.Series]:
     dates = pd.date_range(start="2023-01-01", periods=253, freq="B")
     hist = {}
     for t in ["AAPL", "MSFT", "GOOGL"]:
+        returns = np.random.normal(0.001, 0.015, len(dates))
+        prices = 100 * np.exp(np.cumsum(returns))
+        hist[t] = pd.Series(prices, index=dates)
+    return hist
+
+
+def _multi_asset_price_history() -> dict[str, pd.Series]:
+    np.random.seed(7)
+    dates = pd.date_range(start="2023-01-01", periods=253, freq="B")
+    hist = {}
+    for t in _UNIVERSE:
         returns = np.random.normal(0.001, 0.015, len(dates))
         prices = 100 * np.exp(np.cumsum(returns))
         hist[t] = pd.Series(prices, index=dates)
@@ -44,3 +60,59 @@ def test_approved_weight_never_exceeds_proposed(weight: float, vix: float) -> No
 
     # RiskAssessment's validator would raise on construction if this were violated
     assert result.approved_weight <= result.proposed_weight + 1e-9
+
+
+@settings(deadline=None, max_examples=50)
+@given(
+    tickers=st.lists(
+        st.sampled_from(_UNIVERSE),
+        min_size=RISK.min_positions_diversification,
+        max_size=len(_UNIVERSE),
+        unique=True,
+    ),
+    data=st.data(),
+)
+def test_optimal_weights_never_exceed_total_deployment_budget(tickers: list[str], data) -> None:
+    """RE-1 regression: the SLSQP solve never deploys more than the book's capital.
+
+    Before the fix, the optimizer had a sum(w) >= 0.50 floor and no upper bound,
+    so a sufficiently bullish conviction vector could solve past 100% deployment.
+    """
+    engine = RiskStatisticalEngine()
+    # Mirrors graph.py's node_risk_evaluation: even split, capped at the single-position limit
+    base_weight = min(0.15, 1.0 / len(tickers))
+    positions = [{"ticker": t, "weight": base_weight} for t in tickers]
+    convictions = {
+        t: data.draw(st.floats(min_value=-1.0, max_value=1.0, allow_nan=False)) for t in tickers
+    }
+
+    result = engine.evaluate(
+        positions, _multi_asset_price_history(), current_vix=20.0, convictions=convictions
+    )
+
+    assert sum(result.optimal_weights.values()) <= RISK.slsqp_max_total_deployment + 1e-6
+
+
+def test_all_negative_convictions_veto_not_reduce_at_zero() -> None:
+    """RE-1 guard: a near-zero SLSQP cap becomes VETO, not REDUCE-to-zero.
+
+    REDUCE still counts as an approved ticker downstream (portfolio.py:236), so a
+    0%-cap REDUCE would leave the portfolio agent demanding invest_pct deployment
+    against a cap with no room for it — this is the bug _apply_portfolio_cap closes.
+    """
+    engine = RiskStatisticalEngine()
+    history = _multi_asset_price_history()
+    tickers = _UNIVERSE[:5]
+    positions = [{"ticker": t, "weight": 0.15} for t in tickers]
+    convictions = {t: -0.9 for t in tickers}
+
+    portfolio_result = engine.evaluate(positions, history, current_vix=20.0, convictions=convictions)
+
+    assert portfolio_result.optimizer_converged is True
+    assert sum(portfolio_result.optimal_weights.values()) < RISK.slsqp_zero_cap_epsilon
+
+    for ticker in tickers:
+        single = engine.evaluate([{"ticker": ticker, "weight": 0.15}], history, current_vix=20.0)
+        updates = _apply_portfolio_cap(single, portfolio_result.optimal_weights[ticker])
+        assert updates["verdict"] == RiskVerdict.VETO
+        assert updates["approved_weight"] == 0.0


### PR DESCRIPTION
## Summary

- Decision B step 2 from #24: delete `RISK.slsqp_min_equity_deployment` (the `sum(w) >= 0.50` floor that forced deployment into an all-bearish book) and replace it with `RISK.slsqp_max_total_deployment = 1.0` as an upper-bound constraint — a long-only book cannot exceed its capital (RE-1).
- Add the cap-below-epsilon guard: a per-ticker SLSQP cap under `RISK.slsqp_zero_cap_epsilon` now downgrades to `RiskVerdict.VETO` instead of `REDUCE`-to-zero. REDUCE still counts as approved downstream (`portfolio.py:236`), so a 0%-cap REDUCE would leave the portfolio agent demanding `invest_pct` deployment against a cap with no room for it. Extracted the cap→verdict mapping into a standalone `_apply_portfolio_cap` helper so this is unit-testable without spinning up the whole graph.
- Report `res.success == False` through `RiskAssessment.optimizer_converged` and `ARGUSState.errors` (RE-8) — previously a failed solve left `optimal_weights = {}` and silently applied no cap at all, indistinguishable from "enforcement passed."
- Bumped `PARAMS_VERSION` to 7.

## Test plan

- [x] `tests/test_risk_properties.py::test_optimal_weights_never_exceed_total_deployment_budget` — Hypothesis property over random universes/conviction vectors asserting `sum(optimal_weights) <= 1.0 + 1e-6`
- [x] `tests/test_risk_properties.py::test_all_negative_convictions_veto_not_reduce_at_zero` — reproduces the audit's all-bearish case and asserts VETO, not REDUCE-at-zero
- [x] `.venv/bin/python -m pytest tests/ -q` — 217 passed
- [x] `.venv/bin/ruff check .` on changed files — clean
- [x] `.venv/bin/mypy argus api scripts` — no new errors (4 pre-existing, unrelated to this change)

Part of #24.