### PR TITLE
Enforce risk decisions in code

### DIFF
--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -6,10 +6,11 @@ Generative portfolio construction and allocation manager agent.
 Responsibilities:
   - Synthesize specialist analyst inputs into optimized portfolio allocations
   - Apply Half-Kelly position sizing bounded by risk engine ceilings
+  - Enforce risk-engine verdicts and caps on the LLM's proposal before validation
   - Produce per-position advisor notes for client-facing rationale
 
 Not responsible for:
-  - Risk enforcement or statistical limit checking (see agents/risk.py)
+  - Computing statistical risk limits — VaR, CVaR, correlation (see agents/risk.py)
   - Signal aggregation (see orchestration/aggregator.py)
   - Macro regime classification (see agents/macro.py)
 
@@ -24,14 +25,14 @@ import json
 import logging
 import time
 from datetime import datetime
-from typing import Optional
+from typing import Optional, TypeGuard
 from uuid import uuid4
 
 import numpy as np
 
 from argus.config import settings
 from argus.params import PORTFOLIO
-from argus.schemas.signals import MacroContext, PortfolioAllocation, RiskVerdict
+from argus.schemas.signals import MacroContext, PortfolioAllocation, RiskAssessment, RiskVerdict
 from argus.seams import GroqLLMClient, LLMClient
 
 logger = logging.getLogger("argus.portfolio")
@@ -68,6 +69,19 @@ def half_kelly_weight(
     return float(np.clip(half_kelly, 0.0, max_position))
 
 
+def _is_risk_approved(risk: Optional[RiskAssessment]) -> TypeGuard[RiskAssessment]:
+    """Whether a ticker's risk verdict permits an equity allocation.
+
+    Args:
+        risk: The ticker's RiskAssessment, or None if the risk node never evaluated it.
+
+    Returns:
+        True for APPROVE or REDUCE; False for VETO or a missing assessment. Shared
+        by the prompt table and post-LLM enforcement so the two cannot drift.
+    """
+    return risk is not None and risk.verdict in (RiskVerdict.APPROVE, RiskVerdict.REDUCE)
+
+
 def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContext]) -> str:
     """Constructs a consolidated prompt table mapping approved specialist signal values.
 
@@ -98,7 +112,7 @@ def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContex
 
     for ticker, sigs in all_signals.items():
         risk = sigs.get("risk")
-        if not risk or risk.verdict not in (RiskVerdict.APPROVE, RiskVerdict.REDUCE):
+        if not _is_risk_approved(risk):
             continue
 
         f = sigs.get("fundamental")
@@ -110,16 +124,12 @@ def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContex
         tsig = f"{t.signal.value}({t.conviction:.2f})" if t else "N/A"
         ssig = f"{s.signal.value}({s.conviction:.2f})" if s else "N/A"
         asig = f"{agg.signal.value}({agg.conviction:.2f})" if agg else "N/A"
-        stop = risk.stop_loss
-        if isinstance(stop, float):
-            stop = f"{stop:.2f}"
-        else:
-            stop = "N/A"
+        stop_display = f"{risk.stop_loss:.2f}" if isinstance(risk.stop_loss, float) else "N/A"
         evidence = f"{len(agg.agents_present)}/3" if agg else "0/3"
 
         line = (
             f"{ticker}: FUND={fsig} TECH={tsig} SENT={ssig} AGG={asig} Evidence={evidence} "
-            f"VaR={risk.var_99:.2%} Beta={risk.portfolio_beta:.2f} Stop={stop} Cap={risk.approved_weight:.1%}"
+            f"VaR={risk.var_99:.2%} Beta={risk.portfolio_beta:.2f} Stop={stop_display} Cap={risk.approved_weight:.1%}"
         )
         lines.append(line)
 
@@ -204,6 +214,7 @@ class PortfolioManagerAgent:
         macro: Optional[MacroContext],
         cultural_wisdom: Optional[list[str]] = None,
         cultural_warnings: Optional[list[str]] = None,
+        adjustments: Optional[list[str]] = None,
     ) -> Optional[PortfolioAllocation]:
         """Aggregates all specialist agent verdicts to construct a consolidated PortfolioAllocation.
 
@@ -221,20 +232,20 @@ class PortfolioManagerAgent:
             cultural_wisdom: Optional list of historical wisdom strings from cultural memory.
             cultural_warnings: Optional list of failed-trade pattern strings from
                 cultural memory, scoped to the current macro regime.
+            adjustments: Optional list that receives one human-readable entry per
+                clamped, zeroed, or dropped position — the caller's record of
+                where the LLM's proposal disagreed with risk enforcement.
 
         Returns:
             A validated PortfolioAllocation, all-cash if no tickers are approved, or None
             if all 3 LLM retry attempts fail.
         """
-        investable = float(user_profile.get("total_wealth", 0.0)) * float(
+        total_wealth = user_profile.get("total_wealth")
+        investable = (float(total_wealth) if total_wealth is not None else 0.0) * float(
             user_profile.get("invest_pct", 1.0)
         )
 
-        approved_tickers = [
-            t
-            for t, s in all_signals.items()
-            if s.get("risk") and s["risk"].verdict in (RiskVerdict.APPROVE, RiskVerdict.REDUCE)
-        ]
+        approved_tickers = [t for t, s in all_signals.items() if _is_risk_approved(s.get("risk"))]
 
         if not approved_tickers:
             logger.debug("[Portfolio] No approved tickers. Reverting to all-cash.")
@@ -318,21 +329,61 @@ class PortfolioManagerAgent:
 
                 data = json.loads(raw)
 
-                # Convert percentage allocations to fiat quantities before schema validation
+                # Enforce risk verdicts in code: the LLM's proposal is advisory input,
+                # not a binding allocation, so it cannot be trusted to respect caps it
+                # was merely shown in the prompt.
+                enforced_portfolio = []
                 for pos in data.get("portfolio", []):
-                    pos["allocation_usd"] = round(investable * pos["allocation_pct"], 2)
                     ticker = pos["ticker"]
+                    if ticker not in all_signals:
+                        msg = (
+                            f"portfolio_allocation: dropped {ticker} "
+                            "(not in this session's signal universe)"
+                        )
+                        logger.warning(msg)
+                        if adjustments is not None:
+                            adjustments.append(msg)
+                        continue
+
+                    risk = all_signals[ticker].get("risk")
+                    proposed_pct = pos.get("allocation_pct", 0.0)
+                    if not _is_risk_approved(risk):
+                        if proposed_pct:
+                            verdict = risk.verdict.value if risk else "MISSING"
+                            msg = (
+                                f"portfolio_allocation: zeroed {ticker} allocation "
+                                f"(risk verdict {verdict})"
+                            )
+                            logger.warning(msg)
+                            if adjustments is not None:
+                                adjustments.append(msg)
+                        pos["allocation_pct"] = 0.0
+                    else:
+                        cap = risk.approved_weight
+                        if proposed_pct > cap + 1e-9:
+                            msg = (
+                                f"portfolio_allocation: clamped {ticker} allocation from "
+                                f"{proposed_pct:.4f} to risk cap {cap:.4f}"
+                            )
+                            logger.warning(msg)
+                            if adjustments is not None:
+                                adjustments.append(msg)
+                            pos["allocation_pct"] = cap
+
+                    pos["allocation_usd"] = round(investable * pos["allocation_pct"], 2)
                     if "thesis" in pos and isinstance(pos["thesis"], str):
                         pos["thesis"] = pos["thesis"][:PORTFOLIO.thesis_char_limit]
                     if "advisor_note" in pos and isinstance(pos["advisor_note"], str):
                         pos["advisor_note"] = pos["advisor_note"][:PORTFOLIO.advisor_note_char_limit]
-                    if ticker in all_signals and all_signals[ticker].get("risk"):
-                        engine_stop = all_signals[ticker]["risk"].stop_loss
-                        if engine_stop is not None:
-                            pos["stop_loss"] = float(engine_stop)
+                    if risk is not None and risk.stop_loss is not None:
+                        pos["stop_loss"] = float(risk.stop_loss)
+
+                    enforced_portfolio.append(pos)
+
+                data["portfolio"] = enforced_portfolio
 
                 # Force residual exact; LLM may set cash_reserve_pct independently, not as 1-equity
-                total_equity = sum(p["allocation_pct"] for p in data.get("portfolio", []))
+                total_equity = sum(p["allocation_pct"] for p in data["portfolio"])
                 data["cash_reserve_pct"] = round(max(0.0, 1.0 - total_equity), 6)
 
                 data["session_id"] = str(uuid4())

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -486,7 +486,9 @@ def build_graph(
         wisdom = mem.get("wisdom", [])
         warnings = mem.get("warnings", [])
 
-        alloc = portfolio_agent.allocate(profile, signals_dict, macro, wisdom, warnings)
+        alloc = portfolio_agent.allocate(
+            profile, signals_dict, macro, wisdom, warnings, adjustments=errors
+        )
         if alloc is None:
             logger.error(
                 "node_portfolio_allocation: PortfolioManagerAgent returned None (LLM API failure). "

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -188,11 +188,23 @@ def test_golden_dag_runs_offline_and_produces_a_valid_allocation():
     assert final_state.get("sentiment_signals")
     assert final_state.get("risk_assessments")
     assert final_state.get("aggregated_signals")
-    assert final_state.get("errors") == []
+
+    # The fixture LLM response proposes allocations for three VETO'd tickers;
+    # code-level enforcement (PR 4, PA-1) zeroes them rather than trusting the
+    # prompt, and records each correction here instead of leaving errors empty.
+    errors = final_state.get("errors")
+    assert errors is not None and len(errors) == 3
+    for ticker in ("MSFT", "JPM", "GOOGL"):
+        assert any(
+            f"zeroed {ticker} allocation (risk verdict VETO)" in e for e in errors
+        )
 
     alloc = final_state.get("portfolio_allocation")
     assert alloc is not None
     assert len(alloc.portfolio) == len(UNIVERSE)
+    for pos in alloc.portfolio:
+        if pos.ticker in ("MSFT", "JPM", "GOOGL"):
+            assert pos.allocation_pct == 0.0
 
 
 def test_missing_indicator_is_reported_in_errors_not_silently_dropped():

--- a/tests/test_portfolio_enforcement.py
+++ b/tests/test_portfolio_enforcement.py
@@ -1,0 +1,100 @@
+"""
+tests/test_portfolio_enforcement.py
+
+Regression tests for PA-1: PortfolioManagerAgent.allocate() must enforce risk
+verdicts and caps in code, not merely display them in the prompt. Reproduces
+the audit's finding that an over-cap allocation, a VETO'd ticker, and a
+fabricated ticker all validated cleanly.
+"""
+
+import json
+from datetime import datetime
+
+from argus.agents.portfolio import PortfolioManagerAgent
+from argus.schemas.signals import RiskAssessment, RiskVerdict
+from argus.seams import FixtureLLMClient
+
+TIMESTAMP = datetime(2026, 1, 1)
+
+
+def _risk(verdict: RiskVerdict, approved_weight: float, proposed_weight: float) -> RiskAssessment:
+    return RiskAssessment(
+        verdict=verdict,
+        approved_weight=approved_weight,
+        proposed_weight=proposed_weight,
+        var_99=0.05,
+        portfolio_beta=1.0,
+        timestamp=TIMESTAMP,
+    )
+
+
+def _llm_response(portfolio: list[dict]) -> FixtureLLMClient:
+    body = {
+        "portfolio": portfolio,
+        "cash_reserve_pct": 0.5,
+        "expected_sharpe": None,
+        "rebalance_trigger": "MONTHLY",
+    }
+    return FixtureLLMClient({"only": json.dumps(body)}, key_fn=lambda _prompt: "only")
+
+
+def test_allocate_enforces_caps_vetoes_and_fabrications_in_code():
+    """An over-cap allocation is clamped, a VETO'd ticker is zeroed-not-dropped,
+
+    and a fabricated ticker absent from all_signals is dropped — each producing
+    an adjustments entry rather than validating silently.
+    """
+    all_signals = {
+        "OVER_CAP": {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)},
+        "VETOED": {"risk": _risk(RiskVerdict.VETO, approved_weight=0.0, proposed_weight=0.10)},
+    }
+
+    llm_client = _llm_response(
+        [
+            {
+                "ticker": "OVER_CAP",
+                "allocation_pct": 0.15,
+                "stop_loss": 100.0,
+                "thesis": "Bullish",
+                "composite_conviction": 0.7,
+                "time_horizon": "3-6 months",
+            },
+            {
+                "ticker": "VETOED",
+                "allocation_pct": 0.08,
+                "stop_loss": 50.0,
+                "thesis": "Should have been skipped",
+                "composite_conviction": 0.6,
+                "time_horizon": "3-6 months",
+            },
+            {
+                "ticker": "FABRICATED",
+                "allocation_pct": 0.05,
+                "stop_loss": 20.0,
+                "thesis": "Never analyzed",
+                "composite_conviction": 0.5,
+                "time_horizon": "3-6 months",
+            },
+        ]
+    )
+
+    agent = PortfolioManagerAgent(llm_client=llm_client)
+    adjustments: list[str] = []
+    alloc = agent.allocate(
+        user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
+        all_signals=all_signals,
+        macro=None,
+        adjustments=adjustments,
+    )
+
+    assert alloc is not None
+    positions = {pos.ticker: pos for pos in alloc.portfolio}
+
+    assert positions["OVER_CAP"].allocation_pct == 0.10
+    assert positions["VETOED"].allocation_pct == 0.0
+    assert "FABRICATED" not in positions
+
+    assert any("clamped OVER_CAP allocation from 0.1500 to risk cap 0.1000" in a for a in adjustments)
+    assert any("zeroed VETOED allocation (risk verdict VETO)" in a for a in adjustments)
+    assert any("dropped FABRICATED" in a for a in adjustments)
+    assert len(adjustments) == 3


### PR DESCRIPTION
## Summary

- Decision from #24, PR 4: `PortfolioManagerAgent` put risk verdicts and weight caps into the LLM prompt and never checked the response against them (PA-1, Critical) — a ticker capped at 2% could be allocated 15%, a VETO'd ticker could get 15%, and a fabricated ticker could get 10%, all validating cleanly.
- In `agents/portfolio.py`, after `json.loads` and before `model_validate`: zero-and-keep any ticker not APPROVE/REDUCE (dropping would break `len(alloc.portfolio) == len(UNIVERSE)` and contradict prompt rule 6), clamp survivors to `approved_weight`, and drop only tickers absent from `all_signals` entirely (fabrications).
- Extracted the APPROVE/REDUCE predicate `build_signal_table` already used into `_is_risk_approved`, a `TypeGuard`, so the prompt and enforcement can't drift.
- Moved the `cash_reserve_pct` recomputation below the clamp so it reflects enforced, not proposed, allocations.
- Added an `adjustments: list[str] | None = None` out-parameter that `allocate` appends to for every clamp/zero/drop; `node_portfolio_allocation` passes its `errors` list.
- **PA-7:** `float(user_profile.get("total_wealth", 0.0))` only applies its default when the key is absent, so an explicit `None` raised outside the retry guard. Coerced.

This depends on PR 3 (#27, not yet merged) for a real `approved_weight` to enforce against, so it's based on `fix/slsqp-budget` rather than `main`.

## Test plan

- [x] `tests/test_portfolio_enforcement.py::test_allocate_enforces_caps_vetoes_and_fabrications_in_code` — new: a `FixtureLLMClient` returning an over-cap allocation, a VETO'd ticker, and a fabricated ticker; asserts all three are corrected and each produces an `adjustments` entry
- [x] `tests/test_golden_dag.py::test_golden_dag_runs_offline_and_produces_a_valid_allocation` — updated: the fixture LLM response proposes allocations for three VETO'd tickers (MSFT, JPM, GOOGL); asserts they're zeroed with the specific adjustment content, replacing the emptiness check the old prompt-only behavior let pass
- [x] `.venv/bin/python -m pytest tests/ -q` — 218 passed
- [x] `.venv/bin/ruff check .` — clean
- [x] `.venv/bin/mypy argus api scripts` — no new errors (4 pre-existing, unrelated to this change)

Part of #24.