### PR TITLE
Make the pipeline observable

### DIFF
--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -68,14 +68,19 @@ jobs:
         run: |
           mkdir -p publish
           cp -r chroma_db publish/chroma_db
-          [ -f data/decisions.jsonl ] && cp data/decisions.jsonl publish/decisions.jsonl
+          if [ -f data/decisions.jsonl ]; then
+            cp data/decisions.jsonl publish/decisions.jsonl
+          else
+            echo "::warning::decisions.jsonl absent after this cycle — nothing has ever been logged"
+          fi
           # Merge rather than overwrite — reconcile.yml writes to the same
           # status.json on the same branch and its field must survive this
           ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          reason="$(jq -r '.reason // "unknown"' data/collector_result.json 2>/dev/null || echo unknown)"
           if [ -f state/status.json ]; then
-            jq --arg t "$ts" '. + {last_run: $t}' state/status.json > publish/status.json
+            jq --arg t "$ts" --arg r "$reason" '. + {last_run: $t, last_reason: $r}' state/status.json > publish/status.json
           else
-            printf '{"last_run": "%s"}\n' "$ts" > publish/status.json
+            jq -n --arg t "$ts" --arg r "$reason" '{last_run: $t, last_reason: $r}' > publish/status.json
           fi
           rm -rf state
           cd publish

--- a/api/main.py
+++ b/api/main.py
@@ -266,6 +266,7 @@ class AnalysisResponse(BaseModel):
     vix_level: float
     governor_report: dict
     timestamp: str
+    errors: list[str] = []
 
 
 @app.get("/health")
@@ -428,6 +429,7 @@ async def analyze(req: AnalysisRequest):
         vix_level=vix_level,
         governor_report=governor.get_usage_report(),
         timestamp=datetime.now().isoformat(),
+        errors=final_state.get("errors") or [],
     )
 
 

--- a/argus/backtesting/replay.py
+++ b/argus/backtesting/replay.py
@@ -184,7 +184,7 @@ def replay_session(
                 mock_get_cultural_memory.return_value = mock.Mock(
                     retrieve_wisdom=mock.Mock(return_value=[]),
                     retrieve_warnings=mock.Mock(return_value=[]),
-                    get_agent_accuracy=mock.Mock(return_value=0.5),
+                    get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
                     store_decision_snapshot=mock.Mock(),
                 )
             final_state = graph.invoke(state, config)

--- a/argus/memory/cultural.py
+++ b/argus/memory/cultural.py
@@ -258,7 +258,7 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
         agent_name: str,
         regime: Optional[str] = None,
         as_of: Optional[datetime] = None,
-    ) -> float:
+    ) -> tuple[float, int]:
         """Computes shrunk statistical win rates for trades driven primarily by a specific specialist agent.
 
         Win rate is shrunk toward the 0.5 neutral prior by
@@ -279,10 +279,13 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
                 passes it to avoid reading future outcomes.
 
         Returns:
-            Shrunk win rate as a float in [0, 1]. Returns 0.5 (neutral prior) when no data exists.
+            (rate, n) — the shrunk win rate in [0, 1], and the raw sample count it
+            was computed from. n distinguishes "0.5 because no data exists" from
+            "0.5 because that's the measured rate"; callers that need to gate on
+            data actually existing (e.g. the Kelly anchor) should check n, not rate.
         """
         if self.collection.count() == 0:
-            return 0.5
+            return 0.5, 0
 
         try:
             conditions: list[dict[str, Any]] = [{"primary_driver": agent_name.lower()}]
@@ -294,15 +297,15 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
             results = self.collection.get(where=_where(conditions))  # type: ignore[arg-type]
             metadatas = results.get("metadatas", [])
             if not metadatas:
-                return 0.5
+                return 0.5, 0
 
             wins = sum(1 for m in metadatas if m.get("outcome") == "SUCCESSFUL")
             n = len(metadatas)
             k = MEMORY.accuracy_shrinkage_k
-            return (float(wins) + k * 0.5) / (n + k)
+            return (float(wins) + k * 0.5) / (n + k), n
         except Exception as e:
             logger.warning("[Memory] Failed to compute agent accuracy: %s", e)
-            return 0.5
+            return 0.5, 0
 
     def summary_stats(self) -> dict:
         """Compiles aggregate performance statistics and regime diagnostics from the memory database.

--- a/argus/orchestration/collector.py
+++ b/argus/orchestration/collector.py
@@ -50,6 +50,7 @@ class CollectionResult:
     tickers_with_session_data: list[str] = field(default_factory=list)
     decisions_logged: int = 0
     macro_regime: str | None = None
+    errors: list[str] = field(default_factory=list)
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
 
 
@@ -154,6 +155,7 @@ async def run_collection_cycle(
 
     decisions: list[ARGUSDecision] = final_state.get("decisions") or []
     logged = _append_decisions_jsonl(decisions, decisions_log_path)
+    errors = final_state.get("errors") or []
 
     macro_context = final_state.get("macro_context")
     macro_regime = macro_context.macro_regime.value if macro_context else None
@@ -167,4 +169,5 @@ async def run_collection_cycle(
         tickers_with_session_data=tickers_with_data,
         decisions_logged=logged,
         macro_regime=macro_regime,
+        errors=errors,
     )

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -25,8 +25,8 @@ Agent wiring is a build_graph() parameter, not a module-level singleton:
 every agent that touches the network or an LLM accepts a
 MarketDataProvider/LLMClient, defaulting to the real implementation, so a
 test can build a fixture-backed graph without patching this module's
-internals. `graph` below is the default, real-data instance — the one
-api/main.py imports.
+internals. Callers — api/main.py, orchestration/collector.py — call
+build_graph() themselves rather than importing a shared instance.
 """
 
 import logging
@@ -341,7 +341,7 @@ def build_graph(
             try:
                 memory = get_cultural_memory()
                 reliability = {
-                    name: memory.get_agent_accuracy(name, regime=regime, as_of=as_of)
+                    name: memory.get_agent_accuracy(name, regime=regime, as_of=as_of)[0]
                     for name in agent_names
                 }
             except ImportError as exc:
@@ -595,7 +595,3 @@ def build_graph(
         checkpointer = None
 
     return builder.compile(checkpointer=checkpointer)
-
-
-# Default, real-data graph — what api/main.py imports and invokes in production.
-graph = build_graph()

--- a/scripts/collect_session.py
+++ b/scripts/collect_session.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import dataclasses
+import json
 import logging
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -61,6 +64,12 @@ def main() -> None:
         default=f"{settings.ARGUS_DATA_DIR}/decisions.jsonl",
         help="JSONL file each cycle's decisions are appended to",
     )
+    parser.add_argument(
+        "--result-out",
+        default=f"{settings.ARGUS_DATA_DIR}/collector_result.json",
+        help="Where to write this cycle's CollectionResult as JSON, for the "
+        "scheduled workflow to fold into status.json",
+    )
     args = parser.parse_args()
 
     universe = [t.strip() for t in args.universe.split(",") if t.strip()] if args.universe else settings.ARGUS_UNIVERSE
@@ -78,6 +87,9 @@ def main() -> None:
         )
     )
     pipeline.buffer.close()
+
+    Path(args.result_out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.result_out).write_text(json.dumps(dataclasses.asdict(result)))
 
     print(f"ran={result.ran} reason={result.reason!r}")
     if result.ran:

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -57,7 +57,7 @@ def test_replay_session_closed_loop_scopes_cultural_memory_to_the_session_date()
     mock_memory = mock.Mock(
         retrieve_wisdom=mock.Mock(return_value=[]),
         retrieve_warnings=mock.Mock(return_value=[]),
-        get_agent_accuracy=mock.Mock(return_value=0.5),
+        get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
         store_decision_snapshot=mock.Mock(),
     )
     with mock.patch("argus.orchestration.graph.get_cultural_memory", return_value=mock_memory):

--- a/tests/test_cultural.py
+++ b/tests/test_cultural.py
@@ -61,9 +61,9 @@ def _macro(regime: Regime = Regime.EXPANSION, vix_regime: VixRegime = VixRegime.
 
 
 def test_zero_observations_returns_prior():
-    """With no stored outcomes, accuracy falls back to the prior."""
+    """With no stored outcomes, accuracy falls back to the prior with n=0."""
     manager = _manager_with_metadatas([])
-    assert manager.get_agent_accuracy("technical") == 0.5
+    assert manager.get_agent_accuracy("technical") == (0.5, 0)
 
 
 def test_small_sample_shrinks_toward_prior_instead_of_reporting_the_raw_rate():
@@ -72,12 +72,13 @@ def test_small_sample_shrinks_toward_prior_instead_of_reporting_the_raw_rate():
     metadatas = [{"outcome": "SUCCESSFUL", "primary_driver": "technical"}] * 2
     manager = _manager_with_metadatas(metadatas)
 
-    accuracy = manager.get_agent_accuracy("technical")
+    accuracy, n = manager.get_agent_accuracy("technical")
     k = MEMORY.accuracy_shrinkage_k
     expected = (2 + k * 0.5) / (2 + k)
 
     assert accuracy == expected
     assert 0.5 < accuracy < 1.0
+    assert n == 2
 
 
 def test_large_sample_converges_to_the_raw_win_rate():
@@ -88,7 +89,9 @@ def test_large_sample_converges_to_the_raw_win_rate():
     )
     manager = _manager_with_metadatas(metadatas)
 
-    assert abs(manager.get_agent_accuracy("technical") - 0.9) < 0.01
+    accuracy, n = manager.get_agent_accuracy("technical")
+    assert abs(accuracy - 0.9) < 0.01
+    assert n == 1000
 
 
 def test_flat_outcomes_count_as_non_wins_in_the_denominator():
@@ -103,11 +106,12 @@ def test_flat_outcomes_count_as_non_wins_in_the_denominator():
     ]
     manager = _manager_with_metadatas(metadatas)
 
-    accuracy = manager.get_agent_accuracy("technical")
+    accuracy, n = manager.get_agent_accuracy("technical")
     k = MEMORY.accuracy_shrinkage_k
     expected = (1 + k * 0.5) / (2 + k)
 
     assert accuracy == expected
+    assert n == 2
 
 
 def test_get_agent_accuracy_as_of_filters_on_timestamp():

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -118,7 +118,7 @@ def _run_fixture_graph() -> dict:
         mock_get_cultural_memory.return_value = mock.Mock(
             retrieve_wisdom=mock.Mock(return_value=[]),
             retrieve_warnings=mock.Mock(return_value=[]),
-            get_agent_accuracy=mock.Mock(return_value=0.5),
+            get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
             store_decision_snapshot=mock.Mock(),
         )
         final_state = graph.invoke(_initial_state(), config)
@@ -159,7 +159,7 @@ def test_macro_context_none_still_produces_a_degraded_allocation():
         mock_get_cultural_memory.return_value = mock.Mock(
             retrieve_wisdom=mock.Mock(return_value=[]),
             retrieve_warnings=mock.Mock(return_value=[]),
-            get_agent_accuracy=mock.Mock(return_value=0.5),
+            get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
             store_decision_snapshot=mock.Mock(),
         )
         final_state = graph.invoke(_initial_state(), config)
@@ -231,7 +231,7 @@ def test_missing_indicator_is_reported_in_errors_not_silently_dropped():
         mock_get_cultural_memory.return_value = mock.Mock(
             retrieve_wisdom=mock.Mock(return_value=[]),
             retrieve_warnings=mock.Mock(return_value=[]),
-            get_agent_accuracy=mock.Mock(return_value=0.5),
+            get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
             store_decision_snapshot=mock.Mock(),
         )
         final_state = graph.invoke(state, config)
@@ -277,7 +277,7 @@ def test_missing_indicator_still_reaches_aggregation_with_evidence_surfaced():
         mock_get_cultural_memory.return_value = mock.Mock(
             retrieve_wisdom=mock.Mock(return_value=[]),
             retrieve_warnings=mock.Mock(return_value=[]),
-            get_agent_accuracy=mock.Mock(return_value=0.5),
+            get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
             store_decision_snapshot=mock.Mock(),
         )
         final_state = graph.invoke(state, config)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,7 +22,7 @@ from argus.agents.risk import RiskStatisticalEngine
 from argus.agents.technical import TechnicalStatisticalAgent
 from argus.data.pipeline import MFTDataPipeline
 from argus.orchestration.governor import BOOTSTRAP_LIMITS, governor
-from argus.orchestration.graph import graph
+from argus.orchestration.graph import build_graph
 from argus.orchestration.state import ARGUSState
 from argus.risk.kill_switch import KillSwitch
 from argus.schemas.signals import (
@@ -90,7 +90,7 @@ class TestEndToEnd:
     @mock.patch("argus.orchestration.graph.get_cultural_memory")
     @mock.patch("argus.agents.fundamental.FundamentalAgent.analyze")
     @mock.patch("argus.agents.sentiment.SentimentAgent.analyze")
-    async def test_full_graph_smoke(self, mock_sent, mock_fund, mock_cultural_memory):
+    async def test_full_graph_smoke(self, mock_sent, mock_fund, mock_cultural_memory, tmp_path):
         """Runs the complete LangGraph graph for AAPL, MSFT using mocked LLMs.
 
         Cultural memory is mocked out (not just left real) because its embedding
@@ -102,11 +102,13 @@ class TestEndToEnd:
             mock_sent: Patched SentimentAgent.analyze.
             mock_fund: Patched FundamentalAgent.analyze.
             mock_cultural_memory: Patched get_cultural_memory.
+            tmp_path: Pytest tempdir, so this run's checkpoint never lands in
+                the production argus_graph.db.
         """
         mock_cultural_memory.return_value = mock.Mock(
             retrieve_wisdom=mock.Mock(return_value=[]),
             retrieve_warnings=mock.Mock(return_value=[]),
-            get_agent_accuracy=mock.Mock(return_value=0.5),
+            get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
             store_decision_snapshot=mock.Mock(),
         )
 
@@ -189,6 +191,7 @@ class TestEndToEnd:
         )
 
         config = {"configurable": {"thread_id": str(uuid4())}}
+        graph = build_graph(checkpoint_db_path=str(tmp_path / "argus_graph_test.db"))
 
         try:
             final_state = await asyncio.to_thread(graph.invoke, state, config)

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -529,7 +529,7 @@ def test_load_decisions_from_checkpoints_round_trips_a_real_graph_run(tmp_path):
         mock_get_cultural_memory.return_value = mock.Mock(
             retrieve_wisdom=mock.Mock(return_value=[]),
             retrieve_warnings=mock.Mock(return_value=[]),
-            get_agent_accuracy=mock.Mock(return_value=0.5),
+            get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
             store_decision_snapshot=mock.Mock(),
         )
         graph.invoke({**state}, {"configurable": {"thread_id": "test-thread"}})


### PR DESCRIPTION
## Summary

PR 0 from #24, done out of order — it was skipped when PRs 1-4 landed, and PR 5 needs its `get_agent_accuracy` prerequisite.

- **X-1:** `errors` now flows through `AnalysisResponse` (api/main.py) and `CollectionResult` (collector.py). The scheduled collector workflow publishes the cycle's `reason` into `status.json` on `argus-data`, and warns loudly instead of no-opping when `decisions.jsonl` is absent.
- **X-2:** deleted the module-level `graph = build_graph()` singleton — its only importer was `tests/test_integration.py`, via `argus-reconcile`'s transitive import, which built the whole agent stack and leaked a SQLite connection it never used. That test now builds its own graph with a tmp-path checkpoint.
- **Decision C prerequisite:** `get_agent_accuracy` now returns `(rate, n)` instead of a bare rate, so "0.5 because no data" and "0.5 because that's the measured rate" are distinguishable. Every caller and mock across the test suite updated to match.

## Test plan

- [x] `.venv/bin/python -m pytest tests/ -q` — 218 passed
- [x] `.venv/bin/ruff check .` — clean
- [x] `.venv/bin/mypy argus api scripts` — no new errors (4 pre-existing, unrelated to this change)