### PR TITLE
Correct position sizing and the weight basis

### DIFF
--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -32,7 +32,7 @@ import numpy as np
 
 from argus.config import settings
 from argus.params import PORTFOLIO
-from argus.schemas.signals import MacroContext, PortfolioAllocation, RiskAssessment, RiskVerdict
+from argus.schemas.signals import MacroContext, PortfolioAllocation, RiskAssessment, RiskVerdict, Signal
 from argus.seams import GroqLLMClient, LLMClient
 
 logger = logging.getLogger("argus.portfolio")
@@ -241,9 +241,10 @@ class PortfolioManagerAgent:
             if all 3 LLM retry attempts fail.
         """
         total_wealth = user_profile.get("total_wealth")
-        investable = (float(total_wealth) if total_wealth is not None else 0.0) * float(
-            user_profile.get("invest_pct", 1.0)
-        )
+        # Capital base is total wealth, not wealth pre-scaled by invest_pct — invest_pct
+        # is the equity deployment target (ALLOCATION RULE 3 below), applied once by the
+        # LLM against this base, not twice
+        investable = float(total_wealth) if total_wealth is not None else 0.0
 
         approved_tickers = [t for t, s in all_signals.items() if _is_risk_approved(s.get("risk"))]
 
@@ -251,23 +252,54 @@ class PortfolioManagerAgent:
             logger.debug("[Portfolio] No approved tickers. Reverting to all-cash.")
             return self._all_cash_allocation(investable)
 
-        # Compute Half-Kelly baselines to anchor the LLM's sizing distribution
-        kelly_suggestions = {}
+        # Compute Half-Kelly baselines to anchor the LLM's sizing distribution, using
+        # each ticker's would-be primary_driver's measured win rate (see
+        # reconciliation.credit_primary_driver's argmax(weighted_votes) heuristic) as
+        # the win probability Kelly actually wants. Direction-blind conviction is not
+        # a probability of profit (see README) — using it here was PA-2/PA-3's bug.
+        # reliability/reliability_n are session-level, identical on every ticker's
+        # AggregatedSignal, so any one of them tells us whether outcome data exists at
+        # all without re-querying cultural memory.
+        reliability_n: dict[str, int] = {}
         for ticker in approved_tickers:
             agg = all_signals[ticker].get("aggregated")
-            risk_signal = all_signals[ticker].get("risk")
-            max_pos = risk_signal.approved_weight if risk_signal else self.max_position_pct
-            if agg:
+            if agg and agg.reliability_n:
+                reliability_n = agg.reliability_n
+                break
+        have_accuracy_data = any(n > 0 for n in reliability_n.values())
+
+        kelly_suggestions = {}
+        if have_accuracy_data:
+            for ticker in approved_tickers:
+                agg = all_signals[ticker].get("aggregated")
+                risk_signal = all_signals[ticker].get("risk")
+                max_pos = risk_signal.approved_weight if risk_signal else self.max_position_pct
+                # Anchors are for NEUTRAL/BULLISH sizing only (matches the prompt text below)
+                if not agg or agg.signal == Signal.BEARISH or not agg.weighted_votes:
+                    continue
+                driver = max(agg.weighted_votes, key=agg.weighted_votes.get)
+                win_prob = agg.reliability.get(driver, 0.5)
                 kelly_suggestions[ticker] = half_kelly_weight(
-                    win_probability=agg.conviction, max_position=max_pos
+                    win_probability=win_prob, max_position=max_pos
                 )
 
         signal_table = build_signal_table(all_signals, macro)
         wisdom_text = "\n".join(f"- {w}" for w in (cultural_wisdom or [])[:3])
         warnings_text = "\n".join(f"- {w}" for w in (cultural_warnings or [])[:3])
-        kelly_text = "\n".join(
-            f"{t}: half-Kelly suggests {w:.1%}" for t, w in kelly_suggestions.items()
-        )
+        if kelly_suggestions:
+            kelly_text = "\n".join(
+                f"{t}: half-Kelly suggests {w:.1%}" for t, w in kelly_suggestions.items()
+            )
+            kelly_block = (
+                "HALF-KELLY ANCHORS (mathematical starting point for NEUTRAL/BULLISH sizing; "
+                "override only with explicit signal justification):\n"
+                f"{kelly_text}\n"
+            )
+        else:
+            kelly_block = (
+                "HALF-KELLY ANCHORS: omitted — no agent has recorded outcome history yet. "
+                "Size NEUTRAL/BULLISH positions from signal strength and Cap alone.\n"
+            )
 
         prompt = (
             f"<portfolio_context session=\"{self._session_count}\" as_of=\"intraday\">\n"
@@ -290,9 +322,7 @@ class PortfolioManagerAgent:
             f"{signal_table}\n"
             "</signal_table>\n"
             "\n"
-            "HALF-KELLY ANCHORS (mathematical starting point for NEUTRAL/BULLISH sizing; "
-            "override only with explicit signal justification):\n"
-            f"{kelly_text}\n"
+            f"{kelly_block}"
             "\n"
             "CULTURAL WISDOM (from prior sessions with similar macro regime):\n"
             f"{wisdom_text if wisdom_text else 'None available.'}\n"

--- a/argus/orchestration/aggregator.py
+++ b/argus/orchestration/aggregator.py
@@ -56,6 +56,7 @@ class HybridSignalAggregator:
         fundamental: Optional[FundamentalSignal],
         sentiment: Optional[SentimentSignal],
         reliability: Optional[dict[str, float]] = None,
+        reliability_n: Optional[dict[str, int]] = None,
     ) -> AggregatedSignal:
         """Aggregates specialist signals via conviction-weighted voting with macro multipliers.
 
@@ -73,6 +74,10 @@ class HybridSignalAggregator:
                 (or missing/omitted entirely) votes at its unscaled base
                 weight — agents that have been right in this regime count
                 for more, agents that haven't count for less.
+            reliability_n: Optional agent name -> raw sample count each reliability
+                rate was computed from (see cultural.get_agent_accuracy's n).
+                Carried onto the result untouched, for agents/portfolio.py's
+                Half-Kelly anchor to distinguish "no data" from "measured 0.5".
 
         Returns:
             AggregatedSignal with a consensus direction, conviction, and weighted vote breakdown.
@@ -106,6 +111,7 @@ class HybridSignalAggregator:
         weighted_votes: dict[str, float] = {}
         agents_present: list[str] = [name for name, signal in sources.items() if signal is not None]
         reliability_used: dict[str, float] = dict(reliability) if reliability else {}
+        reliability_n_used: dict[str, int] = dict(reliability_n) if reliability_n else {}
 
         for name, signal in sources.items():
             if signal is None:
@@ -133,6 +139,7 @@ class HybridSignalAggregator:
                 weighted_votes=weighted_votes,
                 agents_present=agents_present,
                 reliability=reliability_used,
+                reliability_n=reliability_n_used,
             )
 
         bull_pct = bull_pool / max_pool
@@ -180,4 +187,5 @@ class HybridSignalAggregator:
             weighted_votes=weighted_votes,
             agents_present=agents_present,
             reliability=reliability_used,
+            reliability_n=reliability_n_used,
         )

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -340,17 +340,21 @@ def build_graph(
             regime = macro.macro_regime.value
             try:
                 memory = get_cultural_memory()
-                reliability = {
-                    name: memory.get_agent_accuracy(name, regime=regime, as_of=as_of)[0]
+                accuracy = {
+                    name: memory.get_agent_accuracy(name, regime=regime, as_of=as_of)
                     for name in agent_names
                 }
+                reliability = {name: accuracy[name][0] for name in agent_names}
+                reliability_n = {name: accuracy[name][1] for name in agent_names}
             except ImportError as exc:
                 # Same optional-dependency guard as node_retrieve_cultural_memory;
                 # degrade every agent to the 0.5 neutral prior rather than crash
                 logger.warning("node_signal_aggregation: cultural memory unavailable: %s", exc)
                 reliability = {name: 0.5 for name in agent_names}
+                reliability_n = {name: 0 for name in agent_names}
         else:
             reliability = {name: 0.5 for name in agent_names}
+            reliability_n = {name: 0 for name in agent_names}
 
         for ticker in state["universe"]:
             tech = state.get("technical_signals", {}).get(ticker)
@@ -358,7 +362,9 @@ def build_graph(
             sent = state.get("sentiment_signals", {}).get(ticker)
             if tech is None and fund is None and sent is None:
                 continue
-            aggs[ticker] = aggregator.aggregate(tech, macro, fund, sent, reliability=reliability)
+            aggs[ticker] = aggregator.aggregate(
+                tech, macro, fund, sent, reliability=reliability, reliability_n=reliability_n
+            )
         return {"aggregated_signals": aggs}
 
     def node_risk_evaluation(state: ARGUSState) -> dict:

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -430,6 +430,17 @@ class AggregatedSignal(BaseModel):
             "instead of silently resetting every ablated rerun to the 1.0 unweighted default."
         ),
     )
+    reliability_n: dict[str, int] = Field(
+        default_factory=dict,
+        description=(
+            "Agent name → raw sample count each reliability rate was computed from "
+            "(see cultural.get_agent_accuracy's n). Session-level, identical across "
+            "every ticker's AggregatedSignal this run. Persisted so agents/portfolio.py's "
+            "Half-Kelly anchor can tell '0.5 because no outcome data exists yet' from "
+            "'0.5 because that is the measured win rate', without re-querying cultural "
+            "memory per ticker."
+        ),
+    )
 
 
 class PositionAllocation(BaseModel):
@@ -461,7 +472,8 @@ class PortfolioAllocation(BaseModel):
 
     session_id: str = Field(..., description="Unique identifier for this advisory session")
     user_investable_capital: float = Field(
-        ..., gt=0.0, description="Total capital available for investment (USD)"
+        ..., gt=0.0, description="Total wealth this allocation was computed against (USD) — "
+        "the capital base for allocation_pct and allocation_usd, not wealth pre-scaled by invest_pct"
     )
     portfolio: list[PositionAllocation] = Field(
         default_factory=list, description="List of recommended positions"

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -1,0 +1,201 @@
+"""
+tests/test_position_sizing.py
+
+Regression tests for PA-2, PA-3, PA-4: the Half-Kelly anchor must come from a
+measured win rate (not direction-blind conviction) and must be omitted when no
+such measurement exists, and the capital base for allocation_pct/allocation_usd
+must be total wealth rather than wealth pre-scaled by invest_pct.
+"""
+
+import json
+from datetime import datetime
+
+from argus.agents.portfolio import PortfolioManagerAgent
+from argus.schemas.signals import AggregatedSignal, RiskAssessment, RiskVerdict, Signal
+from argus.seams import FixtureLLMClient
+
+TIMESTAMP = datetime(2026, 1, 1)
+
+
+def _risk(approved_weight: float = 0.15) -> RiskAssessment:
+    return RiskAssessment(
+        verdict=RiskVerdict.APPROVE,
+        approved_weight=approved_weight,
+        proposed_weight=approved_weight,
+        var_99=0.05,
+        portfolio_beta=1.0,
+        timestamp=TIMESTAMP,
+    )
+
+
+def _agg(
+    ticker: str,
+    signal: Signal,
+    weighted_votes: dict[str, float],
+    reliability: dict[str, float] | None = None,
+    reliability_n: dict[str, int] | None = None,
+) -> AggregatedSignal:
+    return AggregatedSignal(
+        ticker=ticker,
+        signal=signal,
+        conviction=0.6,
+        weighted_votes=weighted_votes,
+        agents_present=list(weighted_votes),
+        reliability=reliability or {},
+        reliability_n=reliability_n or {},
+    )
+
+
+def _agent_with_capture(body: dict) -> tuple[PortfolioManagerAgent, list[str]]:
+    """Builds a PortfolioManagerAgent whose FixtureLLMClient records the user prompt."""
+    prompts: list[str] = []
+
+    def key_fn(user_prompt: str) -> str:
+        prompts.append(user_prompt)
+        return "only"
+
+    llm_client = FixtureLLMClient({"only": json.dumps(body)}, key_fn=key_fn)
+    return PortfolioManagerAgent(llm_client=llm_client), prompts
+
+
+def test_bearish_ticker_receives_no_kelly_anchor():
+    """A BEARISH ticker is never listed under HALF-KELLY ANCHORS, even with outcome data."""
+    all_signals = {
+        "BULL": {
+            "risk": _risk(),
+            "aggregated": _agg(
+                "BULL",
+                Signal.BULLISH,
+                {"technical": 0.5},
+                reliability={"technical": 0.65},
+                reliability_n={"technical": 20},
+            ),
+        },
+        "BEAR": {
+            "risk": _risk(),
+            "aggregated": _agg(
+                "BEAR",
+                Signal.BEARISH,
+                {"technical": 0.5},
+                reliability={"technical": 0.65},
+                reliability_n={"technical": 20},
+            ),
+        },
+    }
+    body = {
+        "portfolio": [],
+        "cash_reserve_pct": 1.0,
+        "expected_sharpe": None,
+        "rebalance_trigger": "MONTHLY",
+    }
+    agent, prompts = _agent_with_capture(body)
+    agent.allocate(
+        user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
+        all_signals=all_signals,
+        macro=None,
+    )
+
+    assert len(prompts) == 1
+    assert "BULL: half-Kelly suggests" in prompts[0]
+    assert "BEAR: half-Kelly suggests" not in prompts[0]
+
+
+def test_kelly_anchor_block_omitted_when_no_agent_has_data():
+    """The whole HALF-KELLY ANCHORS block is omitted, with an explanation, when n == 0 for every agent."""
+    all_signals = {
+        "AAPL": {
+            "risk": _risk(),
+            "aggregated": _agg(
+                "AAPL",
+                Signal.BULLISH,
+                {"technical": 0.5},
+                reliability={"technical": 0.5, "fundamental": 0.5, "sentiment": 0.5},
+                reliability_n={"technical": 0, "fundamental": 0, "sentiment": 0},
+            ),
+        },
+    }
+    body = {
+        "portfolio": [],
+        "cash_reserve_pct": 1.0,
+        "expected_sharpe": None,
+        "rebalance_trigger": "MONTHLY",
+    }
+    agent, prompts = _agent_with_capture(body)
+    agent.allocate(
+        user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
+        all_signals=all_signals,
+        macro=None,
+    )
+
+    assert len(prompts) == 1
+    assert "HALF-KELLY ANCHORS: omitted" in prompts[0]
+    assert "half-Kelly suggests" not in prompts[0]
+
+
+def test_kelly_anchor_uses_primary_drivers_measured_win_rate_not_conviction():
+    """The anchor is derived from the argmax(weighted_votes) agent's reliability rate."""
+    all_signals = {
+        "AAPL": {
+            "risk": _risk(),
+            "aggregated": _agg(
+                "AAPL",
+                Signal.BULLISH,
+                {"technical": 0.9, "fundamental": 0.1},
+                reliability={"technical": 0.7, "fundamental": 0.5},
+                reliability_n={"technical": 30, "fundamental": 0},
+            ),
+        },
+    }
+    body = {
+        "portfolio": [],
+        "cash_reserve_pct": 1.0,
+        "expected_sharpe": None,
+        "rebalance_trigger": "MONTHLY",
+    }
+    agent, prompts = _agent_with_capture(body)
+    agent.allocate(
+        user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
+        all_signals=all_signals,
+        macro=None,
+    )
+
+    # b=2, p=0.7, q=0.3: full Kelly (2*0.7-0.3)/2=0.55, half=0.275, clipped to the 0.15 cap
+    assert "AAPL: half-Kelly suggests 15.0%" in prompts[0]
+
+
+def test_capital_base_is_total_wealth_not_wealth_times_invest_pct():
+    """user_investable_capital and allocation_usd are based on total_wealth, not total_wealth * invest_pct.
+
+    Reproduces PA-2/PA-3: previously invest_pct was applied once to shrink the
+    capital base and again by the LLM's deployment target, so requesting 80%
+    deployment produced roughly invest_pct^2 (64%) of true total wealth.
+    """
+    all_signals = {
+        "AAPL": {"risk": _risk()},
+    }
+    body = {
+        "portfolio": [
+            {
+                "ticker": "AAPL",
+                "allocation_pct": 0.10,
+                "stop_loss": 100.0,
+                "thesis": "Bullish",
+                "composite_conviction": 0.7,
+                "time_horizon": "3-6 months",
+            }
+        ],
+        "cash_reserve_pct": 0.9,
+        "expected_sharpe": None,
+        "rebalance_trigger": "MONTHLY",
+    }
+    agent, prompts = _agent_with_capture(body)
+    alloc = agent.allocate(
+        user_profile={"total_wealth": 100_000.0, "invest_pct": 0.8, "risk_tolerance": "MODERATE"},
+        all_signals=all_signals,
+        macro=None,
+    )
+
+    assert alloc is not None
+    assert alloc.user_investable_capital == 100_000.0
+    assert alloc.portfolio[0].allocation_usd == 10_000.0
+    assert "capital_usd: $100,000" in prompts[0]


### PR DESCRIPTION
## Summary

PR 5 of the issue #24 remediation series (fixes PA-2, PA-3, PA-4), implementing Design Decisions C and D.

- **Decision C — Kelly anchor from measured win rate.** `half_kelly_weight` was called with `win_probability=agg.conviction`, which is direction-blind and, post-PR-1's conviction rescale, saturates the anchor to 0.0 for nearly every ticker (b=2 makes `half_kelly_weight` return 0 for any p < 0.5333, and post-rescale conviction sits around 0.3-0.6). Added `AggregatedSignal.reliability_n` (session-level sample counts, mirroring the existing `reliability` field) so `get_agent_accuracy`'s `n` reaches the portfolio agent without a second cultural-memory query. The anchor now uses the `argmax(weighted_votes)` agent's measured win rate, skips BEARISH tickers (anchors are for NEUTRAL/BULLISH sizing only), and the `HALF-KELLY ANCHORS` block is omitted entirely — with an explanatory line in its place — when no agent has any recorded outcomes. Since no agent has outcome data today, this means the anchor disappears in practice; the mechanism reinstates itself once the learning loop produces rows.
- **Decision D — capital base is total wealth, not wealth × invest_pct.** `investable` used to be `total_wealth × invest_pct`, and the LLM was separately asked to target `invest_pct` deployment against that already-shrunk base — so deployment tracked roughly `invest_pct²`, not `invest_pct`. `allocation_pct`/`allocation_usd` are now rebased on `total_wealth` directly; `invest_pct` applies exactly once, as the LLM's deployment target. `PortfolioAllocation.user_investable_capital`'s Field description is updated to reflect this (not renamed — it's persisted in checkpoints and `decisions.jsonl`).

## Test plan

- [x] `tests/test_position_sizing.py` (new, 4 tests): BEARISH ticker gets no anchor; the whole anchor block is omitted when `n == 0` for every agent; the anchor uses the primary driver's measured win rate, not conviction; capital base equals total wealth (not `total_wealth × invest_pct`), reproducing PA-2/PA-3.
- [x] `half_kelly_weight`'s 4 existing tests unchanged and green (only its caller changed).
- [x] Full suite: 222 passed (218 baseline + 4 new).
- [x] `ruff check .` clean.
- [x] `mypy argus api scripts`: only 4 pre-existing errors, in files this PR doesn't touch.

Closes part of #24.