### PR TITLE
Close the risk-evaluation safety gaps

### DIFF
--- a/argus/agents/risk.py
+++ b/argus/agents/risk.py
@@ -330,16 +330,23 @@ class RiskStatisticalEngine:
                     f"{pos['ticker']} weight {pos['weight']:.1%} > limit {self.max_position_pct:.1%}"
                 )
 
+        # Below-floor diversification is informational (folded into veto_reasons below on
+        # whichever verdict is reached), not a `violations` entry — a 2-4 ticker universe is
+        # a normal small-book session, not a structural fault worth an all-cash VETO
+        diversification_note: Optional[str] = None
         if (
             len(proposed_positions) > 1
             and len(proposed_positions) < RISK.min_positions_diversification
             and total_weight > 0
         ):
-            violations.append(
-                f"Insufficient diversification: {len(proposed_positions)} positions (min {RISK.min_positions_diversification})"
+            diversification_note = (
+                f"Below diversification floor: {len(proposed_positions)} positions "
+                f"(min {RISK.min_positions_diversification})"
             )
 
         if len(proposed_positions) > RISK.max_positions:
+            # api/main.py's AnalyzeRequest.tickers caps max_length at the same 20, so this
+            # branch is currently unreachable through the API — kept for direct callers
             violations.append(
                 f"Over-diversification: {len(proposed_positions)} positions (max {RISK.max_positions})"
             )
@@ -355,7 +362,7 @@ class RiskStatisticalEngine:
                 verdict=RiskVerdict.VETO,
                 approved_weight=0.0,
                 proposed_weight=total_weight,
-                veto_reasons=violations,
+                veto_reasons=violations + ([diversification_note] if diversification_note else []),
                 optimal_weights={},
                 var_99=0.0,
                 cvar=0.0,
@@ -444,8 +451,13 @@ class RiskStatisticalEngine:
         returns = compute_portfolio_returns(proposed_positions, price_history)
         port_returns = returns.sum(axis=1) if not returns.empty else pd.Series(dtype=float)
 
-        var99 = historical_var(port_returns)
-        cvar = conditional_var(port_returns)
+        # Normalize to a full (weight=1.0) book before comparing to var_limit/cvar_limit, so
+        # the same threshold means the same thing for the portfolio call (sum(w)~1.0) and a
+        # single-ticker call (w=0.15) — unnormalized, the per-ticker call was diluted 1/0.15x
+        # and under-detected exactly the volatility the gate exists to catch
+        normalized_returns = port_returns / total_weight if total_weight > 0 else port_returns
+        var99 = historical_var(normalized_returns)
+        cvar = conditional_var(normalized_returns)
         beta = ols_portfolio_beta(proposed_positions, price_history, market_data=self.market_data)
         corr = avg_pairwise_correlation(returns)
 
@@ -472,7 +484,8 @@ class RiskStatisticalEngine:
                 verdict=RiskVerdict.REDUCE,
                 approved_weight=min(total_weight * RISK.reduce_weight_multiplier, total_weight),
                 proposed_weight=total_weight,
-                veto_reasons=stat_violations,
+                veto_reasons=stat_violations
+                + ([diversification_note] if diversification_note else []),
                 optimal_weights=optimal_weights,
                 optimizer_converged=optimizer_converged,
                 var_99=var99,
@@ -497,7 +510,7 @@ class RiskStatisticalEngine:
             verdict=RiskVerdict.APPROVE,
             approved_weight=total_weight,
             proposed_weight=total_weight,
-            veto_reasons=[],
+            veto_reasons=[diversification_note] if diversification_note else [],
             optimal_weights=optimal_weights,
             optimizer_converged=optimizer_converged,
             var_99=var99,

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -195,10 +195,17 @@ def build_graph(
                 ``session_states`` pre-populated from the MFT live cache.
 
         Returns:
-            Partial state update with ``price_history`` only. ``session_states``
-            is passed through unchanged from the incoming state.
+            Partial state update with ``price_history``, which also carries the SPY
+            benchmark series alongside the universe. ``session_states`` is passed
+            through unchanged from the incoming state.
         """
-        history_dfs = market_data.multiple_daily(state["universe"], period="1y")
+        # SPY rides along with the universe fetch so risk.py's ols_portfolio_beta finds it
+        # already in price_history, instead of issuing its own uncached fetch on every one
+        # of the N+1 risk_engine.evaluate() calls node_risk_evaluation makes this session
+        fetch_tickers = list(state["universe"])
+        if "SPY" not in fetch_tickers:
+            fetch_tickers.append("SPY")
+        history_dfs = market_data.multiple_daily(fetch_tickers, period="1y")
         history_serializable = {}
 
         for ticker, df in history_dfs.items():
@@ -373,81 +380,116 @@ def build_graph(
                 and ``aggregated_signals`` populated.
 
         Returns:
-            Partial state update with ``risk_assessments`` and ``errors``.
+            Partial state update with ``risk_assessments`` and ``errors``. On an
+            unexpected failure, ``risk_assessments`` is empty and the failure is
+            named in ``errors`` rather than raised (RE-10) — nothing downstream
+            can safely allocate against a risk session that half-completed.
         """
         import pandas as pd
 
-        history_raw = state.get("price_history", {})
-        history = {
-            ticker: pd.Series(data["prices"], index=pd.to_datetime(data["dates"]))
-            for ticker, data in history_raw.items()
-        }
-        macro_ctx = state.get("macro_context")
-        vix = macro_ctx.vix_level if macro_ctx else 20.0
-        universe = state["universe"]
-
-        # Extract signed convictions: positive = BULLISH, negative = BEARISH, zero = NEUTRAL
-        convictions = {}
-        aggs = state.get("aggregated_signals", {})
-        if aggs:
-            for t, sig in aggs.items():
-                sign = (
-                    1.0
-                    if sig.signal == Signal.BULLISH
-                    else (-1.0 if sig.signal == Signal.BEARISH else 0.0)
-                )
-                convictions[t] = sig.conviction * sign
-
-        # Joint evaluation captures inter-asset covariance and global diversification limits
-        base_weight = min(0.15, 1.0 / len(universe)) if universe else 0.15
-        full_portfolio = [{"ticker": t, "weight": base_weight} for t in universe]
-        portfolio_result = risk_engine.evaluate(full_portfolio, history, vix, convictions=convictions)
-
-        portfolio_vetoed = portfolio_result.verdict == RiskVerdict.VETO
-        ticker_cap_map: dict[str, float] = portfolio_result.optimal_weights
-
         errors: list[str] = []
-        if portfolio_result.optimizer_converged is False:
-            errors.append(
-                "risk_evaluation: SLSQP solve did not converge; portfolio-level caps "
-                "were not applied to any ticker"
+
+        try:
+            history_raw = state.get("price_history", {})
+            history = {
+                ticker: pd.Series(data["prices"], index=pd.to_datetime(data["dates"]))
+                for ticker, data in history_raw.items()
+            }
+            macro_ctx = state.get("macro_context")
+            if macro_ctx is not None:
+                vix = macro_ctx.vix_level
+            else:
+                # A FRED outage only takes out the macro bundle; the VIX blackout gate
+                # needs just the index level, which yfinance can still serve directly
+                try:
+                    vix = market_data.vix()
+                except Exception as exc:
+                    logger.warning(
+                        "node_risk_evaluation: VIX fetch failed with no macro_context; "
+                        "falling back to vix=20.0: %s",
+                        exc,
+                    )
+                    errors.append(
+                        f"risk_evaluation: VIX fetch failed, used fallback vix=20.0 ({exc})"
+                    )
+                    vix = 20.0
+            universe = state["universe"]
+
+            # Extract signed convictions: positive = BULLISH, negative = BEARISH, zero = NEUTRAL
+            convictions = {}
+            aggs = state.get("aggregated_signals", {})
+            if aggs:
+                for t, sig in aggs.items():
+                    sign = (
+                        1.0
+                        if sig.signal == Signal.BULLISH
+                        else (-1.0 if sig.signal == Signal.BEARISH else 0.0)
+                    )
+                    convictions[t] = sig.conviction * sign
+
+            # Joint evaluation captures inter-asset covariance and global diversification limits
+            base_weight = min(0.15, 1.0 / len(universe)) if universe else 0.15
+            full_portfolio = [{"ticker": t, "weight": base_weight} for t in universe]
+            portfolio_result = risk_engine.evaluate(
+                full_portfolio, history, vix, convictions=convictions
             )
 
-        assessments = {}
+            portfolio_vetoed = portfolio_result.verdict == RiskVerdict.VETO
+            ticker_cap_map: dict[str, float] = portfolio_result.optimal_weights
 
-        for ticker in universe:
-            single = risk_engine.evaluate(
-                [{"ticker": ticker, "weight": settings.MAX_SINGLE_POSITION_PCT}], history, vix
+            if portfolio_result.optimizer_converged is False:
+                errors.append(
+                    "risk_evaluation: SLSQP solve did not converge; portfolio-level caps "
+                    "were not applied to any ticker"
+                )
+            # RE-4: below-floor diversification is informational on the assessment's own
+            # veto_reasons (risk.py), not a hard VETO — surface it here too so it's visible
+            # without inspecting every per-ticker assessment
+            errors.extend(
+                f"risk_evaluation: {r}"
+                for r in portfolio_result.veto_reasons
+                if r.startswith("Below diversification floor")
             )
 
-            updates: dict = {}
+            assessments = {}
 
-            # Propagate portfolio-level correlation stats for uniform telemetry, but only
-            # when the portfolio call actually measured them — a structural-violation
-            # short-circuit reports None, not a fabricated 0.0
-            if portfolio_result.avg_correlation is not None:
-                updates["avg_correlation"] = portfolio_result.avg_correlation
+            for ticker in universe:
+                single = risk_engine.evaluate(
+                    [{"ticker": ticker, "weight": settings.MAX_SINGLE_POSITION_PCT}], history, vix
+                )
 
-            if ticker in ticker_cap_map and not portfolio_vetoed:
-                updates.update(_apply_portfolio_cap(single, ticker_cap_map[ticker]))
+                updates: dict = {}
 
-            # Portfolio-level veto overrides all individual verdicts to prevent partial allocation
-            if portfolio_vetoed:
-                updates["verdict"] = RiskVerdict.VETO
-                updates["approved_weight"] = 0.0
-                updates["veto_reasons"] = single.veto_reasons + [
-                    f"[Portfolio] {r}" for r in portfolio_result.veto_reasons
-                ]
+                # Propagate portfolio-level correlation stats for uniform telemetry, but only
+                # when the portfolio call actually measured them — a structural-violation
+                # short-circuit reports None, not a fabricated 0.0
+                if portfolio_result.avg_correlation is not None:
+                    updates["avg_correlation"] = portfolio_result.avg_correlation
 
-            # A single model_validate reconstruction, not sequential model_copy calls —
-            # model_copy skips validators, so it was bypassing approved_le_proposed
-            assessments[ticker] = (
-                RiskAssessment.model_validate({**single.model_dump(), **updates})
-                if updates
-                else single
-            )
+                if ticker in ticker_cap_map and not portfolio_vetoed:
+                    updates.update(_apply_portfolio_cap(single, ticker_cap_map[ticker]))
 
-        return {"risk_assessments": assessments, "errors": errors}
+                # Portfolio-level veto overrides all individual verdicts to prevent partial allocation
+                if portfolio_vetoed:
+                    updates["verdict"] = RiskVerdict.VETO
+                    updates["approved_weight"] = 0.0
+                    updates["veto_reasons"] = single.veto_reasons + [
+                        f"[Portfolio] {r}" for r in portfolio_result.veto_reasons
+                    ]
+
+                # A single model_validate reconstruction, not sequential model_copy calls —
+                # model_copy skips validators, so it was bypassing approved_le_proposed
+                assessments[ticker] = (
+                    RiskAssessment.model_validate({**single.model_dump(), **updates})
+                    if updates
+                    else single
+                )
+
+            return {"risk_assessments": assessments, "errors": errors}
+        except Exception as exc:
+            logger.exception("node_risk_evaluation: unexpected failure")
+            errors.append(f"risk_evaluation: unexpected failure: {exc}")
+            return {"risk_assessments": {}, "errors": errors}
 
     def node_portfolio_allocation(state: ARGUSState) -> dict:
         """Determines capital allocations using specialist ratings, risk targets, and memory heuristics.

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -24,6 +24,9 @@ from pathlib import Path
 from unittest import mock
 from uuid import uuid4
 
+import numpy as np
+import pandas as pd
+
 from argus.orchestration.graph import build_graph
 from argus.orchestration.state import ARGUSState
 from argus.seams import FixtureLLMClient, FixtureMarketDataProvider
@@ -176,6 +179,109 @@ def test_macro_context_none_still_produces_a_degraded_allocation():
     assert len(alloc.portfolio) == len(UNIVERSE)
 
     assert any("macro_context unavailable" in e for e in final_state.get("errors", []))
+
+
+class _SpyCountingMarketData(FixtureMarketDataProvider):
+    """Wraps the fixture provider to count ``ohlcv_daily`` calls and fabricate a SPY series.
+
+    The shared price_history fixture predates RE-5 and has no "SPY" entry, and adding
+    one there would perturb every other golden_dag test's carefully-tuned VETO/REDUCE
+    expectations (real beta feeding risk.py's beta gate). Fabricating it only here keeps
+    this test's SPY data isolated from the rest of the fixture-backed suite.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.ohlcv_daily_calls: list[str] = []
+        dates = pd.date_range("2024-01-01", periods=252, freq="B")
+        prices = 400 + np.cumsum(np.random.default_rng(0).normal(0, 1, len(dates)))
+        self._spy_df = pd.DataFrame({"close": prices}, index=dates)
+
+    def ohlcv_daily(self, ticker: str, period: str = "2y"):
+        """Records the call and returns fabricated SPY data, else defers to the fixture."""
+        self.ohlcv_daily_calls.append(ticker)
+        if ticker == "SPY":
+            return self._spy_df
+        return super().ohlcv_daily(ticker, period=period)
+
+    def multiple_daily(self, tickers: list[str], period: str = "1y"):
+        """Same as the base multiple_daily, but routes SPY through ohlcv_daily for counting."""
+        result = super().multiple_daily([t for t in tickers if t != "SPY"], period=period)
+        if "SPY" in tickers:
+            result["SPY"] = self.ohlcv_daily("SPY", period=period)
+        return result
+
+
+def test_spy_fetched_once_per_graph_run_not_once_per_risk_call():
+    """RE-5 regression: SPY rides along with node_fetch_price_history's universe fetch.
+
+    Before the fix, node_fetch_price_history never carried SPY in price_history, so
+    risk.py's ols_portfolio_beta fell back to its own live fetch on every one of the
+    N+1 risk_engine.evaluate() calls a session makes (one portfolio-level plus one per
+    ticker) — 7 fetches for this 6-ticker universe instead of 1.
+    """
+    provider = _SpyCountingMarketData()
+    graph = build_graph(
+        market_data=provider,
+        fundamental_llm=_per_ticker_llm("fundamental.json"),
+        sentiment_llm=_per_ticker_llm("sentiment.json"),
+        portfolio_llm=_portfolio_llm(),
+    )
+    config = {"configurable": {"thread_id": str(uuid4())}}
+
+    with mock.patch("argus.orchestration.graph.get_cultural_memory") as mock_get_cultural_memory:
+        mock_get_cultural_memory.return_value = mock.Mock(
+            retrieve_wisdom=mock.Mock(return_value=[]),
+            retrieve_warnings=mock.Mock(return_value=[]),
+            get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
+            store_decision_snapshot=mock.Mock(),
+        )
+        graph.invoke(_initial_state(), config)
+
+    assert provider.ohlcv_daily_calls.count("SPY") == 1
+
+
+class _CountingVixMarketData(_NoneMacroMarketData):
+    """_NoneMacroMarketData with a vix() call counter, isolated from other tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.vix_calls = 0
+
+    def vix(self) -> float:
+        """Records the call, then defers to the inherited fixture-backed reading."""
+        self.vix_calls += 1
+        return super().vix()
+
+
+def test_macro_context_none_still_reaches_a_real_vix_reading():
+    """RE-6 regression: a FRED outage must not silently default the blackout gate to 20.0.
+
+    _NoneMacroMarketData forces macro_bundle() (hence macro_context) to None but leaves
+    vix() — read straight from yfinance in production, independent of FRED — intact, so
+    the risk engine's blackout gate should reach a real VIX reading via one explicit call
+    rather than defaulting.
+    """
+    provider = _CountingVixMarketData()
+    graph = build_graph(
+        market_data=provider,
+        fundamental_llm=_per_ticker_llm("fundamental.json"),
+        sentiment_llm=_per_ticker_llm("sentiment.json"),
+        portfolio_llm=_portfolio_llm(),
+    )
+    config = {"configurable": {"thread_id": str(uuid4())}}
+
+    with mock.patch("argus.orchestration.graph.get_cultural_memory") as mock_get_cultural_memory:
+        mock_get_cultural_memory.return_value = mock.Mock(
+            retrieve_wisdom=mock.Mock(return_value=[]),
+            retrieve_warnings=mock.Mock(return_value=[]),
+            get_agent_accuracy=mock.Mock(return_value=(0.5, 0)),
+            store_decision_snapshot=mock.Mock(),
+        )
+        final_state = graph.invoke(_initial_state(), config)
+
+    assert final_state.get("macro_context") is None
+    assert provider.vix_calls == 1
 
 
 def test_golden_dag_runs_offline_and_produces_a_valid_allocation():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -200,7 +200,10 @@ class TestEndToEnd:
             assert len(alloc.portfolio) >= 1 or alloc.cash_reserve_pct == 1.0
 
             for pos in alloc.portfolio:
-                assert pos.stop_loss > 0.0
+                # RE-7: the per-ticker risk gate now REDUCEs (stop_loss=0.0) real
+                # positions it previously under-detected, so 0.0 is a legitimate
+                # outcome on live market data, not just an unpopulated field
+                assert pos.stop_loss >= 0.0
         except Exception as e:
             # The checkpointer can raise a dataframe serialization error unrelated to graph wiring
             if "msgpack" in str(e).lower() or "not msgpack serializable" in str(e).lower():

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -149,3 +149,45 @@ def test_zero_api_calls(risk_engine: RiskStatisticalEngine, price_history: dict)
     result = risk_engine.evaluate(positions, price_history, current_vix=40.0)
 
     assert result.api_calls_used == 0
+
+
+def test_small_universe_is_noted_not_vetoed(
+    risk_engine: RiskStatisticalEngine, price_history: dict
+) -> None:
+    """RE-4 regression: a 2-4 ticker universe is informational, not a hard VETO.
+
+    Before the fix, a book below the 5-position diversification floor was
+    structurally VETOed regardless of its actual risk profile, returning
+    all-cash with no reason a human could act on.
+    """
+    positions = [{"ticker": t, "weight": 0.1} for t in ["AAPL", "MSFT", "GOOGL"]]
+    result = risk_engine.evaluate(positions, price_history, current_vix=20.0)
+
+    assert result.verdict == RiskVerdict.APPROVE
+    assert any("Below diversification floor" in r for r in result.veto_reasons)
+
+
+def test_per_ticker_var_normalized_to_full_weight() -> None:
+    """RE-7 regression: a volatile single ticker at weight=0.15 must REDUCE, not APPROVE.
+
+    Before the fix, var99/cvar were computed from the weight-diluted return series
+    (0.15x), so the same var_limit was ~6.7x looser for a per-ticker call than for
+    the portfolio call — a stock volatile enough to clearly breach the limit at full
+    weight passed the per-ticker gate outright.
+    """
+    engine = RiskStatisticalEngine()
+    np.random.seed(3)
+    dates = pd.date_range(start="2023-01-01", periods=253, freq="B")
+    hist = {
+        "AAPL": pd.Series(
+            100 * np.exp(np.cumsum(np.random.normal(0.0, 0.05, len(dates)))), index=dates
+        ),
+        "SPY": pd.Series(
+            100 * np.exp(np.cumsum(np.random.normal(0.0, 0.01, len(dates)))), index=dates
+        ),
+    }
+
+    result = engine.evaluate([{"ticker": "AAPL", "weight": 0.15}], hist, current_vix=20.0)
+
+    assert result.verdict == RiskVerdict.REDUCE
+    assert result.var_99 > 0.03


### PR DESCRIPTION
## Summary

PR 6 of the issue #24 remediation series (fixes RE-4, RE-5, RE-6, RE-7, RE-10).

- **RE-6 — real VIX during a FRED outage.** `node_risk_evaluation` used to default the blackout gate straight to `vix=20.0` whenever `macro_context` was `None`. It now calls `MarketDataProvider.vix()` — a yfinance-only read, independent of FRED — for a real reading. A fetch failure still falls back to `20.0`, but logged and named in `errors`, so the degraded-allocation guarantee survives a total data outage too.
- **RE-5 — one SPY fetch per session, not N+1.** `node_fetch_price_history` now fetches `SPY` alongside the universe and carries it in `price_history`, so `ols_portfolio_beta` finds it already there instead of issuing its own uncached fetch on every one of the `N+1` `risk_engine.evaluate()` calls a session makes (one portfolio-level, one per ticker).
- **RE-4 — diversification floor is informational, not a hard VETO.** A 2-4 ticker universe used to structurally VETO the whole book and return all-cash with no actionable reason. It's now folded into `veto_reasons` on whichever verdict the book actually earns, and surfaced through `errors`. Noted the symmetric case in a comment: `max_positions` equals `api/main.py`'s `max_length`, so the over-diversification branch is currently unreachable through the API.
- **RE-7 — VaR/CVaR normalized by weight before comparing.** Both are now computed from returns normalized by `total_weight` before comparing to `var_limit`/`cvar_limit`, so the same threshold means the same thing for the portfolio-level call (`sum(w)~1.0`) and a per-ticker call (`w=0.15`). Unnormalized, the per-ticker gate was diluted ~6.7x and essentially never fired — a live-network integration test's `stop_loss > 0.0` assumption relied on exactly this gap (see Test plan).
- **RE-10 — the node no longer crashes the graph.** `node_risk_evaluation`'s body is now wrapped in `try/except`; an unexpected failure returns through `errors` with empty `risk_assessments` instead of raising out of the graph invocation.

## Test plan

- [x] `tests/test_risk.py` (2 new): a 3-ticker book is APPROVEd with a diversification note in `veto_reasons`, not VETOed (RE-4); a volatile single ticker at `weight=0.15` now REDUCEs where the pre-fix diluted threshold would have APPROVEd it (RE-7).
- [x] `tests/test_golden_dag.py` (2 new): a call-counting `MarketDataProvider` asserts exactly one `SPY` fetch per graph run (RE-5); a call-counting wrapper of the existing `_NoneMacroMarketData` asserts the blackout gate reaches a real VIX reading via one explicit call during a FRED outage (RE-6).
- [x] `tests/test_integration.py`: relaxed `TestEndToEnd::test_full_graph_smoke`'s `stop_loss > 0.0` assertion to `>= 0.0` — this live-network smoke test's assumption that every allocated position got APPROVE only held because the RE-7 gate was too diluted to ever REDUCE a single ticker; a REDUCE (`stop_loss=0.0`) is now a legitimate outcome, not a wiring failure.
- [x] Full suite: 222 passed (218 baseline + 4 new).
- [x] `ruff check .` clean.
- [x] `mypy argus api scripts`: only 4 pre-existing errors, in files this PR doesn't touch.

Closes part of #24.