### PR TITLE
Mock the portfolio LLM in the graph smoke test

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,6 +28,7 @@ from argus.risk.kill_switch import KillSwitch
 from argus.schemas.signals import (
     FundamentalSignal,
     MacroContext,
+    PortfolioAllocation,
     Regime,
     RiskAssessment,
     SectorSignal,
@@ -87,21 +88,30 @@ class TestEndToEnd:
         assert r_sig.api_calls_used == 0
 
     @pytest.mark.asyncio
+    @mock.patch("argus.agents.portfolio.PortfolioManagerAgent.allocate")
     @mock.patch("argus.orchestration.graph.get_cultural_memory")
     @mock.patch("argus.agents.fundamental.FundamentalAgent.analyze")
     @mock.patch("argus.agents.sentiment.SentimentAgent.analyze")
-    async def test_full_graph_smoke(self, mock_sent, mock_fund, mock_cultural_memory, tmp_path):
+    async def test_full_graph_smoke(
+        self, mock_sent, mock_fund, mock_cultural_memory, mock_portfolio, tmp_path
+    ):
         """Runs the complete LangGraph graph for AAPL, MSFT using mocked LLMs.
 
         Cultural memory is mocked out (not just left real) because its embedding
         function needs the optional `[models]` extra (sentence-transformers) that
         default installs/CI don't have, and because this smoke test is about graph
-        wiring, not vector-DB behavior.
+        wiring, not vector-DB behavior. PortfolioManagerAgent.allocate is mocked
+        for the same reason FundamentalAgent/SentimentAgent are: GROQ_API_KEY is
+        intentionally unset in CI (see .github/workflows/ci.yml), and with RE-4's
+        fix this 2-ticker universe no longer VETOes every ticker, so allocate()
+        now actually reaches the LLM call instead of short-circuiting to
+        all-cash before ever touching the network.
 
         Args:
             mock_sent: Patched SentimentAgent.analyze.
             mock_fund: Patched FundamentalAgent.analyze.
             mock_cultural_memory: Patched get_cultural_memory.
+            mock_portfolio: Patched PortfolioManagerAgent.allocate.
             tmp_path: Pytest tempdir, so this run's checkpoint never lands in
                 the production argus_graph.db.
         """
@@ -166,6 +176,39 @@ class TestEndToEnd:
             )
 
         mock_sent.side_effect = sent_side_effect
+
+        def portfolio_side_effect(
+            user_profile,
+            all_signals,
+            macro,
+            cultural_wisdom=None,
+            cultural_warnings=None,
+            adjustments=None,
+        ):
+            """Stand in for PortfolioManagerAgent.allocate, matching its real signature.
+
+            Args:
+                user_profile: Dict with total_wealth/invest_pct/risk_tolerance.
+                all_signals: Mapping of ticker -> dict of signal objects; unused.
+                macro: Current macroeconomic context; unused.
+                cultural_wisdom: Unused; accepted to match the real signature.
+                cultural_warnings: Unused; accepted to match the real signature.
+                adjustments: Unused; accepted to match the real signature.
+
+            Returns:
+                A fixed all-cash PortfolioAllocation.
+            """
+            return PortfolioAllocation(
+                session_id=str(uuid4()),
+                user_investable_capital=float(user_profile.get("total_wealth") or 0.0),
+                portfolio=[],
+                cash_reserve_pct=1.0,
+                expected_sharpe=0.0,
+                rebalance_trigger="MONTHLY",
+                timestamp=datetime.now(),
+            )
+
+        mock_portfolio.side_effect = portfolio_side_effect
 
         state = ARGUSState(
             ticker="AAPL",


### PR DESCRIPTION
## Summary

PR #31 (RE-4) fixed the diversification-floor bug that was hard-VETOing
every ticker in a 2-4 ticker universe. `test_full_graph_smoke`'s universe
is `["AAPL", "MSFT"]` — exactly that range — so before the fix, risk
evaluation VETOed both tickers on every run, and `PortfolioManagerAgent.allocate`
short-circuited to its all-cash fast path (`if not approved_tickers: return
self._all_cash_allocation(...)`) without ever calling the LLM.

With RE-4 fixed, this universe now clears risk approval, so `allocate()`
proceeds to its real Groq call. CI intentionally leaves `GROQ_API_KEY` unset
(see `.github/workflows/ci.yml`) on the theory that "LLM agents are mocked or
fixture-backed in CI" — true for the fundamental/sentiment agents this test
already mocks, but not for the portfolio agent. The call now fails after three
retries, `allocate()` returns `None`, and `assert alloc is not None` fails.

This is what broke CI on `main` after PR #31 merged
(https://github.com/nevilcp/argus/actions/runs/31900169049).

Fix: mock `PortfolioManagerAgent.allocate` in this test the same way
`FundamentalAgent.analyze` and `SentimentAgent.analyze` already are, returning
a fixed all-cash allocation. The test still exercises full graph wiring
end-to-end against live market data; only the LLM boundary is stubbed.

## Test plan

- [x] `GROQ_API_KEY="" .venv/bin/python -m pytest tests/test_integration.py::TestEndToEnd::test_full_graph_smoke -v` passes locally
- [x] `.venv/bin/python -m pytest tests/ -q` — 233 passed
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/mypy argus api scripts` (pre-existing unrelated errors only, verified against main)