### PR TITLE
Stop contaminating the learning loop

### DIFF
--- a/argus/backtesting/replay.py
+++ b/argus/backtesting/replay.py
@@ -131,7 +131,10 @@ def replay_session(
             via `as_of` to what existed as of this session's own capture
             date — never outcomes from sessions replayed "later" in this
             call. The evaluation runs both so it can compare the two
-            conditions.
+            conditions. Either way, `as_of` is also what node_log_decisions
+            stamps each decision's session_timestamp with, so a replayed
+            decision's date is always the fixture's capture date, never
+            replay wall-clock time.
 
     Returns:
         SessionResult with the session's universe and the graph's final state.
@@ -147,7 +150,7 @@ def replay_session(
         risk_tolerance=risk_tolerance,
         backtest_mode=False,
         session_seed=None,
-        as_of=session_date if closed_loop else None,
+        as_of=session_date,
         price_history={},
         session_states=session_states,
         macro_context=None,
@@ -189,27 +192,7 @@ def replay_session(
                 )
             final_state = graph.invoke(state, config)
 
-    _rebase_decision_timestamps(final_state, session_states)
     return SessionResult(session_dir=session_dir, universe=universe, final_state=final_state)
-
-
-def _rebase_decision_timestamps(final_state: dict[str, Any], session_states: dict[str, dict]) -> None:
-    """Overwrites each decision's session_timestamp with the fixture's captured point-in-time date.
-
-    node_log_decisions stamps session_timestamp with datetime.now() — correct
-    for a live session (the decision genuinely happens now), wrong for a
-    replayed one: the fixture's session_states were captured on a real past
-    date (its "timestamp" field), and PR 10's evaluation needs that date, not
-    replay wall-clock time, to look up a forward return. Every ticker in a
-    session shares one capture date, so any one of them is representative.
-    """
-    decisions = final_state.get("decisions") or []
-    if not decisions or not session_states:
-        return
-    session_date = datetime.fromisoformat(next(iter(session_states.values()))["timestamp"])
-    final_state["decisions"] = [
-        d.model_copy(update={"session_timestamp": session_date}) for d in decisions
-    ]
 
 
 def replay_sessions(session_dirs: list[Path], **kwargs: Any) -> list[SessionResult]:

--- a/argus/memory/cultural.py
+++ b/argus/memory/cultural.py
@@ -163,6 +163,16 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
                 }
             ],
         )
+
+        # The PENDING snapshot has now settled into a trade_{id} row; leaving it
+        # in place would double-count the decision (dragging down avg_return_pct
+        # via its zero return_pct) in summary_stats
+        snapshot_id = f"snapshot_{decision.decision_id}"
+        try:
+            self.collection.delete(ids=[snapshot_id])
+        except Exception as e:
+            logger.warning("[Memory] Failed to delete snapshot %s: %s", snapshot_id, e)
+
         logger.info("[Memory] Stored %s trade pattern. Total: %d", prefix, self.collection.count())
 
     def retrieve_wisdom(
@@ -359,7 +369,7 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
             logger.warning("[Memory] Failed to compute summary stats: %s", e)
             return {"total_stored": count}
 
-    def store_decision_snapshot(self, decision: "ARGUSDecision") -> None:
+    def store_decision_snapshot(self, decision: "ARGUSDecision") -> bool:
         """Persists a real-time decision profile before outcomes are finalized.
 
         Populates the vector store with decision-making context, enabling retrieval
@@ -367,6 +377,9 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
 
         Args:
             decision: In-flight ARGUSDecision captured at signal generation time.
+
+        Returns:
+            True if the snapshot was written, False if the write failed.
         """
         try:
             macro_regime = decision.macro.macro_regime.value if decision.macro else "unknown"
@@ -408,8 +421,10 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
                 decision.ticker,
                 decision.decision_id,
             )
+            return True
         except Exception as e:
             logger.warning("[Memory] Failed to snapshot decision for %s: %s", decision.ticker, e)
+            return False
 
 
 _cultural_memory: Optional[CulturalMemoryManager] = None

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -340,6 +340,7 @@ def build_graph(
         macro = state.get("macro_context")
         as_of = state.get("as_of")
         agent_names = ("technical", "fundamental", "sentiment")
+        model_healthy = True
 
         if macro is not None:
             # Per-regime reliability doesn't depend on ticker, so compute it once
@@ -359,6 +360,7 @@ def build_graph(
                 logger.warning("node_signal_aggregation: cultural memory unavailable: %s", exc)
                 reliability = {name: 0.5 for name in agent_names}
                 reliability_n = {name: 0 for name in agent_names}
+                model_healthy = False
         else:
             reliability = {name: 0.5 for name in agent_names}
             reliability_n = {name: 0 for name in agent_names}
@@ -369,8 +371,11 @@ def build_graph(
             sent = state.get("sentiment_signals", {}).get(ticker)
             if tech is None and fund is None and sent is None:
                 continue
-            aggs[ticker] = aggregator.aggregate(
+            agg = aggregator.aggregate(
                 tech, macro, fund, sent, reliability=reliability, reliability_n=reliability_n
+            )
+            aggs[ticker] = (
+                agg if model_healthy else agg.model_copy(update={"model_healthy": False})
             )
         return {"aggregated_signals": aggs}
 
@@ -555,7 +560,8 @@ def build_graph(
             state: ARGUSState with all fields populated from prior nodes.
 
         Returns:
-            Partial state update with ``decisions`` list of completed ARGUSDecision objects.
+            Partial state update with ``decisions`` list of completed ARGUSDecision
+            objects and ``errors`` naming any per-ticker construction failures.
         """
         allocation = state.get("portfolio_allocation")
         if not allocation:
@@ -563,9 +569,20 @@ def build_graph(
             return {"decisions": []}
 
         positions = {pos.ticker: pos for pos in allocation.portfolio}
-        now = datetime.now()
+        # A replayed session's as_of is the fixture's own capture date; falling back
+        # to wall-clock only applies to genuinely live sessions
+        now = state.get("as_of") or datetime.now()
         decisions: list[ARGUSDecision] = []
+        errors: list[str] = []
 
+        try:
+            memory = get_cultural_memory()
+        except ImportError as exc:
+            # Same optional-dependency guard as node_retrieve_cultural_memory
+            logger.warning("node_log_decisions: cultural memory unavailable: %s", exc)
+            memory = None
+
+        snapshots_stored = 0
         for ticker in state.get("universe", []):
             try:
                 decision = ARGUSDecision(
@@ -582,17 +599,20 @@ def build_graph(
                 decisions.append(decision)
 
                 # Snapshot stored pre-confirmation to enable pre-settlement similarity retrieval
-                get_cultural_memory().store_decision_snapshot(decision)
+                if memory is not None and memory.store_decision_snapshot(decision):
+                    snapshots_stored += 1
 
             except Exception as exc:
-                logger.warning("[log_decisions] Failed to build decision for %s: %s", ticker, exc)
+                msg = f"log_decisions: failed to build decision for {ticker}: {exc}"
+                logger.warning("[log_decisions] %s", msg)
+                errors.append(msg)
 
         logger.info(
             "[log_decisions] Logged %d/%d decisions to cultural memory.",
-            len(decisions),
+            snapshots_stored,
             len(state.get("universe", [])),
         )
-        return {"decisions": decisions}
+        return {"decisions": decisions, "errors": errors}
 
     builder = StateGraph(ARGUSState)
 

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -168,11 +168,15 @@ def compute_realized_return(
     Returns:
         (actual_return_pct, holding_days, exit_reason), or None when there is
         nothing to reconcile: no technical signal (no entry price), no
-        allocation (no position was taken), or the price series doesn't yet
-        extend past the target exit date — horizon not reached, deferred
-        rather than fabricated.
+        allocation or a zero/negative-weight allocation (no position was
+        taken), or the price series doesn't yet extend past the target exit
+        date — horizon not reached, deferred rather than fabricated.
     """
-    if decision.technical is None or decision.allocation is None:
+    if (
+        decision.technical is None
+        or decision.allocation is None
+        or decision.allocation.allocation_pct <= 0
+    ):
         return None
 
     entry_price = decision.technical.current_price

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -441,6 +441,16 @@ class AggregatedSignal(BaseModel):
             "memory per ticker."
         ),
     )
+    model_healthy: bool = Field(
+        True,
+        description=(
+            "False when reliability weighting fell back to the 0.5 neutral prior "
+            "because cultural memory was unavailable (e.g. an ImportError on its "
+            "optional [models] extra), rather than because no outcome history "
+            "exists yet. Distinguishes a broken dependency from a genuinely new "
+            "system — see reliability_n for the latter, which is 0 in both cases."
+        ),
+    )
 
 
 class PositionAllocation(BaseModel):
@@ -492,6 +502,23 @@ class PortfolioAllocation(BaseModel):
     )
     api_calls_used: int = Field(1, ge=0)
     timestamp: datetime = Field(..., description="UTC timestamp of signal production")
+
+    @field_validator("portfolio")
+    @classmethod
+    def tickers_are_unique(
+        cls, portfolio: list[PositionAllocation]
+    ) -> list[PositionAllocation]:
+        """Rejects a portfolio with a repeated ticker.
+
+        Every downstream consumer (node_log_decisions, risk cap enforcement)
+        keys positions by ticker; a duplicate would silently overwrite one
+        of the two allocations rather than raising.
+        """
+        seen = [pos.ticker for pos in portfolio]
+        duplicates = {t for t in seen if seen.count(t) > 1}
+        if duplicates:
+            raise ValueError(f"Duplicate ticker(s) in portfolio: {sorted(duplicates)}")
+        return portfolio
 
     @model_validator(mode="after")
     def total_allocation_sums_to_one(self) -> "PortfolioAllocation":

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -47,6 +47,27 @@ def test_replay_session_never_touches_the_production_checkpoint_db(tmp_path, mon
     assert not (tmp_path / "argus_graph.db").exists()
 
 
+def test_replay_session_stamps_decisions_with_the_fixture_capture_date():
+    """Every replayed decision's session_timestamp is the fixture's own capture date.
+
+    Regression test for LD-2: node_log_decisions previously stamped
+    datetime.now() regardless of as_of, so a closed_loop=True replay wrote
+    wall-clock dates straight into the real ./chroma_db via
+    store_decision_snapshot before any post-hoc rebase could run. as_of is
+    now always passed to the graph, and node_log_decisions uses it directly
+    (or falls back to wall-clock only when it is unset, as in a live session).
+    """
+    with open(FIXTURES_DIR / "market_data" / "session_states.json") as f:
+        session_states = json.load(f)
+    expected_date = datetime.fromisoformat(next(iter(session_states.values()))["timestamp"])
+
+    result = replay_session(FIXTURES_DIR, closed_loop=False)
+
+    decisions = result.final_state.get("decisions") or []
+    assert decisions
+    assert all(d.session_timestamp == expected_date for d in decisions)
+
+
 def test_replay_session_closed_loop_scopes_cultural_memory_to_the_session_date():
     """closed_loop=True must pass the fixture's own capture date as `as_of`.
 

--- a/tests/test_cultural.py
+++ b/tests/test_cultural.py
@@ -179,6 +179,49 @@ def test_store_trade_outcome_writes_vix_regime_value_not_enum_repr():
     assert "VixRegime" not in document
 
 
+def test_store_trade_outcome_deletes_the_settled_pending_snapshot():
+    """Storing a trade outcome removes the snapshot_{id} row it settles.
+
+    Regression test for LD-5: leaving the PENDING snapshot in place after the
+    trade settles double-counts the decision in summary_stats via the
+    snapshot's zero return_pct.
+    """
+    manager = _manager_with_metadatas([])
+    decision = ARGUSDecision(ticker="AAPL", session_timestamp=datetime.now())
+
+    manager.store_trade_outcome(
+        decision,
+        actual_return_pct=0.05,
+        holding_days=3,
+        exit_reason="target_hit",
+        primary_driver="technical",
+    )
+
+    manager.collection.delete.assert_called_once_with(ids=[f"snapshot_{decision.decision_id}"])
+
+
+def test_store_decision_snapshot_returns_true_on_success():
+    """A successful upsert reports success so callers can count real writes."""
+    manager = _manager_with_metadatas([])
+    decision = ARGUSDecision(ticker="AAPL", session_timestamp=datetime.now())
+
+    assert manager.store_decision_snapshot(decision) is True
+
+
+def test_store_decision_snapshot_returns_false_on_failure():
+    """A failed upsert reports failure instead of silently swallowing it.
+
+    Regression test for LD-3: store_decision_snapshot previously returned None
+    unconditionally, so node_log_decisions logged every built decision as
+    "logged to cultural memory" even when the write itself failed.
+    """
+    manager = _manager_with_metadatas([])
+    manager.collection.upsert.side_effect = RuntimeError("chroma write failed")
+    decision = ARGUSDecision(ticker="AAPL", session_timestamp=datetime.now())
+
+    assert manager.store_decision_snapshot(decision) is False
+
+
 def test_retrieve_wisdom_and_retrieve_warnings_apply_a_symmetric_regime_filter():
     """retrieve_wisdom filters on regime exactly like retrieve_warnings does.
 

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -294,6 +294,7 @@ def test_golden_dag_runs_offline_and_produces_a_valid_allocation():
     assert final_state.get("sentiment_signals")
     assert final_state.get("risk_assessments")
     assert final_state.get("aggregated_signals")
+    assert all(agg.model_healthy is True for agg in final_state["aggregated_signals"].values())
 
     # The fixture LLM response proposes allocations for three VETO'd tickers;
     # code-level enforcement (PR 4, PA-1) zeroes them rather than trusting the
@@ -418,6 +419,13 @@ def test_cultural_memory_import_error_degrades_instead_of_crashing_the_run():
     assert final_state.get("cultural_memory") == {"wisdom": [], "warnings": []}
     assert final_state.get("portfolio_allocation") is not None
     assert len(final_state["portfolio_allocation"].portfolio) == len(UNIVERSE)
+
+    # SA-5: reliability fell back to the 0.5 prior because cultural memory was
+    # unavailable, not because no outcome history exists yet — model_healthy
+    # must say so rather than carrying full multiplier authority silently.
+    aggs = final_state.get("aggregated_signals") or {}
+    assert aggs
+    assert all(agg.model_healthy is False for agg in aggs.values())
 
 
 def test_golden_dag_output_is_stable_across_runs():

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -373,6 +373,32 @@ def test_compute_realized_return_none_without_technical_signal():
     assert compute_realized_return(decision, market_data, horizon_days=5) is None
 
 
+def test_compute_realized_return_none_with_zero_weight_allocation():
+    """A decision allocated 0% has no position to reconcile, matching no allocation at all.
+
+    Regression test for LD-1: filtering 0%-weight positions belongs at the
+    reconciliation boundary, not at graph.py's decision-building step (which
+    would break the audit trail of "we evaluated this ticker and chose not
+    to hold").
+    """
+    decision = ARGUSDecision(
+        ticker="TEST",
+        session_timestamp=datetime(2026, 1, 1),
+        technical=_technical(Signal.BULLISH, 0.8),
+        allocation=PositionAllocation(
+            ticker="TEST",
+            allocation_pct=0.0,
+            allocation_usd=0.0,
+            stop_loss=90.0,
+            thesis="no position taken",
+            composite_conviction=0.0,
+            time_horizon="30 days",
+        ),
+    )
+    market_data = _ten_day_series(datetime(2026, 1, 1))
+    assert compute_realized_return(decision, market_data, horizon_days=5) is None
+
+
 def test_compute_realized_return_none_when_horizon_not_yet_reached():
     """No return is computed until price data reaches the requested horizon."""
     start = datetime(2026, 1, 1)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,56 @@
+"""
+tests/test_signals.py
+
+Tests for schema-level validators in argus/schemas/signals.py that aren't
+already covered end to end by the modules exercising them.
+"""
+
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from argus.schemas.signals import PortfolioAllocation, PositionAllocation
+
+
+def _position(ticker: str) -> PositionAllocation:
+    return PositionAllocation(
+        ticker=ticker,
+        allocation_pct=0.05,
+        allocation_usd=5_000.0,
+        stop_loss=90.0,
+        thesis="test thesis",
+        composite_conviction=0.6,
+        time_horizon="30 days",
+    )
+
+
+def test_portfolio_allocation_rejects_a_duplicate_ticker():
+    """A repeated ticker in the portfolio list is rejected.
+
+    Regression test for LD-6: node_log_decisions and risk cap enforcement key
+    positions by ticker, so a duplicate would silently overwrite one of the
+    two allocations rather than raising.
+    """
+    with pytest.raises(ValidationError, match="Duplicate ticker"):
+        PortfolioAllocation(
+            session_id="s1",
+            user_investable_capital=100_000.0,
+            portfolio=[_position("AAPL"), _position("AAPL")],
+            cash_reserve_pct=0.90,
+            rebalance_trigger="VIX > 35",
+            timestamp=datetime.now(),
+        )
+
+
+def test_portfolio_allocation_accepts_unique_tickers():
+    """Distinct tickers pass the uniqueness validator."""
+    alloc = PortfolioAllocation(
+        session_id="s1",
+        user_investable_capital=100_000.0,
+        portfolio=[_position("AAPL"), _position("MSFT")],
+        cash_reserve_pct=0.90,
+        rebalance_trigger="VIX > 35",
+        timestamp=datetime.now(),
+    )
+    assert len(alloc.portfolio) == 2


### PR DESCRIPTION
Part of #24 (PR 7). Findings: LD-1 … LD-7, SA-5.

## Summary

- **LD-1** — extend `compute_realized_return`'s guard so a zero/negative-weight
  allocation has nothing to reconcile, scoped to the reconciliation boundary
  rather than decision-build time (which would have broken the audit trail of
  "we evaluated this ticker and chose not to hold").
- **LD-2** — `node_log_decisions` stamps `session_timestamp` from
  `state["as_of"]` when set, falling back to wall-clock only for a genuinely
  live session. `replay_session` now always passes the fixture's own capture
  date as `as_of` (previously only when `closed_loop=True`), which fixes the
  real bug: a closed-loop replay was writing wall-clock dates straight into
  the real `./chroma_db` via `store_decision_snapshot` before the old
  post-hoc `_rebase_decision_timestamps` step ever ran. That step is now
  redundant and removed.
- **LD-3** — `store_decision_snapshot` returns whether the write actually
  succeeded; `node_log_decisions` counts real successes instead of decisions
  built, so a broken write path no longer logs a false `20/20`.
- **LD-4** — hoist `get_cultural_memory()` above the per-ticker loop in
  `node_log_decisions`, with the same `ImportError` guard its sibling nodes
  already use.
- **LD-5** — `store_trade_outcome` deletes the settled `snapshot_{id}` row so
  it stops double-counting the decision in `summary_stats` via the snapshot's
  zero `return_pct`.
- **LD-6** — `PortfolioAllocation` rejects a portfolio with a duplicate
  ticker (every downstream consumer keys positions by ticker).
- **LD-7** — `node_log_decisions` reports per-ticker `ARGUSDecision`
  construction failures through `errors`, not just a log line.
- **SA-5** — `AggregatedSignal` carries `model_healthy`, set `False` when
  reliability weighting fell back to the 0.5 prior because cultural memory
  was unavailable (e.g. the `[models]` extra isn't installed), distinct from
  falling back because no outcome history exists yet.

## Test plan

- [x] New regression tests: `test_compute_realized_return_none_with_zero_weight_allocation`,
      `test_store_decision_snapshot_returns_{true,false}_on_{success,failure}`,
      `test_store_trade_outcome_deletes_the_settled_pending_snapshot`,
      `test_portfolio_allocation_{rejects_a_duplicate_ticker,accepts_unique_tickers}`,
      `test_replay_session_stamps_decisions_with_the_fixture_capture_date`,
      plus `model_healthy` assertions added to the existing golden-DAG healthy-
      run and cultural-memory-ImportError tests.
- [x] `GROQ_API_KEY="" .venv/bin/python -m pytest tests/ -q` — 233 passed
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/mypy argus api scripts` (pre-existing unrelated errors only, verified against main)