### PR TITLE
Finish the remaining lifecycle and contract cleanup

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -121,12 +121,15 @@ def _log_task_exception(task: asyncio.Task, name: str) -> None:
         logger.error("[%s] background task crashed: %s", name, exc, exc_info=exc)
 
 
-async def _collector_loop(pipeline: MFTDataPipeline) -> None:
+async def _collector_loop(pipeline: MFTDataPipeline, compiled_graph) -> None:
     """Runs run_collection_cycle on a fixed interval for as long as the app is alive.
 
     Args:
         pipeline: The shared MFT pipeline instance, so this loop reuses the
             same warm buffer the live /analyze cache draws from.
+        compiled_graph: The shared, already-built graph (module-level
+            ``_graph``) — the same instance /analyze invokes, so this loop
+            reopens no extra SqliteSaver connection on every cycle.
     """
     global _last_collection_result
     while True:
@@ -137,7 +140,7 @@ async def _collector_loop(pipeline: MFTDataPipeline) -> None:
                 invest_pct=settings.ARGUS_INVEST_PCT,
                 risk_tolerance=settings.ARGUS_RISK_TOLERANCE,
                 pipeline=pipeline,
-                checkpoint_db_path=f"{settings.ARGUS_DATA_DIR}/argus_graph.db",
+                compiled_graph=compiled_graph,
                 decisions_log_path=f"{settings.ARGUS_DATA_DIR}/decisions.jsonl",
             )
             logger.info("[Collector] cycle result: %s", _last_collection_result)
@@ -197,7 +200,7 @@ async def lifespan(app: FastAPI):
     )
 
     if settings.ARGUS_COLLECTOR_ENABLED:
-        _collector_task = asyncio.create_task(_collector_loop(_mft_pipeline))
+        _collector_task = asyncio.create_task(_collector_loop(_mft_pipeline, _graph))
         _collector_task.add_done_callback(lambda t: _log_task_exception(t, "CollectorLoop"))
         logger.info(
             "[Startup] Unattended collector loop launched (interval=%ds).",

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -234,7 +234,11 @@ class PortfolioManagerAgent:
                 cultural memory, scoped to the current macro regime.
             adjustments: Optional list that receives one human-readable entry per
                 clamped, zeroed, or dropped position — the caller's record of
-                where the LLM's proposal disagreed with risk enforcement.
+                where the LLM's proposal disagreed with risk enforcement. Also
+                receives one entry naming which of the three retry-loop stages
+                (``llm_call``, ``json_parse``, ``response_enforcement``, or
+                ``schema_validation``) was failing when all 3 attempts were
+                exhausted, if that happens.
 
         Returns:
             A validated PortfolioAllocation, all-cash if no tickers are approved, or None
@@ -345,6 +349,7 @@ class PortfolioManagerAgent:
             '"cash_reserve_pct":0.0,"expected_sharpe":null,"rebalance_trigger":"MONTHLY"}'
         )
         for attempt in range(3):
+            stage = "llm_call"
             try:
                 raw = self.llm_client.complete(SYSTEM_PROMPT, prompt).strip()
                 if raw.startswith("```"):
@@ -357,8 +362,10 @@ class PortfolioManagerAgent:
                     if raw.startswith("json"):
                         raw = raw[4:].strip()
 
+                stage = "json_parse"
                 data = json.loads(raw)
 
+                stage = "response_enforcement"
                 # Enforce risk verdicts in code: the LLM's proposal is advisory input,
                 # not a binding allocation, so it cannot be trusted to respect caps it
                 # was merely shown in the prompt.
@@ -420,17 +427,21 @@ class PortfolioManagerAgent:
                 data["user_investable_capital"] = investable
                 data["timestamp"] = datetime.now().isoformat()
 
+                stage = "schema_validation"
                 allocation = PortfolioAllocation.model_validate(data)
                 self._session_count += 1
                 return allocation
 
             except Exception as e:
-                logger.warning("[Portfolio] Attempt %d failed: %s", attempt + 1, e)
+                logger.warning("[Portfolio] Attempt %d failed (%s): %s", attempt + 1, stage, e)
                 if attempt == 2:
-                    logger.error(
-                        "[Portfolio] All retry attempts exhausted. "
-                        "Returning None to allow graceful exit rather than a fabricated allocation."
+                    msg = (
+                        f"portfolio_allocation: PortfolioManagerAgent failed after 3 attempts "
+                        f"at {stage}: {e}"
                     )
+                    logger.error("[Portfolio] %s", msg)
+                    if adjustments is not None:
+                        adjustments.append(msg)
                     return None
                 time.sleep(2**attempt)
 

--- a/argus/backtesting/replay.py
+++ b/argus/backtesting/replay.py
@@ -15,8 +15,8 @@ the system's "return None rather than fabricate defaults" rule.
 
 A "session" here is one fixture snapshot directory shaped like
 tests/fixtures/ (market_data/ + llm_responses/ subdirectories) — one real
-point-in-time capture of everything the graph needs, in the same format
-scripts/capture_fixtures.py produces. Point-in-time correctness is
+point-in-time capture of everything the graph needs, hand-captured in the
+same format. Point-in-time correctness is
 structural here, not runtime-enforced (contrast the deleted
 PointInTimeEnforcer): each session's FixtureMarketDataProvider is scoped to
 that session's own directory, so a later session's data cannot leak into an

--- a/argus/memory/cultural.py
+++ b/argus/memory/cultural.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 import os
 from datetime import datetime
+from threading import Lock
 from typing import Any, Optional
 
 from argus.params import MEMORY, RECONCILIATION
@@ -86,6 +87,26 @@ class CulturalMemoryManager:
         )
         self.persist_dir = persist_dir
         logger.info("[Memory] Cultural Memory Manager initialized at %s", persist_dir)
+
+    def already_reconciled(self, decision_ids: list[str]) -> set[str]:
+        """Returns the subset of decision_ids that already have a stored trade outcome.
+
+        A single batched ``get`` rather than one existence check per decision,
+        so a caller reconciling a growing history of decisions (see
+        orchestration/reconciliation.py) can filter its work list down to
+        unreconciled decisions before touching market data at all.
+
+        Args:
+            decision_ids: Candidate ARGUSDecision.decision_id values.
+
+        Returns:
+            The subset already stored under a ``trade_{decision_id}`` row.
+        """
+        if not decision_ids:
+            return set()
+        ids = [f"trade_{decision_id}" for decision_id in decision_ids]
+        results = self.collection.get(ids=ids)
+        return {stored_id.removeprefix("trade_") for stored_id in results.get("ids") or []}
 
     def store_trade_outcome(
         self,
@@ -428,6 +449,7 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
 
 
 _cultural_memory: Optional[CulturalMemoryManager] = None
+_cultural_memory_lock = Lock()
 
 
 def get_cultural_memory(persist_dir: str = "./chroma_db") -> CulturalMemoryManager:
@@ -449,8 +471,11 @@ def get_cultural_memory(persist_dir: str = "./chroma_db") -> CulturalMemoryManag
     """
     global _cultural_memory
     if _cultural_memory is None:
-        _cultural_memory = CulturalMemoryManager(persist_dir)
-    elif os.path.abspath(persist_dir) != _cultural_memory.persist_dir:
+        with _cultural_memory_lock:
+            if _cultural_memory is None:
+                _cultural_memory = CulturalMemoryManager(persist_dir)
+                return _cultural_memory
+    if os.path.abspath(persist_dir) != _cultural_memory.persist_dir:
         logger.warning(
             "[Memory] get_cultural_memory(persist_dir=%r) ignored; the process-wide "
             "singleton is already initialized at %s.",

--- a/argus/orchestration/collector.py
+++ b/argus/orchestration/collector.py
@@ -11,8 +11,8 @@ call it, so the two deployment paths can't drift apart from each other.
 
 Responsibilities:
   - Run one MFT fetch-and-compress sweep via MFTDataPipeline.run_once()
-  - Invoke the LangGraph DAG (via build_graph(), not the module-level
-    singleton) over whatever tickers the sweep actually populated
+  - Invoke the caller-supplied compiled LangGraph DAG over whatever tickers
+    the sweep actually populated
   - Append every resulting ARGUSDecision to a JSONL decision log
 
 Not responsible for:
@@ -30,7 +30,6 @@ from datetime import datetime
 from pathlib import Path
 
 from argus.data.pipeline import MFTDataPipeline
-from argus.orchestration.graph import build_graph
 from argus.orchestration.state import ARGUSState
 from argus.schemas.signals import ARGUSDecision
 
@@ -82,7 +81,7 @@ async def run_collection_cycle(
     risk_tolerance: str,
     *,
     pipeline: MFTDataPipeline,
-    checkpoint_db_path: str = "argus_graph.db",
+    compiled_graph,
     decisions_log_path: str = "data/decisions.jsonl",
 ) -> CollectionResult:
     """Runs one unattended fetch → analyze → log cycle for the given universe.
@@ -101,10 +100,12 @@ async def run_collection_cycle(
             (rather than built here) so a long-lived caller — the API
             process's background loop — reuses its warm buffer across cycles
             instead of starting cold every time.
-        checkpoint_db_path: SQLite file build_graph() checkpoints to. Callers
-            that don't need durable checkpoints (the scheduled Actions
-            runner, which persists only decisions_log_path) should point
-            this at an ephemeral path.
+        compiled_graph: Already-built graph (build_graph()) to invoke. Passed
+            in for the same reason as ``pipeline``: a long-lived caller builds
+            the six agents (LLM clients, the macro HMM classifier load) once
+            rather than reconstructing them every cycle. Each ``.invoke()``
+            still opens its own checkpoint connection — see
+            graph.py's ``_CheckpointedGraph``.
         decisions_log_path: JSONL file each cycle's decisions are appended to.
 
     Returns:
@@ -120,7 +121,7 @@ async def run_collection_cycle(
 
     state: ARGUSState = ARGUSState(
         ticker=tickers_with_data[0],
-        universe=universe,
+        universe=tickers_with_data,
         total_wealth=total_wealth,
         invest_pct=invest_pct,
         risk_tolerance=risk_tolerance,
@@ -141,7 +142,6 @@ async def run_collection_cycle(
         errors=[],
     )
 
-    compiled_graph = build_graph(checkpoint_db_path=checkpoint_db_path)
     config = {"configurable": {"thread_id": f"collector-{datetime.now().strftime('%Y%m%d%H%M%S')}"}}
 
     logger.info(

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -35,6 +35,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+from chromadb.errors import ChromaError
+from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langgraph.graph import END, StateGraph
@@ -78,6 +80,60 @@ def build_checkpoint_serde() -> JsonPlusSerializer:
             ("argus.schemas.signals", cls) for cls in _CHECKPOINT_MODEL_CLASSES
         ]
     )
+
+
+def _open_checkpointer(checkpoint_db_path: str) -> Optional[SqliteSaver]:
+    """Opens a fresh SqliteSaver connection, or None if the path can't be opened.
+
+    Args:
+        checkpoint_db_path: SQLite file to checkpoint to.
+
+    Returns:
+        A new SqliteSaver, or None on any I/O failure (a checkpointer-less
+        compile still runs the graph, just without resumability).
+    """
+    try:
+        if checkpoint_db_path != ":memory:":
+            Path(checkpoint_db_path).parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(checkpoint_db_path, check_same_thread=False)
+        return SqliteSaver(conn, serde=build_checkpoint_serde())
+    except Exception:
+        return None
+
+
+class _CheckpointedGraph:
+    """Compiles the DAG fresh, with its own SQLite connection, on every invoke().
+
+    StateGraph.compile() does no I/O beyond opening the checkpoint connection;
+    the expensive part — constructing the six agents (LLM clients, the macro
+    HMM classifier load from disk) — happens once in build_graph() and is
+    captured in the node closures this wraps. Concurrent callers (parallel
+    /analyze requests, the unattended collector loop) therefore each get their
+    own sqlite3.Connection instead of contending on one shared checkpointer.
+    """
+
+    def __init__(self, builder: StateGraph, checkpoint_db_path: str):
+        """Stores the built (but not compiled) graph and its checkpoint path."""
+        self._builder = builder
+        self._checkpoint_db_path = checkpoint_db_path
+
+    def invoke(self, state: ARGUSState, config: Optional[RunnableConfig] = None) -> dict:
+        """Compiles with a fresh checkpointer and invokes the graph once.
+
+        Args:
+            state: Initial ARGUSState for this session.
+            config: LangGraph run config, e.g. ``{"configurable": {"thread_id": ...}}``.
+
+        Returns:
+            The final ARGUSState dict produced by the run.
+        """
+        checkpointer = _open_checkpointer(self._checkpoint_db_path)
+        compiled = self._builder.compile(checkpointer=checkpointer)
+        try:
+            return compiled.invoke(state, config)
+        finally:
+            if checkpointer is not None:
+                checkpointer.conn.close()
 
 
 def _summarize_technical_posture(aggregated_signals: dict[str, AggregatedSignal]) -> str:
@@ -161,14 +217,16 @@ def build_graph(
             client.
         portfolio_llm: LLMClient for PortfolioManagerAgent. Defaults to a real
             Groq client.
-        checkpoint_db_path: SQLite file the compiled graph checkpoints
-            ARGUSState to after each run. Exposed (rather than hardcoded) so
-            tests — and argus/orchestration/reconciliation.py's own tests —
-            can point it at a temp file instead of the real
-            argus_graph.db production callers use.
+        checkpoint_db_path: SQLite file each invocation checkpoints ARGUSState
+            to. Exposed (rather than hardcoded) so tests — and
+            argus/orchestration/reconciliation.py's own tests — can point it
+            at a temp file instead of the real argus_graph.db production
+            callers use.
 
     Returns:
-        A compiled LangGraph graph, ready for .invoke()/.ainvoke().
+        A _CheckpointedGraph, ready for .invoke(). Recompiles with a fresh
+        checkpointer connection on every call rather than baking one
+        connection into a single compiled graph — see _CheckpointedGraph.
     """
     market_data = market_data or LiveMarketDataProvider()
 
@@ -303,9 +361,11 @@ def build_graph(
 
         try:
             memory = get_cultural_memory()
-        except ImportError as exc:
-            # sentence-transformers/torch are an optional [models] extra; their
-            # absence degrades to the same empty result as no macro context
+        except (ImportError, OSError, ChromaError) as exc:
+            # ImportError: sentence-transformers/torch are an optional [models]
+            # extra. OSError/ChromaError: persist_dir unwritable or an
+            # incompatible on-disk Chroma schema. All three degrade to the same
+            # empty result as no macro context, rather than crashing the node
             logger.warning("node_retrieve_cultural_memory: cultural memory unavailable: %s", exc)
             return {"cultural_memory": {"wisdom": [], "warnings": []}}
 
@@ -354,9 +414,9 @@ def build_graph(
                 }
                 reliability = {name: accuracy[name][0] for name in agent_names}
                 reliability_n = {name: accuracy[name][1] for name in agent_names}
-            except ImportError as exc:
-                # Same optional-dependency guard as node_retrieve_cultural_memory;
-                # degrade every agent to the 0.5 neutral prior rather than crash
+            except (ImportError, OSError, ChromaError) as exc:
+                # Same guard as node_retrieve_cultural_memory; degrade every
+                # agent to the 0.5 neutral prior rather than crash
                 logger.warning("node_signal_aggregation: cultural memory unavailable: %s", exc)
                 reliability = {name: 0.5 for name in agent_names}
                 reliability_n = {name: 0 for name in agent_names}
@@ -511,8 +571,13 @@ def build_graph(
         Returns:
             Partial state update with ``portfolio_allocation``.
         """
+        # Scoped to tickers with an aggregated signal, not the whole universe: a
+        # ticker every specialist failed on has nothing to allocate against, and
+        # an all-None entry would still pass build_signal_table's is-approved
+        # filter through to _is_risk_approved(None) -> False silently rather than
+        # never appearing in all_signals at all
         signals_dict = {}
-        for ticker in state["universe"]:
+        for ticker in state.get("aggregated_signals", {}):
             signals_dict[ticker] = {
                 "technical": state.get("technical_signals", {}).get(ticker),
                 "fundamental": state.get("fundamental_signals", {}).get(ticker),
@@ -543,12 +608,11 @@ def build_graph(
             profile, signals_dict, macro, wisdom, warnings, adjustments=errors
         )
         if alloc is None:
+            # allocate() has already appended the specific failing stage (LLM call,
+            # JSON parse, response enforcement, or schema validation) to errors
             logger.error(
-                "node_portfolio_allocation: PortfolioManagerAgent returned None (LLM API failure). "
+                "node_portfolio_allocation: PortfolioManagerAgent returned None. "
                 "Skipping portfolio_allocation to allow graceful exit."
-            )
-            errors.append(
-                "portfolio_allocation: PortfolioManagerAgent returned None (LLM API failure)"
             )
             return {"errors": errors}
         return {"portfolio_allocation": alloc, "errors": errors}
@@ -577,8 +641,8 @@ def build_graph(
 
         try:
             memory = get_cultural_memory()
-        except ImportError as exc:
-            # Same optional-dependency guard as node_retrieve_cultural_memory
+        except (ImportError, OSError, ChromaError) as exc:
+            # Same guard as node_retrieve_cultural_memory
             logger.warning("node_log_decisions: cultural memory unavailable: %s", exc)
             memory = None
 
@@ -654,12 +718,4 @@ def build_graph(
     builder.add_edge("portfolio_allocation", "log_decisions")
     builder.add_edge("log_decisions", END)
 
-    try:
-        if checkpoint_db_path != ":memory:":
-            Path(checkpoint_db_path).parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(checkpoint_db_path, check_same_thread=False)
-        checkpointer = SqliteSaver(conn, serde=build_checkpoint_serde())
-    except Exception:
-        checkpointer = None
-
-    return builder.compile(checkpointer=checkpointer)
+    return _CheckpointedGraph(builder, checkpoint_db_path)

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -149,6 +149,54 @@ def _as_naive_timestamp(value: datetime | pd.Timestamp) -> pd.Timestamp:
     return ts.tz_localize(None) if ts.tzinfo is not None else ts
 
 
+def _needs_reconciliation(decision: ARGUSDecision) -> bool:
+    """Whether a decision took a position that could have a realized outcome."""
+    return (
+        decision.technical is not None
+        and decision.allocation is not None
+        and decision.allocation.allocation_pct > 0
+    )
+
+
+def _realized_return_from_prices(
+    decision: ARGUSDecision, prices: pd.Series, horizon_days: int
+) -> Optional[tuple[float, int, str]]:
+    """Pairs a decision's entry price with a later close drawn from an already-fetched series.
+
+    Args:
+        decision: Completed ARGUSDecision; caller has already confirmed
+            _needs_reconciliation(decision).
+        prices: Close-price Series for decision.ticker.
+        horizon_days: Calendar days after session_timestamp defining the
+            target exit date.
+
+    Returns:
+        (actual_return_pct, holding_days, exit_reason), or None when the
+        price series doesn't yet extend past the target exit date — horizon
+        not reached, deferred rather than fabricated.
+    """
+    assert decision.technical is not None, "caller must confirm _needs_reconciliation(decision)"
+    entry_price = decision.technical.current_price
+    entry_date = _as_naive_timestamp(decision.session_timestamp)
+    target_exit_date = entry_date + timedelta(days=horizon_days)
+
+    prices = prices.copy()
+    prices.index = pd.DatetimeIndex([_as_naive_timestamp(ts) for ts in prices.index])
+
+    on_or_after = prices[prices.index >= target_exit_date].sort_index()
+    if on_or_after.empty:
+        return None
+
+    exit_date = on_or_after.index[0]
+    exit_price = float(on_or_after.iloc[0])
+
+    actual_return_pct = (exit_price - entry_price) / entry_price
+    holding_days = (exit_date - entry_date).days
+    exit_reason = f"horizon reached ({horizon_days}d target, {holding_days}d actual)"
+
+    return actual_return_pct, holding_days, exit_reason
+
+
 def compute_realized_return(
     decision: ARGUSDecision, market_data: MarketDataProvider, horizon_days: int
 ) -> Optional[tuple[float, int, str]]:
@@ -172,34 +220,10 @@ def compute_realized_return(
         taken), or the price series doesn't yet extend past the target exit
         date — horizon not reached, deferred rather than fabricated.
     """
-    if (
-        decision.technical is None
-        or decision.allocation is None
-        or decision.allocation.allocation_pct <= 0
-    ):
+    if not _needs_reconciliation(decision):
         return None
-
-    entry_price = decision.technical.current_price
-    entry_date = _as_naive_timestamp(decision.session_timestamp)
-    target_exit_date = entry_date + timedelta(days=horizon_days)
-
     prices = market_data.ohlcv_daily(decision.ticker)["close"]
-    prices.index = pd.DatetimeIndex(
-        [_as_naive_timestamp(ts) for ts in prices.index]
-    )
-
-    on_or_after = prices[prices.index >= target_exit_date].sort_index()
-    if on_or_after.empty:
-        return None
-
-    exit_date = on_or_after.index[0]
-    exit_price = float(on_or_after.iloc[0])
-
-    actual_return_pct = (exit_price - entry_price) / entry_price
-    holding_days = (exit_date - entry_date).days
-    exit_reason = f"horizon reached ({horizon_days}d target, {holding_days}d actual)"
-
-    return actual_return_pct, holding_days, exit_reason
+    return _realized_return_from_prices(decision, prices, horizon_days)
 
 
 def reconcile_decision(
@@ -207,6 +231,8 @@ def reconcile_decision(
     market_data: MarketDataProvider,
     cultural: CulturalMemoryManager,
     horizon_days: int = RECONCILIATION.horizon_days,
+    *,
+    prices: Optional[pd.Series] = None,
 ) -> bool:
     """Reconciles a single decision: computes its outcome and stores it if the horizon has passed.
 
@@ -216,6 +242,10 @@ def reconcile_decision(
         cultural: CulturalMemoryManager to persist the outcome to.
         horizon_days: Calendar days after session_timestamp defining the
             target exit date.
+        prices: Pre-fetched close-price Series for decision.ticker. Passed by
+            reconcile_decisions() so decisions sharing a ticker issue one
+            market_data fetch between them instead of one each; fetched here
+            when omitted.
 
     Returns:
         True if an outcome was computed and handed to
@@ -224,7 +254,11 @@ def reconcile_decision(
         docstring). False if the decision had nothing to reconcile or its
         horizon hasn't passed yet.
     """
-    outcome = compute_realized_return(decision, market_data, horizon_days)
+    if not _needs_reconciliation(decision):
+        return False
+    if prices is None:
+        prices = market_data.ohlcv_daily(decision.ticker)["close"]
+    outcome = _realized_return_from_prices(decision, prices, horizon_days)
     if outcome is None:
         return False
 
@@ -255,7 +289,13 @@ def reconcile_decisions(
     cultural: CulturalMemoryManager,
     horizon_days: int = RECONCILIATION.horizon_days,
 ) -> int:
-    """Reconciles every decision whose horizon has passed.
+    """Reconciles every not-yet-reconciled decision whose horizon has passed.
+
+    Skips decisions cultural already has a stored outcome for (see
+    CulturalMemoryManager.already_reconciled) and fetches each ticker's price
+    history at most once regardless of how many decisions share it. This runs
+    on a daily schedule against a decision history that only grows — without
+    both, every past decision gets re-fetched and re-processed on every run.
 
     Args:
         decisions: Decisions to attempt reconciliation for, e.g. from
@@ -268,9 +308,30 @@ def reconcile_decisions(
     Returns:
         Count of decisions actually stored via cultural.store_trade_outcome.
     """
-    return sum(
-        reconcile_decision(d, market_data, cultural, horizon_days) for d in decisions
-    )
+    already_done = cultural.already_reconciled([d.decision_id for d in decisions])
+    candidates = [
+        d for d in decisions if d.decision_id not in already_done and _needs_reconciliation(d)
+    ]
+
+    prices_by_ticker: dict[str, Optional[pd.Series]] = {}
+    stored = 0
+    for decision in candidates:
+        if decision.ticker not in prices_by_ticker:
+            try:
+                prices_by_ticker[decision.ticker] = market_data.ohlcv_daily(decision.ticker)["close"]
+            except Exception as exc:
+                logger.warning(
+                    "[Reconcile] failed to fetch price history for %s: %s", decision.ticker, exc
+                )
+                prices_by_ticker[decision.ticker] = None
+
+        prices = prices_by_ticker[decision.ticker]
+        if prices is None:
+            continue
+        if reconcile_decision(decision, market_data, cultural, horizon_days, prices=prices):
+            stored += 1
+
+    return stored
 
 
 def load_decisions_from_checkpoints(db_path: str = "argus_graph.db") -> list[ARGUSDecision]:

--- a/argus/orchestration/state.py
+++ b/argus/orchestration/state.py
@@ -18,8 +18,6 @@ import operator
 from datetime import datetime
 from typing import Annotated, Any, Optional, TypedDict
 
-import pandas as pd
-
 from argus.schemas.signals import (
     AggregatedSignal,
     FundamentalSignal,
@@ -68,8 +66,10 @@ class ARGUSState(TypedDict):
     session's own capture date, so it can't read outcomes that hadn't happened yet."""
 
     # ── Node 1: fetch_price_history ───────────────────────────────────────────
-    price_history: dict[str, pd.Series]
-    """Mapping of ticker → daily close price Series, populated by fetch_price_history."""
+    price_history: dict[str, dict[str, list]]
+    """Mapping of ticker → {"dates": [...], "prices": [...]}, populated by
+    fetch_price_history. SPY rides along with the universe (see
+    graph.py:node_fetch_price_history) so it's present even when not requested."""
 
     session_states: dict[str, dict]
     """Mapping of ticker → compressed technical feature dict (rsi, macd, etc.)."""

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -154,7 +154,7 @@ class MacroContext(BaseModel):
         ),
     )
     api_calls_used: int = Field(0, ge=0)
-    timestamp: datetime = Field(..., description="UTC timestamp of signal production")
+    timestamp: datetime = Field(..., description="Naive local timestamp of signal production")
 
     @field_validator("agent_multipliers", mode="before")
     @classmethod
@@ -213,7 +213,7 @@ class TechnicalSignal(BaseModel):
     )
 
     api_calls_used: int = Field(0, ge=0, description="External API calls consumed")
-    timestamp: datetime = Field(..., description="UTC timestamp of signal production")
+    timestamp: datetime = Field(..., description="Naive local timestamp of signal production")
 
     @field_validator("conviction", mode="before")
     @classmethod
@@ -256,7 +256,7 @@ class FundamentalSignal(BaseModel):
     )
 
     api_calls_used: int = Field(1, ge=0)
-    timestamp: datetime = Field(..., description="UTC timestamp of signal production")
+    timestamp: datetime = Field(..., description="Naive local timestamp of signal production")
 
     @field_validator("conviction", mode="before")
     @classmethod
@@ -313,7 +313,7 @@ class SentimentSignal(BaseModel):
         ..., max_length=400, description="LLM rationale for the signal (≤400 chars)"
     )
     api_calls_used: int = Field(1, ge=0)
-    timestamp: datetime = Field(..., description="UTC timestamp of signal production")
+    timestamp: datetime = Field(..., description="Naive local timestamp of signal production")
 
     @field_validator("conviction", mode="before")
     @classmethod
@@ -381,7 +381,7 @@ class RiskAssessment(BaseModel):
     )
 
     api_calls_used: int = Field(0, ge=0)
-    timestamp: datetime = Field(..., description="UTC timestamp of signal production")
+    timestamp: datetime = Field(..., description="Naive local timestamp of signal production")
 
     @model_validator(mode="after")
     def approved_le_proposed(self) -> "RiskAssessment":
@@ -501,7 +501,7 @@ class PortfolioAllocation(BaseModel):
         ..., description="Condition that will next trigger rebalancing, e.g. 'VIX > 35'"
     )
     api_calls_used: int = Field(1, ge=0)
-    timestamp: datetime = Field(..., description="UTC timestamp of signal production")
+    timestamp: datetime = Field(..., description="Naive local timestamp of signal production")
 
     @field_validator("portfolio")
     @classmethod
@@ -558,7 +558,7 @@ class ARGUSDecision(BaseModel):
         description="UUID v4 unique identifier for this decision record",
     )
     ticker: str = Field(..., description="Equity ticker symbol")
-    session_timestamp: datetime = Field(..., description="UTC timestamp of the decision cycle")
+    session_timestamp: datetime = Field(..., description="Naive local timestamp of the decision cycle")
 
     # All signal fields are optional; populated as each agent completes
     technical: TechnicalSignal | None = Field(None)

--- a/argus/seams.py
+++ b/argus/seams.py
@@ -128,10 +128,11 @@ class LiveMarketDataProvider:
 class FixtureMarketDataProvider:
     """Serves pre-captured data from tests/fixtures/market_data/ instead of the network.
 
-    Fixtures are plain JSON keyed by ticker (see scripts/capture_fixtures.py).
-    A ticker missing from a fixture file raises KeyError rather than silently
-    returning empty/zero data — a test exercising a ticker with no fixture
-    should fail loudly, not pass on fabricated data.
+    Fixtures are plain JSON keyed by ticker, hand-captured under
+    tests/fixtures/market_data/. A ticker missing from a fixture file raises
+    KeyError rather than silently returning empty/zero data — a test
+    exercising a ticker with no fixture should fail loudly, not pass on
+    fabricated data.
     """
 
     def __init__(self, fixtures_dir: Path = FIXTURES_DIR / "market_data") -> None:
@@ -356,10 +357,10 @@ class FixtureLLMClient:
     """Returns pre-captured response text instead of calling Groq.
 
     `responses` maps an opaque key (agent's choosing — e.g. ticker) to the
-    exact raw response text the real model previously produced, captured by
-    scripts/capture_fixtures.py from a real langsmith trace. `complete` is
-    keyed by `key_fn(user_prompt)` so a fixture-backed agent test doesn't
-    need to guess call order.
+    exact raw response text the real model previously produced, hand-captured
+    under tests/fixtures/llm_responses/. `complete` is keyed by
+    `key_fn(user_prompt)` so a fixture-backed agent test doesn't need to
+    guess call order.
     """
 
     def __init__(self, responses: dict[str, str], key_fn: Optional[Any] = None) -> None:

--- a/scripts/collect_session.py
+++ b/scripts/collect_session.py
@@ -32,6 +32,7 @@ load_dotenv()
 from argus.config import settings
 from argus.data.pipeline import MFTDataPipeline
 from argus.orchestration.collector import run_collection_cycle
+from argus.orchestration.graph import build_graph
 
 logger = logging.getLogger("argus.collect_session")
 
@@ -75,6 +76,7 @@ def main() -> None:
     universe = [t.strip() for t in args.universe.split(",") if t.strip()] if args.universe else settings.ARGUS_UNIVERSE
 
     pipeline = MFTDataPipeline(tickers=list(universe), db_path=args.buffer_db)
+    compiled_graph = build_graph(checkpoint_db_path=args.checkpoint_db)
     result = asyncio.run(
         run_collection_cycle(
             universe=universe,
@@ -82,7 +84,7 @@ def main() -> None:
             invest_pct=args.invest_pct,
             risk_tolerance=args.risk_tolerance,
             pipeline=pipeline,
-            checkpoint_db_path=args.checkpoint_db,
+            compiled_graph=compiled_graph,
             decisions_log_path=args.decisions_log,
         )
     )

--- a/tests/test_cultural.py
+++ b/tests/test_cultural.py
@@ -200,6 +200,30 @@ def test_store_trade_outcome_deletes_the_settled_pending_snapshot():
     manager.collection.delete.assert_called_once_with(ids=[f"snapshot_{decision.decision_id}"])
 
 
+def test_already_reconciled_returns_ids_with_a_stored_trade_row():
+    """Only decision_ids with a trade_{id} row come back, stripped of the prefix.
+
+    Regression test for X-6: reconcile_decisions() calls this once per batch,
+    before touching market data, to skip decisions already reconciled on a
+    prior run.
+    """
+    manager = _manager_with_metadatas([])
+    manager.collection.get.return_value = {"ids": ["trade_abc", "trade_def"]}
+
+    result = manager.already_reconciled(["abc", "def", "ghi"])
+
+    manager.collection.get.assert_called_once_with(ids=["trade_abc", "trade_def", "trade_ghi"])
+    assert result == {"abc", "def"}
+
+
+def test_already_reconciled_empty_input_skips_the_query():
+    """An empty decision_ids list returns immediately without touching the collection."""
+    manager = _manager_with_metadatas([])
+
+    assert manager.already_reconciled([]) == set()
+    manager.collection.get.assert_not_called()
+
+
 def test_store_decision_snapshot_returns_true_on_success():
     """A successful upsert reports success so callers can count real writes."""
     manager = _manager_with_metadatas([])

--- a/tests/test_portfolio_enforcement.py
+++ b/tests/test_portfolio_enforcement.py
@@ -5,6 +5,10 @@ Regression tests for PA-1: PortfolioManagerAgent.allocate() must enforce risk
 verdicts and caps in code, not merely display them in the prompt. Reproduces
 the audit's finding that an over-cap allocation, a VETO'd ticker, and a
 fabricated ticker all validated cleanly.
+
+Also covers PA-6: when all 3 retry attempts fail, allocate() must say which
+of its three stages (LLM call, JSON parse, schema validation) was failing,
+not a single generic message regardless of cause.
 """
 
 import json
@@ -98,3 +102,42 @@ def test_allocate_enforces_caps_vetoes_and_fabrications_in_code():
     assert any("zeroed VETOED allocation (risk verdict VETO)" in a for a in adjustments)
     assert any("dropped FABRICATED" in a for a in adjustments)
     assert len(adjustments) == 3
+
+
+def test_allocate_names_the_json_parse_stage_on_exhausted_retries(monkeypatch):
+    """A response that never parses as JSON is reported as a json_parse failure, not a generic one."""
+    monkeypatch.setattr("argus.agents.portfolio.time.sleep", lambda *_: None)
+    llm_client = FixtureLLMClient({"only": "not valid json"}, key_fn=lambda _prompt: "only")
+
+    agent = PortfolioManagerAgent(llm_client=llm_client)
+    adjustments: list[str] = []
+    alloc = agent.allocate(
+        user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
+        all_signals={"OVER_CAP": {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)}},
+        macro=None,
+        adjustments=adjustments,
+    )
+
+    assert alloc is None
+    assert any("json_parse" in a for a in adjustments)
+
+
+def test_allocate_names_the_schema_validation_stage_on_exhausted_retries(monkeypatch):
+    """Valid JSON that fails PortfolioAllocation's schema is reported as schema_validation, not json_parse."""
+    monkeypatch.setattr("argus.agents.portfolio.time.sleep", lambda *_: None)
+    # Missing the required "portfolio" list entirely -> model_validate raises, json.loads does not
+    llm_client = FixtureLLMClient(
+        {"only": json.dumps({"cash_reserve_pct": "not_a_number"})}, key_fn=lambda _prompt: "only"
+    )
+
+    agent = PortfolioManagerAgent(llm_client=llm_client)
+    adjustments: list[str] = []
+    alloc = agent.allocate(
+        user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
+        all_signals={"OVER_CAP": {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)}},
+        macro=None,
+        adjustments=adjustments,
+    )
+
+    assert alloc is None
+    assert any("schema_validation" in a for a in adjustments)

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -479,6 +479,7 @@ def test_reconcile_decisions_counts_only_the_ones_actually_reconciled():
     )
     market_data = _ten_day_series(start, start_price=100.0)
     cultural = mock.create_autospec(CulturalMemoryManager, instance=True)
+    cultural.already_reconciled.return_value = set()
 
     count = reconcile_decisions(
         [reconcilable, not_reconcilable], market_data, cultural, horizon_days=5
@@ -486,6 +487,51 @@ def test_reconcile_decisions_counts_only_the_ones_actually_reconciled():
 
     assert count == 1
     assert cultural.store_trade_outcome.call_count == 1
+
+
+def test_reconcile_decisions_skips_decisions_already_reconciled():
+    """A decision cultural already has a stored outcome for is not touched again."""
+    start = datetime(2026, 1, 1)
+    decision = ARGUSDecision(
+        ticker="TEST",
+        session_timestamp=start,
+        technical=_technical(Signal.BULLISH, 0.8, price=100.0),
+        allocation=_allocation(),
+    )
+    market_data = _ten_day_series(start, start_price=100.0)
+    cultural = mock.create_autospec(CulturalMemoryManager, instance=True)
+    cultural.already_reconciled.return_value = {decision.decision_id}
+
+    count = reconcile_decisions([decision], market_data, cultural, horizon_days=5)
+
+    assert count == 0
+    cultural.store_trade_outcome.assert_not_called()
+
+
+def test_reconcile_decisions_fetches_each_ticker_price_history_once():
+    """Two decisions on the same ticker share a single ohlcv_daily fetch."""
+    start = datetime(2026, 1, 1)
+    first = ARGUSDecision(
+        ticker="TEST",
+        session_timestamp=start,
+        technical=_technical(Signal.BULLISH, 0.8, price=100.0),
+        allocation=_allocation(),
+    )
+    second = ARGUSDecision(
+        ticker="TEST",
+        session_timestamp=start,
+        technical=_technical(Signal.BULLISH, 0.8, price=101.0),
+        allocation=_allocation(),
+    )
+    market_data = _ten_day_series(start, start_price=100.0)
+    market_data.ohlcv_daily = mock.Mock(wraps=market_data.ohlcv_daily)
+    cultural = mock.create_autospec(CulturalMemoryManager, instance=True)
+    cultural.already_reconciled.return_value = set()
+
+    count = reconcile_decisions([first, second], market_data, cultural, horizon_days=5)
+
+    assert count == 2
+    market_data.ohlcv_daily.assert_called_once_with("TEST")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Last of the nine PRs in #24's terminal-node remediation plan (PR 0–7 merged: #29, #25, #26, #27, #28, #30, #31, #32, #33). Closes the remaining findings: X-3 through X-8, SA-4, PA-5, PA-6.

- **X-3/X-5** — `build_graph()` now returns a thin wrapper that recompiles with a fresh SQLite checkpoint connection on every `.invoke()`, instead of baking one connection into a single compiled graph. The six agents (LLM clients, the macro HMM classifier load) are still built once and captured in the node closures. `run_collection_cycle` now takes an already-built `compiled_graph` the same way it already takes an already-built `pipeline`, instead of rebuilding the whole agent stack every collector cycle.
- **X-4** — `get_cultural_memory()`'s singleton check-then-set is now guarded by a lock (double-checked locking).
- **X-6** — `reconcile_decisions()` skips decisions already reconciled (new `CulturalMemoryManager.already_reconciled()` batched lookup) and fetches each ticker's price history at most once per pass, instead of once per decision. The scheduled reconcile job runs daily against a decision history that only grows, so both were previously unbounded.
- **X-7** — `ARGUSState.price_history`'s type annotation now matches what `fetch_price_history` actually produces (`dict[str, dict[str, list]]`, not `dict[str, pd.Series]`).
- **X-8** — The "UTC timestamp" `Field` descriptions across `schemas/signals.py` now say naive local, matching every producer and `cultural.py`'s existing `as_of` docstrings.
- **SA-4** — The three `except ImportError` guards around `get_cultural_memory()` calls in `graph.py` now also catch `OSError` and `chromadb.errors.ChromaError`, so a bad `persist_dir` or an incompatible on-disk Chroma schema degrades the same way an absent optional dependency already does, instead of crashing the run.
- **PA-5** — `node_portfolio_allocation`'s `signals_dict` is now built from tickers with an aggregated signal rather than the whole universe, and the collector passes `tickers_with_data` as `state["universe"]` instead of the full requested universe — matching the module's own documented contract ("over whatever tickers the sweep actually populated").
- **PA-6** — `PortfolioManagerAgent.allocate()` now tracks which retry-loop stage (`llm_call`, `json_parse`, `response_enforcement`, `schema_validation`) was failing and reports it through `adjustments`/`errors` when all 3 attempts are exhausted, instead of always logging a generic "LLM API failure".
- Also fixed three dangling references to `scripts/capture_fixtures.py`, a script that was never added to the repo (`seams.py` x2, `replay.py`).

## Test plan

- [x] `pytest tests/ -q` — 239 passed (232 baseline + 7 new: 2 for `already_reconciled`, 2 for the reconcile-pass watermark/per-ticker-fetch, 2 for the PA-6 stage-naming, plus the existing suite unaffected)
- [x] `ruff check .` — clean
- [x] `mypy argus api scripts` — same 4 pre-existing baseline errors as `main` (`scripts/remediate_macro_regime_tags.py` x3, `api/main.py:413`), none introduced by this change

Closes #24