### PR TITLE
fix: restore the kill switch

### DIFF
--- a/.github/workflows/reconcile.yml
+++ b/.github/workflows/reconcile.yml
@@ -34,6 +34,7 @@ jobs:
           mkdir -p data chroma_db
           [ -d state/chroma_db ] && cp -r state/chroma_db/. ./chroma_db/ || echo "no prior chroma_db"
           [ -f state/decisions.jsonl ] && cp state/decisions.jsonl data/decisions.jsonl || echo "no prior decisions.jsonl"
+          [ -f state/paper_equity.json ] && cp state/paper_equity.json data/paper_equity.json || echo "no prior paper_equity.json"
           chmod -R a+rwX data chroma_db
 
       - name: Log in to GHCR
@@ -56,6 +57,7 @@ jobs:
           mkdir -p publish
           cp -r chroma_db publish/chroma_db
           [ -f data/decisions.jsonl ] && cp data/decisions.jsonl publish/decisions.jsonl
+          [ -f data/paper_equity.json ] && cp data/paper_equity.json publish/paper_equity.json
           # Merge rather than overwrite — collector.yml writes to the same
           # status.json on the same branch and its field must survive this
           ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/api/main.py
+++ b/api/main.py
@@ -54,6 +54,7 @@ from argus.orchestration.graph import build_graph
 from argus.orchestration.reconciliation import load_decisions_from_jsonl, reconcile_decisions
 from argus.orchestration.state import ARGUSState
 from argus.params import RECONCILIATION
+from argus.risk import paper_book
 from argus.risk.kill_switch import get_kill_switch, initialize_kill_switch
 from argus.seams import LiveMarketDataProvider
 
@@ -163,13 +164,34 @@ async def _reconcile_loop() -> None:
         try:
             decisions_log = f"{settings.ARGUS_DATA_DIR}/decisions.jsonl"
             decisions = load_decisions_from_jsonl(decisions_log)
+            market_data = LiveMarketDataProvider()
             stored = reconcile_decisions(
                 decisions,
-                market_data=LiveMarketDataProvider(),
+                market_data=market_data,
                 cultural=get_cultural_memory(),
                 horizon_days=RECONCILIATION.horizon_days,
             )
             logger.info("[Reconcile] stored %d/%d outcome(s)", stored, len(decisions))
+
+            try:
+                book_path = f"{settings.ARGUS_DATA_DIR}/paper_equity.json"
+                book = paper_book.load(book_path)
+                for run_timestamp, run_return in paper_book.compute_run_returns(
+                    decisions, market_data, RECONCILIATION.horizon_days
+                ):
+                    book.apply_run(run_timestamp, run_return)
+                paper_book.save(book, book_path)
+
+                ks = get_kill_switch()
+                if ks is not None:
+                    ks.update_portfolio_value(book.equity)
+                logger.info(
+                    "[Reconcile] paper equity=$%.2f (drawdown=%.1f%%)",
+                    book.equity,
+                    book.drawdown_from_peak() * 100,
+                )
+            except Exception:
+                logger.exception("[Reconcile] paper-book update failed")
         except Exception:
             logger.exception("[Reconcile] cycle failed")
 
@@ -215,11 +237,22 @@ async def lifespan(app: FastAPI):
             settings.ARGUS_RECONCILE_HOUR_ET,
         )
 
-    # Placeholder base; /kill-switch/reset re-bases once the real session is known
+    # Seeded from the persisted paper equity curve (falls back to
+    # ARGUS_TOTAL_WEALTH if none exists yet) so a process restart doesn't
+    # silently forget an already-realized drawdown; /kill-switch/reset
+    # re-bases if a real session base is known instead
+    _book = paper_book.load(f"{settings.ARGUS_DATA_DIR}/paper_equity.json")
     initialize_kill_switch(
-        risk_tolerance=settings.ARGUS_RISK_TOLERANCE, portfolio_value=settings.ARGUS_TOTAL_WEALTH
+        risk_tolerance=settings.ARGUS_RISK_TOLERANCE, portfolio_value=_book.high_water_mark
     )
-    logger.info("[Startup] Kill switch initialized.")
+    _ks = get_kill_switch()
+    if _ks is not None:
+        _ks.update_portfolio_value(_book.equity)
+    logger.info(
+        "[Startup] Kill switch initialized (paper equity=$%.2f, peak=$%.2f).",
+        _book.equity,
+        _book.high_water_mark,
+    )
 
     logger.info("[Startup] Governor initialized: %s", governor.get_usage_report())
 

--- a/argus/orchestration/collector.py
+++ b/argus/orchestration/collector.py
@@ -10,6 +10,7 @@ Both api/main.py's background collector loop and scripts/collect_session.py
 call it, so the two deployment paths can't drift apart from each other.
 
 Responsibilities:
+  - Refuse to run while the process-local kill switch is halted
   - Run one MFT fetch-and-compress sweep via MFTDataPipeline.run_once()
   - Invoke the caller-supplied compiled LangGraph DAG over whatever tickers
     the sweep actually populated
@@ -31,6 +32,7 @@ from pathlib import Path
 
 from argus.data.pipeline import MFTDataPipeline
 from argus.orchestration.state import ARGUSState
+from argus.risk.kill_switch import get_kill_switch
 from argus.schemas.signals import ARGUSDecision
 
 logger = logging.getLogger("argus.collector")
@@ -86,6 +88,15 @@ async def run_collection_cycle(
 ) -> CollectionResult:
     """Runs one unattended fetch → analyze → log cycle for the given universe.
 
+    Refuses to run while this process's kill switch is halted — the
+    unattended collector is one of the two entry paths into the graph
+    (/analyze is the other, already gated in api/main.py), and a halted
+    system must stop feeding new decisions into decisions.jsonl just as it
+    stops serving /analyze. A process with no kill switch initialized
+    (get_kill_switch() returns None — e.g. scripts/collect_session.py's
+    standalone GitHub Actions runner) is ungated; that cross-process gap
+    is documented, not solved, here.
+
     Skips the graph entirely — rather than invoking it against a stale or
     empty buffer — when the MFT sweep produces no usable session data, which
     happens outside market hours or on a market holiday
@@ -111,6 +122,12 @@ async def run_collection_cycle(
     Returns:
         A CollectionResult summarizing what happened.
     """
+    ks = get_kill_switch()
+    if ks is not None and ks.is_halted:
+        reason = f"halted: {ks.status.reason}"
+        logger.warning("run_collection_cycle: skipping graph invocation — %s", reason)
+        return CollectionResult(ran=False, reason=reason)
+
     session_states = await pipeline.run_once()
 
     tickers_with_data = [t for t in universe if t in session_states]

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -198,7 +198,11 @@ def _realized_return_from_prices(
 
 
 def compute_realized_return(
-    decision: ARGUSDecision, market_data: MarketDataProvider, horizon_days: int
+    decision: ARGUSDecision,
+    market_data: MarketDataProvider,
+    horizon_days: int,
+    *,
+    prices: Optional[pd.Series] = None,
 ) -> Optional[tuple[float, int, str]]:
     """Computes realized return by pairing the decision's entry price with a later close.
 
@@ -212,6 +216,10 @@ def compute_realized_return(
         market_data: Source of the ticker's daily close price series.
         horizon_days: Calendar days after session_timestamp defining the
             target exit date.
+        prices: Pre-fetched close-price Series for decision.ticker. Passed by
+            callers batching one fetch per ticker across several decisions
+            (see reconcile_decisions, risk/paper_book.py); fetched here when
+            omitted.
 
     Returns:
         (actual_return_pct, holding_days, exit_reason), or None when there is
@@ -222,7 +230,8 @@ def compute_realized_return(
     """
     if not _needs_reconciliation(decision):
         return None
-    prices = market_data.ohlcv_daily(decision.ticker)["close"]
+    if prices is None:
+        prices = market_data.ohlcv_daily(decision.ticker)["close"]
     return _realized_return_from_prices(decision, prices, horizon_days)
 
 

--- a/argus/risk/kill_switch.py
+++ b/argus/risk/kill_switch.py
@@ -58,6 +58,10 @@ class KillSwitch:
     }
     VIX_BLACKOUT = getattr(settings, "VIX_BLACKOUT_THRESHOLD", 35.0)
 
+    # Consecutive VIX-fetch failures before failing closed (blocking new
+    # positions) rather than continuing to trust a possibly-stale reading
+    _VIX_FAILURE_HALT_THRESHOLD = 5
+
     def __init__(self, user_risk_tolerance: str, check_interval_seconds: int = 60):
         """Initializes the kill switch, deferring monitoring until start() is called.
 
@@ -81,6 +85,10 @@ class KillSwitch:
 
         self._portfolio_inception_value: Optional[float] = None
         self._current_portfolio_value: Optional[float] = None
+        self._high_water_mark: float = 0.0
+
+        self._last_vix: Optional[float] = None
+        self._consecutive_vix_failures: int = 0
 
         self._thread: Optional[threading.Thread] = None
         self._logger = logging.getLogger("argus.kill_switch")
@@ -93,6 +101,7 @@ class KillSwitch:
         """
         self._portfolio_inception_value = initial_portfolio_value
         self._current_portfolio_value = initial_portfolio_value
+        self._high_water_mark = initial_portfolio_value
         self._thread = threading.Thread(
             target=self._monitor_loop, daemon=True, name="KillSwitchMonitor"
         )
@@ -104,10 +113,15 @@ class KillSwitch:
     def update_portfolio_value(self, current_value: float) -> None:
         """Thread-safe update of the current portfolio valuation.
 
+        Also advances the high-water mark if this value is a new peak, so
+        drawdown is always measured peak-to-trough rather than against the
+        (possibly stale) inception value.
+
         Args:
             current_value: Current mark-to-market portfolio value (USD).
         """
         self._current_portfolio_value = current_value
+        self._high_water_mark = max(self._high_water_mark, current_value)
 
     def _monitor_loop(self) -> None:
         """Infinite monitoring loop sleeping between checks."""
@@ -121,32 +135,58 @@ class KillSwitch:
     def _check(self) -> None:
         """Evaluates portfolio drawdown and VIX levels against safety limits.
 
-        Fetches the live VIX value; falls back to 20.0 if the API call fails to
-        prevent a monitor crash from silently disabling the safety gate.
+        Drawdown is measured peak-to-trough against _high_water_mark, not
+        against the inception value. A VIX fetch failure never clears an
+        active blackout; after _VIX_FAILURE_HALT_THRESHOLD consecutive
+        failures it sets one — a monitor that can't observe volatility fails
+        closed rather than silently substituting a benign guess.
         """
         if self._portfolio_inception_value is None:
             return
 
-        current = self._current_portfolio_value or self._portfolio_inception_value
-        drawdown = (self._portfolio_inception_value - current) / self._portfolio_inception_value
+        current = (
+            self._current_portfolio_value
+            if self._current_portfolio_value is not None
+            else self._portfolio_inception_value
+        )
+        self._high_water_mark = max(self._high_water_mark, current)
+        drawdown = (
+            (self._high_water_mark - current) / self._high_water_mark
+            if self._high_water_mark > 0
+            else 0.0
+        )
         threshold = self.DRAWDOWN_THRESHOLDS[self.risk_tolerance]
 
         try:
             from argus.data.fetchers import fetch_vix
 
             vix = fetch_vix()
-        except Exception:
-            vix = 20.0
-
-        if vix >= self.VIX_BLACKOUT and not self._new_positions_blocked.is_set():
-            self._new_positions_blocked.set()
-            self._logger.warning(
-                f"VIX BLACKOUT: {vix:.1f} >= {self.VIX_BLACKOUT}. New positions blocked."
+        except Exception as exc:
+            self._consecutive_vix_failures += 1
+            self._logger.error(
+                f"VIX fetch failed ({self._consecutive_vix_failures} consecutive): {exc}"
             )
+            if (
+                self._consecutive_vix_failures >= self._VIX_FAILURE_HALT_THRESHOLD
+                and not self._new_positions_blocked.is_set()
+            ):
+                self._new_positions_blocked.set()
+                self._logger.warning(
+                    "VIX BLACKOUT (fail-closed): "
+                    f"{self._consecutive_vix_failures} consecutive fetch failures."
+                )
+        else:
+            self._consecutive_vix_failures = 0
+            self._last_vix = vix
 
-        elif vix < self.VIX_BLACKOUT and self._new_positions_blocked.is_set():
-            self._new_positions_blocked.clear()
-            self._logger.info(f"VIX normalized to {vix:.1f}. New positions unblocked.")
+            if vix >= self.VIX_BLACKOUT and not self._new_positions_blocked.is_set():
+                self._new_positions_blocked.set()
+                self._logger.warning(
+                    f"VIX BLACKOUT: {vix:.1f} >= {self.VIX_BLACKOUT}. New positions blocked."
+                )
+            elif vix < self.VIX_BLACKOUT and self._new_positions_blocked.is_set():
+                self._new_positions_blocked.clear()
+                self._logger.info(f"VIX normalized to {vix:.1f}. New positions unblocked.")
 
         if drawdown >= threshold and not self._halted.is_set():
             self._halt_reason = (
@@ -155,7 +195,7 @@ class KillSwitch:
             self._halt_time = datetime.now()
             self._halted.set()
             self._logger.critical(f"KILL SWITCH TRIGGERED: {self._halt_reason}")
-            self._persist_halt_event(drawdown, vix)
+            self._persist_halt_event(drawdown, self._last_vix or 0.0)
 
     def _persist_halt_event(self, drawdown: float, vix: float) -> None:
         """Saves a JSON crash dump to disk upon triggering a circuit breaker halt.
@@ -195,8 +235,13 @@ class KillSwitch:
         if self._portfolio_inception_value is None:
             drawdown = 0.0
         else:
-            current = self._current_portfolio_value or self._portfolio_inception_value
-            drawdown = (self._portfolio_inception_value - current) / self._portfolio_inception_value
+            current = (
+                self._current_portfolio_value
+                if self._current_portfolio_value is not None
+                else self._portfolio_inception_value
+            )
+            hwm = self._high_water_mark if self._high_water_mark > 0 else self._portfolio_inception_value
+            drawdown = (hwm - current) / hwm if hwm > 0 else 0.0
 
         return KillSwitchStatus(
             halted=self._halted.is_set(),
@@ -254,6 +299,8 @@ class KillSwitch:
         self._halt_time = None
         self._portfolio_inception_value = new_inception_value
         self._current_portfolio_value = new_inception_value
+        self._high_water_mark = new_inception_value
+        self._consecutive_vix_failures = 0
         self._logger.info(f"Kill switch reset. New inception value: ${new_inception_value:,.0f}")
 
 

--- a/argus/risk/paper_book.py
+++ b/argus/risk/paper_book.py
@@ -1,0 +1,206 @@
+"""
+argus/risk/paper_book.py
+
+A synthetic paper equity curve derived from matured decision outcomes, giving
+the kill switch a real loss signal to gate on.
+
+ARGUS tracks no positions and executes nothing — there is no broker, no book,
+no mark-to-market. Each graph invocation ("run") is treated as one notional
+rebalance: within a run, decisions that took a position are weighted by
+allocation_pct and averaged into that run's realized return once at least one
+matured decision's outcome is known, then compounded onto the running equity
+curve. A run with only some decisions matured is not diluted with fabricated
+zeros for the rest — it's averaged over the matured subset only.
+
+Responsibilities:
+  - compute_run_returns: group decisions by run (shared session_timestamp),
+    weight-average each run's matured outcomes into one compounding return
+  - PaperBook: equity/high-water-mark/applied-runs state, with idempotent
+    run application
+  - load / save: JSON round trip at a caller-supplied path
+
+Not responsible for:
+  - Reconciling individual decisions into cultural memory (see
+    orchestration/reconciliation.py, which this module calls into)
+  - Deciding when the kill switch halts (see risk/kill_switch.py)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+from argus.config import settings
+from argus.orchestration.reconciliation import _needs_reconciliation, compute_realized_return
+from argus.schemas.signals import ARGUSDecision
+from argus.seams import MarketDataProvider
+
+logger = logging.getLogger("argus.paper_book")
+
+
+def compute_run_returns(
+    decisions: list[ARGUSDecision],
+    market_data: MarketDataProvider,
+    horizon_days: int,
+) -> list[tuple[datetime, float]]:
+    """Groups decisions into runs and computes each matured run's weighted return.
+
+    A run is every decision sharing one session_timestamp (one graph
+    invocation logs all of its decisions with the same timestamp — see
+    graph.py's node_log_decisions). Fetches each ticker's price history at
+    most once across the whole call, mirroring reconcile_decisions.
+
+    Args:
+        decisions: Candidate decisions, e.g. from load_decisions_from_jsonl.
+        market_data: Source of each ticker's daily close price series.
+        horizon_days: Calendar days after session_timestamp defining each
+            decision's target exit date.
+
+    Returns:
+        (run_timestamp, weighted_return) pairs, one per run with at least one
+        matured, priceable decision, sorted by run_timestamp. A run with no
+        matured decisions yet, or whose tickers all failed to fetch, is
+        omitted rather than reported as a 0.0 return.
+    """
+    by_run: dict[datetime, list[ARGUSDecision]] = defaultdict(list)
+    for decision in decisions:
+        if _needs_reconciliation(decision):
+            by_run[decision.session_timestamp].append(decision)
+
+    prices_by_ticker: dict[str, Optional[pd.Series]] = {}
+    results: list[tuple[datetime, float]] = []
+    for run_timestamp in sorted(by_run):
+        weighted_sum = 0.0
+        weight_total = 0.0
+        for decision in by_run[run_timestamp]:
+            ticker = decision.ticker
+            if ticker not in prices_by_ticker:
+                try:
+                    prices_by_ticker[ticker] = market_data.ohlcv_daily(ticker)["close"]
+                except Exception as exc:
+                    logger.warning(
+                        "[PaperBook] failed to fetch price history for %s: %s", ticker, exc
+                    )
+                    prices_by_ticker[ticker] = None
+
+            prices = prices_by_ticker[ticker]
+            if prices is None:
+                continue
+            outcome = compute_realized_return(decision, market_data, horizon_days, prices=prices)
+            if outcome is None:
+                continue
+
+            actual_return_pct, _, _ = outcome
+            assert decision.allocation is not None, "_needs_reconciliation already confirmed this"
+            weight = decision.allocation.allocation_pct
+            weighted_sum += actual_return_pct * weight
+            weight_total += weight
+
+        if weight_total > 0:
+            results.append((run_timestamp, weighted_sum / weight_total))
+
+    return results
+
+
+@dataclass
+class PaperBook:
+    """A synthetic, run-compounded equity curve fed by matured decision outcomes."""
+
+    equity: float
+    high_water_mark: float
+    last_run_timestamp: Optional[datetime] = None
+    runs_applied: set[str] = field(default_factory=set)
+    """ISO-formatted session_timestamps of runs already compounded in, so a
+    re-run of compute_run_returns over a growing decision history doesn't
+    double-apply one already reflected in equity."""
+
+    def apply_run(self, run_timestamp: datetime, run_return: float) -> bool:
+        """Compounds one run's weighted return onto the curve, unless already applied.
+
+        Args:
+            run_timestamp: The run's session_timestamp.
+            run_return: Weighted-average matured return for that run, from
+                compute_run_returns.
+
+        Returns:
+            True if the run was newly applied; False if run_timestamp was
+            already in runs_applied.
+        """
+        key = run_timestamp.isoformat()
+        if key in self.runs_applied:
+            return False
+        self.equity *= 1.0 + run_return
+        self.high_water_mark = max(self.high_water_mark, self.equity)
+        self.last_run_timestamp = run_timestamp
+        self.runs_applied.add(key)
+        return True
+
+    def drawdown_from_peak(self) -> float:
+        """Returns peak-to-trough drawdown as a non-negative fraction."""
+        if self.high_water_mark <= 0:
+            return 0.0
+        return max(0.0, (self.high_water_mark - self.equity) / self.high_water_mark)
+
+
+def load(path: str) -> PaperBook:
+    """Loads a persisted PaperBook, or starts a fresh one at ARGUS_TOTAL_WEALTH.
+
+    A missing or unparseable file is treated as "no history yet" rather than
+    an error — the first-ever reconcile pass on a fresh deployment has
+    nothing to load.
+
+    Args:
+        path: Path a prior save() wrote to.
+
+    Returns:
+        The loaded PaperBook, or a fresh one seeded at settings.ARGUS_TOTAL_WEALTH.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        return PaperBook(
+            equity=settings.ARGUS_TOTAL_WEALTH, high_water_mark=settings.ARGUS_TOTAL_WEALTH
+        )
+
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            raw = json.load(f)
+        last_run_raw = raw.get("last_run_timestamp")
+        return PaperBook(
+            equity=raw["equity"],
+            high_water_mark=raw["high_water_mark"],
+            last_run_timestamp=datetime.fromisoformat(last_run_raw) if last_run_raw else None,
+            runs_applied=set(raw.get("runs_applied", [])),
+        )
+    except Exception as exc:
+        logger.warning("[PaperBook] failed to load %s, starting fresh: %s", path, exc)
+        return PaperBook(
+            equity=settings.ARGUS_TOTAL_WEALTH, high_water_mark=settings.ARGUS_TOTAL_WEALTH
+        )
+
+
+def save(book: PaperBook, path: str) -> None:
+    """Persists a PaperBook to JSON, creating parent directories as needed.
+
+    Args:
+        book: The PaperBook to persist.
+        path: Destination file.
+    """
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "equity": book.equity,
+        "high_water_mark": book.high_water_mark,
+        "last_run_timestamp": (
+            book.last_run_timestamp.isoformat() if book.last_run_timestamp else None
+        ),
+        "runs_applied": sorted(book.runs_applied),
+    }
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)

--- a/scripts/reconcile_outcomes.py
+++ b/scripts/reconcile_outcomes.py
@@ -5,7 +5,10 @@ CLI entry point for argus/orchestration/reconciliation.py — reads every
 decision back out of the LangGraph checkpoint (argus_graph.db) or a
 decisions.jsonl log, reconciles whichever ones have cleared
 RECONCILIATION.horizon_days against live market data, and reports how many
-outcomes were stored to cultural memory.
+outcomes were stored to cultural memory. Also applies matured runs onto the
+persisted paper equity curve (argus/risk/paper_book.py) so the scheduled
+GitHub Actions runner — which has no long-lived KillSwitch daemon to feed —
+still keeps that curve current for whichever process reads it next.
 
     .venv/bin/python scripts/reconcile_outcomes.py [--db PATH] [--horizon-days N]
     .venv/bin/python scripts/reconcile_outcomes.py --decisions-log PATH
@@ -20,6 +23,7 @@ from __future__ import annotations
 import argparse
 import logging
 
+from argus.config import settings
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.reconciliation import (
     load_decisions_from_checkpoints,
@@ -27,6 +31,7 @@ from argus.orchestration.reconciliation import (
     reconcile_decisions,
 )
 from argus.params import RECONCILIATION
+from argus.risk import paper_book
 from argus.seams import LiveMarketDataProvider
 
 logger = logging.getLogger("argus.reconcile_outcomes")
@@ -59,13 +64,26 @@ def main() -> None:
         source = args.db
     print(f"Loaded {len(decisions)} decision(s) from {source}")
 
+    market_data = LiveMarketDataProvider()
     stored = reconcile_decisions(
         decisions,
-        market_data=LiveMarketDataProvider(),
+        market_data=market_data,
         cultural=get_cultural_memory(),
         horizon_days=args.horizon_days,
     )
     print(f"Reconciled {stored}/{len(decisions)} decision(s) (horizon={args.horizon_days}d)")
+
+    book_path = f"{settings.ARGUS_DATA_DIR}/paper_equity.json"
+    book = paper_book.load(book_path)
+    for run_timestamp, run_return in paper_book.compute_run_returns(
+        decisions, market_data, args.horizon_days
+    ):
+        book.apply_run(run_timestamp, run_return)
+    paper_book.save(book, book_path)
+    print(
+        f"Paper equity: ${book.equity:,.2f} "
+        f"(drawdown={book.drawdown_from_peak():.1%} from peak ${book.high_water_mark:,.2f})"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""
+tests/conftest.py
+
+Shared pytest fixtures.
+
+Responsibilities:
+  - Provide an opt-in network guard a test can request to prove it never
+    falls through to a real socket call
+
+Not responsible for:
+  - Test data (see tests/fixtures/)
+  - Blocking network globally — tests/test_integration.py's TestEndToEnd
+    class intentionally exercises live yfinance/FRED calls, and CI relies
+    on that; this fixture is opt-in per test, not autouse
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture
+def block_network(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Makes any outbound socket connection raise, for the duration of the requesting test.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+
+    Yields:
+        None.
+    """
+
+    def _blocked(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("Network access attempted in a test requesting block_network")
+
+    monkeypatch.setattr(socket.socket, "connect", _blocked)
+    monkeypatch.setattr(socket.socket, "connect_ex", _blocked)
+    yield

--- a/tests/test_kill_switch.py
+++ b/tests/test_kill_switch.py
@@ -1,0 +1,469 @@
+"""
+tests/test_kill_switch.py
+
+Tests for argus/risk/kill_switch.py (drawdown/VIX circuit breaker) and
+argus/risk/paper_book.py (the synthetic equity curve that feeds it).
+
+fetch_vix is mocked throughout; no test starts the daemon thread or sleeps —
+_check() is driven directly, following the pattern used to reproduce these
+findings originally.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+import argus.risk.kill_switch as kill_switch_module
+from argus.config import settings
+from argus.orchestration.collector import run_collection_cycle
+from argus.risk import paper_book
+from argus.risk.kill_switch import KillSwitch, initialize_kill_switch
+from argus.risk.paper_book import PaperBook, compute_run_returns
+from argus.schemas.signals import ARGUSDecision, PositionAllocation, Signal, TechnicalSignal
+
+
+@pytest.fixture(autouse=True)
+def _reset_kill_switch_singleton() -> None:
+    """Clears the module-level KillSwitch singleton before and after each test."""
+    kill_switch_module._kill_switch = None
+    yield
+    kill_switch_module._kill_switch = None
+
+
+def _make_ks(risk_tolerance: str = "MODERATE", inception: float = 100_000.0) -> KillSwitch:
+    """Builds a KillSwitch with inception state set directly, bypassing start()'s thread.
+
+    Args:
+        risk_tolerance: Risk tier string.
+        inception: Seed value for inception/current/high-water-mark.
+
+    Returns:
+        A KillSwitch ready for _check() to be driven directly.
+    """
+    ks = KillSwitch(risk_tolerance)
+    ks._portfolio_inception_value = inception
+    ks._current_portfolio_value = inception
+    ks._high_water_mark = inception
+    return ks
+
+
+# ---------------------------------------------------------------------------
+# Drawdown thresholds (KS-4, KS-5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tolerance,threshold",
+    [("CONSERVATIVE", 0.08), ("MODERATE", 0.12), ("AGGRESSIVE", 0.18)],
+)
+@mock.patch("argus.data.fetchers.fetch_vix", return_value=15.0)
+def test_drawdown_halts_at_tier_threshold(mock_vix, tolerance, threshold):
+    """The drawdown halt fires once realized drawdown reaches each tier's own threshold."""
+    ks = _make_ks(tolerance, inception=100_000.0)
+    ks.update_portfolio_value(100_000.0 * (1 - threshold))
+    ks._check()
+    assert ks.is_halted
+
+
+@mock.patch("argus.data.fetchers.fetch_vix", return_value=15.0)
+def test_drawdown_does_not_halt_below_threshold(mock_vix):
+    """A drawdown just short of the tier threshold does not halt."""
+    ks = _make_ks("MODERATE", inception=100_000.0)
+    ks.update_portfolio_value(100_000.0 * (1 - 0.12) + 1.0)
+    ks._check()
+    assert not ks.is_halted
+
+
+@mock.patch("argus.data.fetchers.fetch_vix", return_value=15.0)
+def test_zero_portfolio_value_registers_as_real_drawdown(mock_vix):
+    """KS-4: a literal 0.0 portfolio value must be treated as a real value, not 'unset'."""
+    ks = _make_ks("CONSERVATIVE", inception=100_000.0)
+    ks.update_portfolio_value(0.0)
+    ks._check()
+    assert ks.is_halted
+    assert ks.status.realized_drawdown == pytest.approx(1.0)
+
+
+@mock.patch("argus.data.fetchers.fetch_vix", return_value=15.0)
+def test_peak_to_trough_drawdown_not_inception_relative(mock_vix):
+    """KS-5: drawdown is measured from the running peak, not the stale inception value.
+
+    100k -> 150k (new peak, no drawdown) -> 105k: -5% vs inception (a gain,
+    wouldn't halt under the old logic) but -30% vs the $150k peak, well past
+    even AGGRESSIVE's 18% threshold.
+    """
+    ks = _make_ks("AGGRESSIVE", inception=100_000.0)
+
+    ks.update_portfolio_value(150_000.0)
+    ks._check()
+    assert not ks.is_halted
+
+    ks.update_portfolio_value(105_000.0)
+    ks._check()
+    assert ks.is_halted
+    assert ks.status.realized_drawdown == pytest.approx((150_000.0 - 105_000.0) / 150_000.0)
+
+
+def test_reset_clears_halt_and_reseeds_high_water_mark():
+    """reset() clears the halt/blackout and re-bases both inception and the peak."""
+    ks = _make_ks("MODERATE", inception=100_000.0)
+    with mock.patch("argus.data.fetchers.fetch_vix", return_value=15.0):
+        ks.update_portfolio_value(80_000.0)
+        ks._check()
+    assert ks.is_halted
+
+    ks.reset(120_000.0)
+
+    assert not ks.is_halted
+    assert ks.new_positions_allowed
+    assert ks.status.realized_drawdown == 0.0
+
+
+# ---------------------------------------------------------------------------
+# VIX blackout gate (KS-3)
+# ---------------------------------------------------------------------------
+
+
+def test_vix_blackout_sets_and_clears_on_genuine_readings():
+    """The blackout sets on a high reading and clears on a later genuine low reading."""
+    ks = _make_ks("MODERATE")
+    with mock.patch("argus.data.fetchers.fetch_vix", return_value=40.0):
+        ks._check()
+    assert not ks.new_positions_allowed
+
+    with mock.patch("argus.data.fetchers.fetch_vix", return_value=15.0):
+        ks._check()
+    assert ks.new_positions_allowed
+
+
+def test_vix_fetch_failure_does_not_clear_an_active_blackout():
+    """KS-3: a fetch failure must never clear a blackout that's already set."""
+    ks = _make_ks("MODERATE")
+    with mock.patch("argus.data.fetchers.fetch_vix", return_value=40.0):
+        ks._check()
+    assert not ks.new_positions_allowed
+
+    with mock.patch("argus.data.fetchers.fetch_vix", side_effect=RuntimeError("network down")):
+        ks._check()
+    assert not ks.new_positions_allowed
+
+
+def test_vix_fetch_failure_sets_blackout_after_n_consecutive_failures():
+    """KS-3: repeated fetch failures fail closed instead of silently trusting a stale reading."""
+    ks = _make_ks("MODERATE")
+    assert ks.new_positions_allowed
+
+    with mock.patch("argus.data.fetchers.fetch_vix", side_effect=RuntimeError("down")):
+        for _ in range(KillSwitch._VIX_FAILURE_HALT_THRESHOLD - 1):
+            ks._check()
+            assert ks.new_positions_allowed
+        ks._check()
+
+    assert not ks.new_positions_allowed
+
+
+def test_vix_fetch_success_resets_failure_counter():
+    """A single genuine reading between failures resets the consecutive-failure count."""
+    ks = _make_ks("MODERATE")
+    with mock.patch("argus.data.fetchers.fetch_vix", side_effect=RuntimeError("down")):
+        for _ in range(KillSwitch._VIX_FAILURE_HALT_THRESHOLD - 1):
+            ks._check()
+
+    with mock.patch("argus.data.fetchers.fetch_vix", return_value=15.0):
+        ks._check()
+    assert ks._consecutive_vix_failures == 0
+
+    with mock.patch("argus.data.fetchers.fetch_vix", side_effect=RuntimeError("down")):
+        for _ in range(KillSwitch._VIX_FAILURE_HALT_THRESHOLD - 1):
+            ks._check()
+    assert ks.new_positions_allowed  # only 4 consecutive failures since the reset, not 5
+
+
+# ---------------------------------------------------------------------------
+# Halt persistence and restore-on-init
+# ---------------------------------------------------------------------------
+
+
+def test_halt_restores_from_a_persisted_dump(tmp_path, monkeypatch):
+    """A halt dump written by one KillSwitch instance restores into a fresh one."""
+    monkeypatch.chdir(tmp_path)
+    seed = _make_ks("MODERATE", inception=100_000.0)
+    seed._current_portfolio_value = 80_000.0
+    seed._halt_reason = "Drawdown 20.0% >= 12% limit (MODERATE)"
+    seed._halt_time = datetime.now()
+    seed._persist_halt_event(0.20, 15.0)
+
+    halt_file = kill_switch_module._find_latest_halt_file()
+    assert halt_file is not None
+
+    restored = KillSwitch("MODERATE")
+    restored._restore_halt_from_file(halt_file)
+
+    assert restored.is_halted
+    assert restored._halt_reason == seed._halt_reason
+
+
+def test_initialize_kill_switch_restores_halt_on_reinit(tmp_path, monkeypatch):
+    """initialize_kill_switch() re-applies a leftover halt file rather than starting clean."""
+    monkeypatch.chdir(tmp_path)
+    seed = _make_ks("MODERATE", inception=100_000.0)
+    seed._current_portfolio_value = 80_000.0
+    seed._halt_reason = "Drawdown 20.0% >= 12% limit (MODERATE)"
+    seed._halt_time = datetime.now()
+    seed._persist_halt_event(0.20, 15.0)
+
+    with mock.patch.object(KillSwitch, "start"):
+        ks = initialize_kill_switch("MODERATE", portfolio_value=100_000.0)
+
+    assert ks.is_halted
+    assert ks._halt_reason == seed._halt_reason
+
+
+# ---------------------------------------------------------------------------
+# Collector gate (KS-2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collector_skips_when_kill_switch_halted():
+    """KS-2: run_collection_cycle refuses to run while this process's kill switch is halted."""
+    ks = _make_ks("MODERATE")
+    ks._halted.set()
+    ks._halt_reason = "test halt"
+    kill_switch_module._kill_switch = ks
+
+    pipeline = mock.Mock()
+    pipeline.run_once = mock.AsyncMock(side_effect=AssertionError("must not run while halted"))
+
+    result = await run_collection_cycle(
+        universe=["AAPL"],
+        total_wealth=100_000.0,
+        invest_pct=0.5,
+        risk_tolerance="MODERATE",
+        pipeline=pipeline,
+        compiled_graph=mock.Mock(),
+    )
+
+    assert result.ran is False
+    assert "halted" in result.reason
+    pipeline.run_once.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_collector_runs_when_no_kill_switch_initialized():
+    """A process with no kill switch initialized (get_kill_switch() is None) is ungated."""
+    assert kill_switch_module.get_kill_switch() is None
+
+    pipeline = mock.Mock()
+    pipeline.run_once = mock.AsyncMock(return_value={})
+
+    result = await run_collection_cycle(
+        universe=["AAPL"],
+        total_wealth=100_000.0,
+        invest_pct=0.5,
+        risk_tolerance="MODERATE",
+        pipeline=pipeline,
+        compiled_graph=mock.Mock(),
+    )
+
+    pipeline.run_once.assert_awaited_once()
+    assert result.ran is False  # no session data for AAPL in the empty {} session_states
+    assert "halted" not in result.reason
+
+
+# ---------------------------------------------------------------------------
+# paper_book: compute_run_returns
+# ---------------------------------------------------------------------------
+
+
+def _technical(ticker: str, price: float) -> TechnicalSignal:
+    """Builds a minimal TechnicalSignal, varying only ticker and current_price."""
+    return TechnicalSignal(
+        ticker=ticker,
+        current_price=price,
+        rsi_14=50.0,
+        macd_histogram=0.0,
+        bb_percent_b=0.5,
+        atr_pct=0.02,
+        adx_14=20.0,
+        vwap_distance=0.0,
+        volume_ratio=1.0,
+        momentum_30m=0.0,
+        momentum_1d=0.0,
+        signal=Signal.BULLISH,
+        conviction=0.7,
+        net_score=0.0,
+        timestamp=datetime.now(),
+    )
+
+
+def _allocation(ticker: str, pct: float) -> PositionAllocation:
+    """Builds a minimal PositionAllocation, varying only ticker and allocation_pct."""
+    return PositionAllocation(
+        ticker=ticker,
+        allocation_pct=pct,
+        allocation_usd=pct * 100_000.0,
+        stop_loss=90.0,
+        thesis="test thesis",
+        composite_conviction=0.7,
+        time_horizon="30 days",
+    )
+
+
+def _decision(ticker: str, session_timestamp: datetime, price: float, pct: float) -> ARGUSDecision:
+    """Builds a minimal reconciliation-eligible ARGUSDecision."""
+    return ARGUSDecision(
+        ticker=ticker,
+        session_timestamp=session_timestamp,
+        technical=_technical(ticker, price),
+        allocation=_allocation(ticker, pct),
+    )
+
+
+class _FakePrices:
+    """Minimal MarketDataProvider double: only ohlcv_daily is used by paper_book."""
+
+    def __init__(self, closes: dict[str, pd.Series]) -> None:
+        self._closes = closes
+
+    def ohlcv_daily(self, ticker: str, period: str = "2y") -> pd.DataFrame:
+        return pd.DataFrame({"close": self._closes[ticker]})
+
+
+def _series(start: datetime, start_price: float, days: int = 10, drift: float = 1.0) -> pd.Series:
+    """Builds a daily close series rising by `drift` per day from start_price."""
+    dates = pd.date_range(start=start, periods=days, freq="D")
+    return pd.Series([start_price + drift * i for i in range(days)], index=dates)
+
+
+def test_compute_run_returns_weights_by_allocation_pct():
+    """A run's return is the allocation-weighted average of its matured decisions."""
+    start = datetime(2026, 1, 1)
+    aaa = _decision("AAA", start, price=100.0, pct=0.1)  # +5% over 5 days
+    bbb = _decision("BBB", start, price=200.0, pct=0.15)  # +10% over 5 days
+    prices = _FakePrices(
+        {
+            "AAA": _series(start, 100.0, drift=1.0),
+            "BBB": _series(start, 200.0, drift=4.0),
+        }
+    )
+
+    results = compute_run_returns([aaa, bbb], prices, horizon_days=5)
+
+    assert len(results) == 1
+    run_timestamp, run_return = results[0]
+    assert run_timestamp == start
+    expected = (0.05 * 0.1 + 0.10 * 0.15) / (0.1 + 0.15)
+    assert run_return == pytest.approx(expected)
+
+
+def test_compute_run_returns_partial_maturity_uses_only_matured_subset():
+    """A run with one matured and one unmatured decision isn't diluted by the unmatured one."""
+    start = datetime(2026, 1, 1)
+    matured = _decision("AAA", start, price=100.0, pct=0.1)  # +5% over 5 days
+    unmatured = _decision("BBB", start, price=100.0, pct=0.15)
+    prices = _FakePrices(
+        {
+            "AAA": _series(start, 100.0, days=10, drift=1.0),
+            "BBB": _series(start, 100.0, days=2, drift=1.0),  # short of the 5-day horizon
+        }
+    )
+
+    results = compute_run_returns([matured, unmatured], prices, horizon_days=5)
+
+    assert len(results) == 1
+    _, run_return = results[0]
+    assert run_return == pytest.approx(0.05)
+
+
+def test_compute_run_returns_omits_runs_with_no_matured_decisions():
+    """A run where nothing has matured yet is deferred, not reported as a 0.0 return."""
+    start = datetime(2026, 1, 1)
+    decision = _decision("AAA", start, price=100.0, pct=0.1)
+    prices = _FakePrices({"AAA": _series(start, 100.0, days=2, drift=1.0)})
+
+    assert compute_run_returns([decision], prices, horizon_days=30) == []
+
+
+def test_compute_run_returns_groups_by_session_timestamp():
+    """Decisions from two different runs produce two separate results, in order."""
+    run1 = datetime(2026, 1, 1)
+    run2 = datetime(2026, 1, 8)
+    d1 = _decision("AAA", run1, price=100.0, pct=0.15)
+    d2 = _decision("AAA", run2, price=100.0, pct=0.15)
+    prices = _FakePrices({"AAA": _series(run1, 100.0, days=20, drift=1.0)})
+
+    results = compute_run_returns([d1, d2], prices, horizon_days=5)
+
+    assert [r[0] for r in results] == [run1, run2]
+
+
+def test_compute_run_returns_skips_decisions_that_took_no_position():
+    """A decision with a zero-weight allocation contributes nothing to its run."""
+    start = datetime(2026, 1, 1)
+    zero_weight = _decision("AAA", start, price=100.0, pct=0.0)
+    prices = _FakePrices({"AAA": _series(start, 100.0, drift=1.0)})
+
+    assert compute_run_returns([zero_weight], prices, horizon_days=5) == []
+
+
+# ---------------------------------------------------------------------------
+# paper_book: PaperBook
+# ---------------------------------------------------------------------------
+
+
+def test_paperbook_apply_run_idempotent():
+    """Re-applying the same run_timestamp is a no-op the second time."""
+    book = PaperBook(equity=100_000.0, high_water_mark=100_000.0)
+    ts = datetime(2026, 1, 1)
+
+    assert book.apply_run(ts, 0.05) is True
+    assert book.equity == pytest.approx(105_000.0)
+
+    assert book.apply_run(ts, 0.05) is False
+    assert book.equity == pytest.approx(105_000.0)
+
+
+def test_paperbook_drawdown_from_peak():
+    """drawdown_from_peak reflects the highest equity reached, not the latest run alone."""
+    book = PaperBook(equity=100_000.0, high_water_mark=100_000.0)
+    book.apply_run(datetime(2026, 1, 1), 0.20)
+    book.apply_run(datetime(2026, 1, 8), -0.10)
+
+    assert book.high_water_mark == pytest.approx(120_000.0)
+    assert book.equity == pytest.approx(108_000.0)
+    assert book.drawdown_from_peak() == pytest.approx((120_000.0 - 108_000.0) / 120_000.0)
+
+
+def test_paperbook_save_load_round_trip(tmp_path):
+    """A saved PaperBook loads back with identical field values."""
+    path = str(tmp_path / "paper_equity.json")
+    book = PaperBook(
+        equity=95_000.0,
+        high_water_mark=110_000.0,
+        last_run_timestamp=datetime(2026, 1, 1),
+        runs_applied={"2026-01-01T00:00:00"},
+    )
+
+    paper_book.save(book, path)
+    loaded = paper_book.load(path)
+
+    assert loaded.equity == pytest.approx(95_000.0)
+    assert loaded.high_water_mark == pytest.approx(110_000.0)
+    assert loaded.last_run_timestamp == datetime(2026, 1, 1)
+    assert loaded.runs_applied == {"2026-01-01T00:00:00"}
+
+
+def test_paperbook_load_missing_file_starts_fresh_at_total_wealth(tmp_path):
+    """A missing paper_equity.json is a fresh deployment, not an error."""
+    path = str(tmp_path / "does_not_exist.json")
+
+    book = paper_book.load(path)
+
+    assert book.equity == pytest.approx(settings.ARGUS_TOTAL_WEALTH)
+    assert book.high_water_mark == pytest.approx(settings.ARGUS_TOTAL_WEALTH)
+    assert book.runs_applied == set()


### PR DESCRIPTION
## Summary

PR1 of the safety-layer remediation plan (#36) — restores the kill switch so the safety gate genuinely works end to end. Covers KS-1, KS-2, KS-3, KS-4, KS-5, and the KS-14 test gap. PR2 (kill-switch lifecycle/config/surface) and PR3 (rate limit governor) remain.

- **KS-1** (Critical): `update_portfolio_value()` had no production caller, so drawdown was permanently 0.0. Adds `argus/risk/paper_book.py`, a synthetic paper equity curve derived from matured decision outcomes (one notional rebalance per graph run, weighted by `allocation_pct`, compounded and persisted to `paper_equity.json`). The daily reconcile loop (`api/main.py`, `scripts/reconcile_outcomes.py`) applies matured runs onto the curve and feeds it into the kill switch; `paper_equity.json` round-trips through the `argus-data` branch alongside `decisions.jsonl` in `reconcile.yml`. On API startup the kill switch re-seeds both inception value and high-water mark from the persisted curve, so a process restart can't silently forget an already-realized drawdown.
- **KS-2** (Critical): the unattended collector never consulted the kill switch. `run_collection_cycle` now returns `ran=False, reason="halted: ..."` before touching the pipeline when this process's kill switch is halted. A process with no kill switch initialized (the standalone `scripts/collect_session.py` GitHub Actions runner) stays ungated — a documented, not solved, cross-process gap, same class as GOV-8.
- **KS-5**: drawdown is now measured peak-to-trough against a tracked `_high_water_mark`, not the stale inception value.
- **KS-4**: a literal `0.0` portfolio value is no longer treated as falsy/"unset" via `or`.
- **KS-3**: a VIX fetch failure no longer falls back to a hardcoded `20.0` that could silently clear an active blackout — it holds the existing gate state and fails closed after 5 consecutive failures.
- **KS-14**: `tests/test_kill_switch.py` replaces the single live-network test in `test_integration.py` with 24 unit tests driving `_check()` directly (mocked VIX, no threads, no sleeps). Also adds `tests/conftest.py`'s opt-in `block_network` fixture.

## Test plan

- [x] `pytest tests/ -q` — 263 passed (239 baseline + 24 new)
- [x] `ruff check .` — clean
- [x] `mypy argus api` — no new errors (pre-existing `api/main.py` baseline error unchanged, just shifted line)