### PR TITLE
fix: isolate tests from the production candle buffer (PR0)

### DIFF
--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -17,12 +17,13 @@ Not responsible for:
 
 Dependencies:
   - asyncio
-  - pandas_ta (lazy import; loaded only at indicator compute time)
+  - pandas_ta
 """
 
 from __future__ import annotations
 
 import asyncio
+import importlib.metadata  # noqa: F401 — pandas_ta.maps uses this without importing it
 import logging
 import re
 from collections.abc import Callable
@@ -31,6 +32,7 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pandas as pd
+import pandas_ta as ta
 
 from argus.config import settings
 from argus.data.cache import OHLCVBuffer
@@ -390,9 +392,6 @@ class MFTDataPipeline:
     def _compress_candles(self, df: pd.DataFrame) -> dict:
         """Calculates technical indicators on a DataFrame using pandas-ta.
 
-        Delayed import of pandas_ta avoids loading the heavy C extension on startup,
-        which is particularly important in serverless and cold-start environments.
-
         Args:
             df: Raw OHLCV DataFrame at `self.interval` resolution, float columns,
                 datetime index.
@@ -404,8 +403,6 @@ class MFTDataPipeline:
             are None when pandas_ta cannot compute them; close and timestamp are
             always populated.
         """
-        import pandas_ta as ta  # Lazy import to avoid heavy C extension load on startup
-
         ind_df = _resample_ohlcv(df, self.interval_minutes, _INDICATOR_RESAMPLE_MINUTES)
 
         rsi_series = ta.rsi(ind_df["close"], length=14)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ Shared pytest fixtures.
 Responsibilities:
   - Provide an opt-in network guard a test can request to prove it never
     falls through to a real socket call
+  - Isolate every test from the production candle buffer
 
 Not responsible for:
   - Test data (see tests/fixtures/)
@@ -20,6 +21,24 @@ import socket
 from collections.abc import Iterator
 
 import pytest
+
+from argus.config import settings
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_dir(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Points ARGUS_DATA_DIR at a per-test tmp_path so no test can reach the production buffer.
+
+    Any call site that builds ``MFTDataPipeline`` (or otherwise resolves a
+    path from ``settings.ARGUS_DATA_DIR``) without an explicit override lands
+    here instead of ``data/ohlcv_buffer.db``, which a local `pytest` run
+    would otherwise insert into and prune.
+
+    Args:
+        tmp_path: Pytest's per-test temporary directory.
+        monkeypatch: Pytest's monkeypatch fixture.
+    """
+    monkeypatch.setattr(settings, "ARGUS_DATA_DIR", str(tmp_path))
 
 
 @pytest.fixture

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Test helpers sub-package for ARGUS."""

--- a/tests/helpers/candles.py
+++ b/tests/helpers/candles.py
@@ -1,0 +1,81 @@
+"""
+tests/helpers/candles.py
+
+Shared tz-aware OHLCV candle builders for pipeline and cache tests.
+
+Responsibilities:
+  - Build a tz-aware America/New_York intraday OHLCV frame of N bars
+  - Build a frame straddling the 2025-11-02 DST fall-back transition
+
+Not responsible for:
+  - Buffer construction or insertion (see argus/data/cache.py)
+  - Indicator computation (see argus/data/pipeline.py)
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+_ET = "America/New_York"
+
+
+def et_intraday_candles(
+    n: int, start: str = "2024-01-02 09:30", freq: str = "1min"
+) -> pd.DataFrame:
+    """Builds a tz-aware ET intraday OHLCV frame of monotonically increasing bars.
+
+    Args:
+        n: Number of bars.
+        start: Naive local start timestamp, interpreted as ET.
+        freq: Pandas frequency string for bar spacing.
+
+    Returns:
+        DataFrame with open/high/low/close/volume columns and a tz-aware
+        (America/New_York) DatetimeIndex.
+    """
+    dates = pd.date_range(start, periods=n, freq=freq, tz=_ET)
+    closes = list(range(n))
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c + 1 for c in closes],
+            "low": closes,
+            "close": closes,
+            "volume": [1000] * n,
+        },
+        index=dates,
+    )
+
+
+def dst_straddling_candles(n_per_side: int = 6, freq: str = "1min") -> pd.DataFrame:
+    """Builds an ET intraday frame straddling the 2025-11-02 fall-back DST transition.
+
+    The 01:00-01:59 ET wall-clock hour occurs twice that day (once at UTC-4,
+    once at UTC-5). Built from UTC instants either side of the transition so
+    the result is unambiguous and its UTC instants are monotonic, despite the
+    repeated local wall-clock hour.
+
+    Args:
+        n_per_side: Number of bars on each side of the transition.
+        freq: Pandas frequency string for bar spacing.
+
+    Returns:
+        DataFrame of `2 * n_per_side` bars, tz-aware (America/New_York).
+    """
+    # 01:54-01:59 EDT (UTC-4), the six minutes immediately before the transition
+    pre_utc = pd.date_range("2025-11-02 05:54:00", periods=n_per_side, freq=freq, tz="UTC")
+    # 01:00-01:05 EST (UTC-5), the same wall-clock minutes again, one hour later in UTC
+    post_utc = pd.date_range("2025-11-02 06:00:00", periods=n_per_side, freq=freq, tz="UTC")
+    dates = pre_utc.append(post_utc).tz_convert(_ET)
+    n = 2 * n_per_side
+    closes = list(range(n))
+    return pd.DataFrame(
+        {
+            "open": closes,
+            "high": [c + 1 for c in closes],
+            "low": closes,
+            "close": closes,
+            "volume": [1000] * n,
+        },
+        index=dates,
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,11 +2,16 @@
 Tests for the MFT Data Pipeline.
 """
 
+import importlib
 import logging
+import sys
+from pathlib import Path
 
 import pandas as pd
 import pytest
 
+import argus.data.pipeline as pipeline_module
+from argus.config import settings
 from argus.data.cache import OHLCVBuffer
 from argus.data.pipeline import (
     _FETCH_INTERVAL,
@@ -17,6 +22,7 @@ from argus.data.pipeline import (
     _parse_interval_minutes,
     _resample_ohlcv,
 )
+from tests.helpers.candles import dst_straddling_candles, et_intraday_candles
 
 
 def test_register_tickers():
@@ -205,3 +211,39 @@ def test_inter_request_sleep_floors_at_zero_and_warns_when_universe_outgrows_cad
 
     assert result == 0.0
     assert any("won't fit" in record.message for record in caplog.records)
+
+
+def test_default_db_path_uses_isolated_data_dir(tmp_path):
+    """A pipeline built without an explicit db_path never reaches the production buffer."""
+    pipeline = MFTDataPipeline(["AAPL"])
+    assert Path(pipeline.buffer._db_path).parent == tmp_path
+    assert Path(pipeline.buffer._db_path).parent == Path(settings.ARGUS_DATA_DIR)
+
+
+def test_pandas_ta_import_failure_is_a_boot_failure(monkeypatch):
+    """A broken pandas_ta install fails at module import time, not silently inside compress_all."""
+    monkeypatch.setitem(sys.modules, "pandas_ta", None)
+    try:
+        with pytest.raises(ImportError):
+            importlib.reload(pipeline_module)
+    finally:
+        monkeypatch.undo()
+        importlib.reload(pipeline_module)
+
+
+def test_et_intraday_candles_are_tz_aware_and_monotonic():
+    """The shared candle builder produces a tz-aware, monotonically increasing ET frame."""
+    df = et_intraday_candles(20)
+    assert len(df) == 20
+    assert str(df.index.tz) == "America/New_York"
+    assert df.index.is_monotonic_increasing
+    assert df["close"].iloc[-1] == 19.0
+
+
+def test_dst_straddling_candles_are_monotonic_in_utc_despite_repeated_wall_clock():
+    """The DST fixture's local hour repeats but its underlying UTC instants strictly increase."""
+    df = dst_straddling_candles(n_per_side=6)
+    assert len(df) == 12
+    assert df.index.tz_convert("UTC").is_monotonic_increasing
+    # The repeated 01:xx ET wall-clock hour is exactly the reproduced hazard
+    assert (df.index.hour == 1).all()


### PR DESCRIPTION
## Summary
- Closes MFT-12 and MFT-9 from #41's PR0 (test isolation, no behaviour change): an autouse `tests/conftest.py` fixture points `ARGUS_DATA_DIR` at `tmp_path` for every test, so no test can write to or prune the production candle buffer (`data/ohlcv_buffer.db`) the way ten `MFTDataPipeline(db_path=None)` call sites previously did.
- Hoists `pandas_ta` to a module-level import in `pipeline.py`, converting a broken install from a permanently swallowed per-ticker warning inside `compress_all` into a boot failure. This surfaced a real live bug: `pandas_ta.maps` calls `importlib.metadata.distribution(...)` without importing that submodule itself, so `import pandas_ta` only ever succeeded by accident, depending on something upstream having imported `importlib.metadata` first — fixed with an explicit import ahead of it.
- Adds `tests/helpers/candles.py` (`et_intraday_candles`, `dst_straddling_candles`) — shared tz-aware ET candle builders, including a frame straddling the 2025-11-02 DST fall-back transition, for #41's PR1-PR4 to consume.

## Test plan
- [x] `.venv/bin/pytest tests/ -q` — 297 passed
- [x] `.venv/bin/ruff check .` — clean
- [x] `.venv/bin/mypy argus api scripts` — no new errors (4 pre-existing, unrelated errors in `scripts/remediate_macro_regime_tags.py` and `api/main.py:535`)
- [x] Production buffer's mtime confirmed unchanged across a full suite run