### PR TITLE
fix: canonical timestamps, interval migration, and crash containment (PR1)

### DIFF
--- a/argus/backtesting/replay.py
+++ b/argus/backtesting/replay.py
@@ -44,12 +44,35 @@ from pathlib import Path
 from typing import Any
 from unittest import mock
 from uuid import uuid4
+from zoneinfo import ZoneInfo
 
 from argus.orchestration.graph import build_graph
 from argus.orchestration.state import ARGUSState
 from argus.seams import FixtureLLMClient, FixtureMarketDataProvider
 
 logger = logging.getLogger("argus.backtesting.replay")
+
+_ET = ZoneInfo("America/New_York")
+
+
+def _normalize_as_of(ts: datetime) -> datetime:
+    """Strips an aware timestamp's tzinfo after converting it to ET wall-clock.
+
+    Naive input passes through unchanged, since every naive timestamp
+    reaching this codebase is already treated as local ET. Guards
+    node_log_decisions' session_timestamp against mixing naive and aware
+    values across runs, which raises when paper_book.compute_run_returns
+    later sorts by run.
+
+    Args:
+        ts: Parsed session-capture timestamp, aware or naive.
+
+    Returns:
+        Naive ET datetime.
+    """
+    if ts.tzinfo is None:
+        return ts
+    return ts.astimezone(_ET).replace(tzinfo=None)
 
 
 @dataclass
@@ -140,7 +163,9 @@ def replay_session(
         SessionResult with the session's universe and the graph's final state.
     """
     universe, session_states = _load_session_states(session_dir)
-    session_date = datetime.fromisoformat(next(iter(session_states.values()))["timestamp"])
+    session_date = _normalize_as_of(
+        datetime.fromisoformat(next(iter(session_states.values()))["timestamp"])
+    )
 
     state = ARGUSState(
         ticker=universe[0],

--- a/argus/data/cache.py
+++ b/argus/data/cache.py
@@ -34,9 +34,12 @@ import pandas as pd
 
 logger = logging.getLogger("argus.cache")
 
+_ET = "America/New_York"
+
 _CREATE_OHLCV = """
 CREATE TABLE IF NOT EXISTS ohlcv (
     ticker    TEXT NOT NULL,
+    interval  TEXT NOT NULL,
     timestamp TEXT NOT NULL,
     open      REAL,
     high      REAL,
@@ -48,8 +51,8 @@ CREATE TABLE IF NOT EXISTS ohlcv (
 """
 
 _INSERT_OHLCV = """
-INSERT OR REPLACE INTO ohlcv (ticker, timestamp, open, high, low, close, volume)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT OR REPLACE INTO ohlcv (ticker, interval, timestamp, open, high, low, close, volume)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 _PRUNE_OHLCV = """
@@ -66,13 +69,31 @@ WHERE ticker = ?
 _SELECT_CANDLES = """
 SELECT timestamp, open, high, low, close, volume
 FROM ohlcv
-WHERE ticker = ?
+WHERE ticker = ? AND interval = ?
 ORDER BY timestamp ASC
 """
 
 _SELECT_TICKERS = """
-SELECT DISTINCT ticker FROM ohlcv
+SELECT DISTINCT ticker FROM ohlcv WHERE interval = ?
 """
+
+
+def _canonical_timestamp(ts: object) -> str:
+    """Canonicalizes a candle timestamp to UTC ISO-8601 for storage.
+
+    Naive input is interpreted as ET — every naive timestamp reaching this
+    buffer comes from a US session.
+
+    Args:
+        ts: datetime, pandas Timestamp, or ISO-8601 string; naive or aware.
+
+    Returns:
+        UTC ISO-8601 string.
+    """
+    stamp = pd.Timestamp(ts)
+    if stamp.tzinfo is None:
+        stamp = stamp.tz_localize(_ET)
+    return stamp.tz_convert(timezone.utc).isoformat()
 
 
 class OHLCVBuffer:
@@ -82,40 +103,78 @@ class OHLCVBuffer:
     by the async fetch loop. Thread safety is enforced by a single module-level lock.
     """
 
-    def __init__(self, db_path: str = ":memory:", buffer_size: int = 78) -> None:
+    def __init__(self, db_path: str = ":memory:", buffer_size: int = 78, *, interval: str) -> None:
         """Opens (or creates) the SQLite-backed candle buffer.
 
         Args:
             db_path: SQLite connection path, or ':memory:' for an ephemeral buffer.
             buffer_size: Max candles retained per ticker; older rows are pruned on insert.
+            interval: Candle resolution this buffer holds (e.g. "1m"). Rows
+                written under a different interval are purged on open —
+                mixed-resolution rows would silently corrupt resampled
+                indicators.
         """
         self._db_path = db_path
         self._buffer_size = buffer_size
+        self._interval = interval
         self._lock = threading.Lock()
         if db_path != ":memory:":
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._conn = sqlite3.connect(db_path, check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
+        self._migrate_schema()
+        self._purge_stale_interval()
+        logger.info(
+            "OHLCVBuffer initialised (db=%s, buffer_size=%d, interval=%s)",
+            db_path,
+            buffer_size,
+            interval,
+        )
+
+    def _migrate_schema(self) -> None:
+        """Drops and recreates `ohlcv` once, adding the per-row `interval` column.
+
+        `user_version` 0→1 marks the migration as applied so it never re-runs
+        against a buffer already on the new schema.
+        """
+        version = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if version < 1:
+            self._conn.execute("DROP TABLE IF EXISTS ohlcv")
+            self._conn.execute("PRAGMA user_version = 1")
         self._conn.execute(_CREATE_OHLCV)
         self._conn.commit()
-        logger.info("OHLCVBuffer initialised (db=%s, buffer_size=%d)", db_path, buffer_size)
+
+    def _purge_stale_interval(self) -> None:
+        """Discards rows written under a different interval than this buffer's configured one."""
+        cursor = self._conn.execute("DELETE FROM ohlcv WHERE interval != ?", (self._interval,))
+        self._conn.commit()
+        if cursor.rowcount:
+            logger.warning(
+                "OHLCVBuffer: interval is now %s, discarded %d row(s) written under a "
+                "different interval",
+                self._interval,
+                cursor.rowcount,
+            )
 
     def insert_candle(self, ticker: str, candle: dict) -> None:
         """Inserts a single candlestick entry and prunes historical values exceeding the buffer limit.
 
         Args:
-            ticker: Equity ticker symbol.
+            ticker: Equity ticker symbol; case-insensitive, normalized to upper.
             candle: Dict with keys timestamp, open, high, low, close, volume.
+                timestamp may be naive (interpreted as ET) or tz-aware; stored
+                as canonical UTC ISO-8601.
         """
+        ticker = ticker.upper()
         ts = candle.get("timestamp")
-        if isinstance(ts, datetime):
-            ts = ts.isoformat()
-        elif ts is None:
-            ts = datetime.now(timezone.utc).isoformat()
+        if ts is None:
+            ts = datetime.now(timezone.utc)
+        ts = _canonical_timestamp(ts)
 
         row = (
             ticker,
-            str(ts),
+            self._interval,
+            ts,
             candle.get("open"),
             candle.get("high"),
             candle.get("low"),
@@ -131,19 +190,21 @@ class OHLCVBuffer:
         logger.debug("OHLCVBuffer.insert_candle: %s @ %s", ticker, ts)
 
     def get_candles(self, ticker: str) -> Optional[pd.DataFrame]:
-        """Retrieves buffered candles as a pandas DataFrame indexed by timestamp.
+        """Retrieves buffered candles as a pandas DataFrame, tz-converted to ET.
 
         Returns None when fewer than 14 rows exist, as most indicators require at
         least that many periods to produce meaningful values.
 
         Args:
-            ticker: Equity ticker symbol.
+            ticker: Equity ticker symbol; case-insensitive.
 
         Returns:
-            DataFrame with float OHLCV columns and a datetime index, or None.
+            DataFrame with float OHLCV columns and a tz-aware (ET) datetime
+            index, sorted ascending, or None.
         """
+        ticker = ticker.upper()
         with self._lock:
-            rows = self._conn.execute(_SELECT_CANDLES, (ticker,)).fetchall()
+            rows = self._conn.execute(_SELECT_CANDLES, (ticker, self._interval)).fetchall()
 
         if len(rows) < 14:
             logger.debug(
@@ -152,8 +213,13 @@ class OHLCVBuffer:
             return None
 
         df = pd.DataFrame(rows, columns=["timestamp", "open", "high", "low", "close", "volume"])
-        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        # utc=True + format="ISO8601" is load-bearing: utc=True alone still raises when naive
+        # and aware strings coexist, and tz_convert must run before any indicator math since
+        # resampling/VWAP bin by wall clock
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True, format="ISO8601")
         df.set_index("timestamp", inplace=True)
+        df.sort_index(inplace=True)
+        df = df.tz_convert(_ET)
         df = df.astype(float)
         logger.debug("OHLCVBuffer.get_candles: %s → %d rows", ticker, len(df))
         return df
@@ -165,7 +231,7 @@ class OHLCVBuffer:
             List of ticker strings.
         """
         with self._lock:
-            rows = self._conn.execute(_SELECT_TICKERS).fetchall()
+            rows = self._conn.execute(_SELECT_TICKERS, (self._interval,)).fetchall()
         return [r[0] for r in rows]
 
     def close(self) -> None:

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -23,6 +23,7 @@ Dependencies:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import importlib.metadata  # noqa: F401 — pandas_ta.maps uses this without importing it
 import logging
 import re
@@ -165,8 +166,9 @@ class MFTDataPipeline:
             data_dir = Path(settings.ARGUS_DATA_DIR)
             data_dir.mkdir(parents=True, exist_ok=True)
             db_path = str(data_dir / "ohlcv_buffer.db")
-        self.buffer = OHLCVBuffer(db_path=db_path, buffer_size=buffer_size)
+        self.buffer = OHLCVBuffer(db_path=db_path, buffer_size=buffer_size, interval=self.interval)
         self.running = False
+        self._stop_event = asyncio.Event()
         logger.info(
             "MFTDataPipeline initialised: %d tickers, interval=%s, buffer_size=%d, buffer=%s",
             len(tickers),
@@ -184,10 +186,28 @@ class MFTDataPipeline:
         """
         self.running = True
         logger.info("MFTDataPipeline.start: launching fetch and session loops")
-        await asyncio.gather(
-            self._fetch_loop(),
-            self._session_loop(on_session_ready),
-        )
+        tasks = [
+            asyncio.create_task(self._fetch_loop()),
+            asyncio.create_task(self._session_loop(on_session_ready)),
+        ]
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            # Either task ending (return or raise) must not orphan the other —
+            # cancel and await both so a dead fetch loop can't leave the session
+            # loop sweeping into a closed buffer, or vice versa
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _wait_or_stop(self, timeout: float) -> None:
+        """Sleeps up to `timeout` seconds, waking immediately if `stop()` is called.
+
+        Args:
+            timeout: Max seconds to wait.
+        """
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._stop_event.wait(), timeout=timeout)
 
     def register_tickers(self, tickers: list[str]) -> None:
         """Adds new tickers to the live tracking universe without restarting the pipeline.
@@ -211,6 +231,7 @@ class MFTDataPipeline:
     async def stop(self) -> None:
         """Signals active loops to stop execution."""
         self.running = False
+        self._stop_event.set()
         logger.info("MFTDataPipeline.stop: shutdown requested")
 
     async def run_once(self) -> dict[str, dict]:
@@ -250,12 +271,17 @@ class MFTDataPipeline:
     async def _fetch_loop(self) -> None:
         """Periodically downloads the latest intraday candlesticks for the tracking universe."""
         while self.running:
-            if self._is_market_hours():
-                await self._sweep_once()
-            else:
-                logger.debug("_fetch_loop: outside market hours — idle")
+            try:
+                if self._is_market_hours():
+                    await self._sweep_once()
+                else:
+                    logger.debug("_fetch_loop: outside market hours — idle")
+            except Exception as exc:
+                logger.error(
+                    "_fetch_loop: sweep failed — %s: %s", type(exc).__name__, exc
+                )
 
-            await asyncio.sleep(_FETCH_INTERVAL)
+            await self._wait_or_stop(_FETCH_INTERVAL)
 
     def _inter_request_sleep(self, n_tickers: int) -> float:
         """Derives the per-ticker sleep so a sweep finishes within `_FETCH_INTERVAL`.
@@ -292,7 +318,15 @@ class MFTDataPipeline:
             own floor), letting callers skip waiting a full session interval on a
             cold start.
         """
-        return any(self.buffer.get_candles(t) is not None for t in self.buffer.get_all_tickers())
+        for ticker in self.buffer.get_all_tickers():
+            try:
+                if self.buffer.get_candles(ticker) is not None:
+                    return True
+            except Exception as exc:
+                logger.warning(
+                    "_buffer_warm: %s check failed — %s: %s", ticker, type(exc).__name__, exc
+                )
+        return False
 
     async def _session_loop(self, callback: Callable) -> None:
         """Periodically compiles buffered candlesticks and triggers downstream agent actions.
@@ -304,21 +338,26 @@ class MFTDataPipeline:
         # compress would leave the live cache empty for that whole stretch for
         # no reason; poll faster until there's actually something to compress
         while self.running and not self._buffer_warm():
-            await asyncio.sleep(_WARMUP_POLL_INTERVAL)
+            await self._wait_or_stop(_WARMUP_POLL_INTERVAL)
 
         while self.running:
-            if self._is_market_hours():
-                logger.info("_session_loop: triggering decision cycle")
-                session_states = self.compress_all()
-                try:
-                    await callback(session_states)
-                except Exception as exc:
-                    logger.error(
-                        "_session_loop: callback raised %s: %s",
-                        type(exc).__name__,
-                        exc,
-                    )
-            await asyncio.sleep(self.session_interval_seconds)
+            try:
+                if self._is_market_hours():
+                    logger.info("_session_loop: triggering decision cycle")
+                    session_states = self.compress_all()
+                    try:
+                        await callback(session_states)
+                    except Exception as exc:
+                        logger.error(
+                            "_session_loop: callback raised %s: %s",
+                            type(exc).__name__,
+                            exc,
+                        )
+            except Exception as exc:
+                logger.error(
+                    "_session_loop: iteration failed — %s: %s", type(exc).__name__, exc
+                )
+            await self._wait_or_stop(self.session_interval_seconds)
 
     async def _fetch_one_ticker(self, ticker: str) -> None:
         """Downloads and bulk-inserts all available candles for a specific symbol.
@@ -375,17 +414,17 @@ class MFTDataPipeline:
         """
         states: dict[str, dict] = {}
         for ticker in self.buffer.get_all_tickers():
-            df = self.buffer.get_candles(ticker)
-            if df is not None:
-                try:
+            try:
+                df = self.buffer.get_candles(ticker)
+                if df is not None:
                     states[ticker] = self._compress_candles(df)
-                except Exception as exc:
-                    logger.warning(
-                        "compress_all: %s compression failed — %s: %s",
-                        ticker,
-                        type(exc).__name__,
-                        exc,
-                    )
+            except Exception as exc:
+                logger.warning(
+                    "compress_all: %s compression failed — %s: %s",
+                    ticker,
+                    type(exc).__name__,
+                    exc,
+                )
         logger.info("compress_all: %d tickers compressed", len(states))
         return states
 

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -7,8 +7,9 @@ import json
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
+from zoneinfo import ZoneInfo
 
-from argus.backtesting.replay import replay_session, replay_sessions
+from argus.backtesting.replay import _normalize_as_of, replay_session, replay_sessions
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
@@ -91,3 +92,23 @@ def test_replay_session_closed_loop_scopes_cultural_memory_to_the_session_date()
     assert mock_memory.retrieve_wisdom.call_args.kwargs["as_of"] == expected_as_of
     assert mock_memory.retrieve_warnings.call_args.kwargs["as_of"] == expected_as_of
     assert mock_memory.get_agent_accuracy.call_args.kwargs["as_of"] == expected_as_of
+
+
+def test_normalize_as_of_strips_tzinfo_from_an_aware_timestamp():
+    """An aware fixture timestamp (as a canonical-timestamp buffer would now produce) is
+    converted to ET wall-clock and returned naive, so it can't mix with a naive
+    datetime.now() fallback in node_log_decisions and break compute_run_returns' sort.
+    """
+    aware_utc = datetime(2024, 1, 2, 14, 30, tzinfo=ZoneInfo("UTC"))
+
+    result = _normalize_as_of(aware_utc)
+
+    assert result.tzinfo is None
+    assert result == datetime(2024, 1, 2, 9, 30)
+
+
+def test_normalize_as_of_passes_a_naive_timestamp_through_unchanged():
+    """A naive timestamp (today's fixture format) is returned exactly as given."""
+    naive = datetime(2024, 1, 2, 9, 30)
+
+    assert _normalize_as_of(naive) is naive

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,14 +1,18 @@
 """
-Tests for argus/data/cache.py's DailyBarCache — the per-(ticker, trading_date)
-disk cache that lets fetch_multiple_daily skip the network on same-day re-runs.
+Tests for argus/data/cache.py: DailyBarCache, the per-(ticker, trading_date)
+disk cache that lets fetch_multiple_daily skip the network on same-day
+re-runs, and OHLCVBuffer, the rolling intraday candle buffer.
 """
 
+import logging
+import sqlite3
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 import pytest
 
-from argus.data.cache import DailyBarCache
+from argus.data.cache import DailyBarCache, OHLCVBuffer
+from tests.helpers.candles import dst_straddling_candles
 
 
 def _bars(dates: list[str]) -> pd.DataFrame:
@@ -82,3 +86,98 @@ def test_get_is_isolated_per_ticker(cache):
     """Caching one ticker doesn't make an unrelated ticker appear cached."""
     cache.put("AAPL", _bars(["2026-08-12"]))
     assert cache.get("MSFT") is None
+
+
+def test_dst_straddling_insert_returns_a_monotonic_et_frame():
+    """A buffer fed DST fall-back candles returns them sorted, ET-indexed, not a raise."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=20, interval="1m")
+
+    # Padding bars ahead of the transition so the buffer clears get_candles' 14-row floor —
+    # n_per_side beyond 6 would overlap pre/post UTC instants in the shared DST helper itself
+    padding = pd.date_range("2025-11-02 04:00:00", periods=4, freq="1min", tz="UTC")
+    for i, ts in enumerate(padding):
+        buffer.insert_candle(
+            "AAPL", {"timestamp": ts, "open": i, "high": i + 1, "low": i, "close": i, "volume": 1000}
+        )
+
+    candles = dst_straddling_candles(n_per_side=6)
+    for idx, row in candles.iterrows():
+        buffer.insert_candle("AAPL", {"timestamp": idx, **row.to_dict()})
+
+    result = buffer.get_candles("AAPL")
+
+    assert result is not None
+    assert len(result) == len(padding) + len(candles)
+    assert result.index.is_monotonic_increasing
+    assert str(result.index.tz) == "America/New_York"
+
+
+def test_naive_et_and_aware_utc_inputs_for_one_instant_store_identically():
+    """The same instant, given as naive ET, aware ET, and aware UTC, canonicalizes to one row."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=20, interval="1m")
+    aware_et = pd.Timestamp("2024-01-02T09:30:00", tz="America/New_York")
+
+    buffer.insert_candle("AAPL", {"timestamp": "2024-01-02T09:30:00", "close": 1.0})
+    buffer.insert_candle("AAPL", {"timestamp": aware_et, "close": 2.0})
+    buffer.insert_candle("AAPL", {"timestamp": aware_et.tz_convert("UTC"), "close": 3.0})
+
+    rows = buffer._conn.execute("SELECT close FROM ohlcv WHERE ticker = 'AAPL'").fetchall()
+    assert rows == [(3.0,)]
+
+
+def test_ticker_case_collapses_to_one_key_space():
+    """A lowercase and uppercase ticker write into the same row space."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=20, interval="1m")
+    buffer.insert_candle("aapl", {"timestamp": "2024-01-02T09:30:00", "close": 1.0})
+    buffer.insert_candle("AAPL", {"timestamp": "2024-01-02T09:31:00", "close": 2.0})
+
+    assert buffer.get_all_tickers() == ["AAPL"]
+
+
+def test_schema_migration_from_v0_drops_and_recreates(tmp_path):
+    """A pre-PR1 buffer file (no interval column, user_version 0) migrates without raising."""
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE ohlcv (
+            ticker TEXT NOT NULL, timestamp TEXT NOT NULL,
+            open REAL, high REAL, low REAL, close REAL, volume REAL,
+            PRIMARY KEY (ticker, timestamp)
+        )
+        """
+    )
+    conn.execute("INSERT INTO ohlcv VALUES ('AAPL', '2024-01-02T09:30:00', 1, 1, 1, 1, 100)")
+    conn.commit()
+    conn.close()
+
+    buffer = OHLCVBuffer(db_path=db_path, buffer_size=20, interval="1m")
+
+    assert buffer.get_all_tickers() == []
+    assert buffer._conn.execute("PRAGMA user_version").fetchone()[0] == 1
+
+
+def test_interval_change_purges_stale_rows(tmp_path):
+    """Re-opening a buffer file under a different interval discards the old interval's rows."""
+    db_path = str(tmp_path / "buffer.db")
+    old = OHLCVBuffer(db_path=db_path, buffer_size=20, interval="1m")
+    old.insert_candle("AAPL", {"timestamp": "2024-01-02T09:30:00", "close": 1.0})
+    old.close()
+
+    new = OHLCVBuffer(db_path=db_path, buffer_size=20, interval="5m")
+
+    assert new._conn.execute("SELECT COUNT(*) FROM ohlcv").fetchone()[0] == 0
+
+
+def test_interval_change_logs_the_discarded_count(tmp_path, caplog):
+    """The interval-change purge logs how many stale rows it discarded, at WARNING."""
+    db_path = str(tmp_path / "buffer.db")
+    old = OHLCVBuffer(db_path=db_path, buffer_size=20, interval="1m")
+    for i in range(3):
+        old.insert_candle("AAPL", {"timestamp": f"2024-01-02T09:3{i}:00", "close": float(i)})
+    old.close()
+
+    with caplog.at_level(logging.WARNING, logger="argus.cache"):
+        OHLCVBuffer(db_path=db_path, buffer_size=20, interval="5m")
+
+    assert any("discarded 3" in record.message for record in caplog.records)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,6 +2,7 @@
 Tests for the MFT Data Pipeline.
 """
 
+import asyncio
 import importlib
 import logging
 import sys
@@ -75,7 +76,7 @@ def test_compress_candles():
 
 def test_ohlcv_buffer_insertion():
     """Inserting a candle at an existing timestamp overwrites it rather than appending."""
-    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=20)
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=20, interval="1m")
 
     # 15 candles clears the buffer's 14-candle minimum before it returns data
     for i in range(15):
@@ -247,3 +248,94 @@ def test_dst_straddling_candles_are_monotonic_in_utc_despite_repeated_wall_clock
     assert df.index.tz_convert("UTC").is_monotonic_increasing
     # The repeated 01:xx ET wall-clock hour is exactly the reproduced hazard
     assert (df.index.hour == 1).all()
+
+
+def _seed_buffer(pipeline: MFTDataPipeline, ticker: str, n: int = 20) -> None:
+    """Inserts `n` warm candles for `ticker` directly into a pipeline's buffer.
+
+    Closes are shifted off zero: with n < the 30-bar momentum lookback,
+    momentum_1d's index lands on the earliest bar, and et_intraday_candles'
+    raw closes start at 0 — a zero denominator _compress_candles would raise on.
+    """
+    df = et_intraday_candles(n)
+    df[["open", "high", "low", "close"]] += 100
+    for idx, row in df.iterrows():
+        pipeline.buffer.insert_candle(ticker, {"timestamp": idx, **row.to_dict()})
+
+
+def test_compress_all_skips_a_ticker_whose_get_candles_raises(monkeypatch):
+    """compress_all catches a get_candles failure for one ticker and still returns the rest."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    _seed_buffer(pipeline, "GOOD")
+
+    real_get_candles = pipeline.buffer.get_candles
+
+    def flaky_get_candles(ticker):
+        if ticker == "BAD":
+            raise RuntimeError("boom")
+        return real_get_candles(ticker)
+
+    monkeypatch.setattr(pipeline.buffer, "get_all_tickers", lambda: ["BAD", "GOOD"])
+    monkeypatch.setattr(pipeline.buffer, "get_candles", flaky_get_candles)
+
+    states = pipeline.compress_all()
+
+    assert "GOOD" in states
+    assert "BAD" not in states
+
+
+def test_buffer_warm_skips_a_ticker_whose_get_candles_raises(monkeypatch):
+    """_buffer_warm doesn't let one ticker's get_candles failure hide a genuinely warm ticker."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    _seed_buffer(pipeline, "GOOD")
+
+    real_get_candles = pipeline.buffer.get_candles
+
+    def flaky_get_candles(ticker):
+        if ticker == "BAD":
+            raise RuntimeError("boom")
+        return real_get_candles(ticker)
+
+    monkeypatch.setattr(pipeline.buffer, "get_all_tickers", lambda: ["BAD", "GOOD"])
+    monkeypatch.setattr(pipeline.buffer, "get_candles", flaky_get_candles)
+
+    assert pipeline._buffer_warm() is True
+
+
+@pytest.mark.asyncio
+async def test_start_cancels_the_sibling_loop_when_one_dies(monkeypatch):
+    """If one loop raises out of start()'s gather, the other is cancelled rather than orphaned."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    session_loop_cancelled = asyncio.Event()
+
+    async def dying_fetch_loop():
+        raise RuntimeError("simulated crash")
+
+    async def long_session_loop(callback):
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            session_loop_cancelled.set()
+            raise
+
+    monkeypatch.setattr(pipeline, "_fetch_loop", dying_fetch_loop)
+    monkeypatch.setattr(pipeline, "_session_loop", long_session_loop)
+
+    with pytest.raises(RuntimeError):
+        await pipeline.start(on_session_ready=lambda states: None)
+
+    assert session_loop_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stop_ends_both_loops_promptly():
+    """stop() wakes both loops immediately rather than waiting out their full interval."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    task = asyncio.create_task(pipeline.start(on_session_ready=lambda states: None))
+    await asyncio.sleep(0.05)
+
+    await pipeline.stop()
+
+    # Without the stop_event-based wait, this would block for up to
+    # _WARMUP_POLL_INTERVAL/_FETCH_INTERVAL seconds instead of returning almost immediately
+    await asyncio.wait_for(task, timeout=2.0)


### PR DESCRIPTION
## Summary

Covers MFT-2 (Critical), MFT-10, MFT-14, and the buffer half of API-6 from #41.

- `argus/data/cache.py`: candle timestamps canonicalize to UTC ISO-8601 on write (naive input interpreted as ET) and parse defensively on read (`format="ISO8601"` + `tz_convert` before any indicator math); `OHLCVBuffer` takes a required `interval` kwarg, migrates its schema (`user_version` 0→1) to add a per-row `interval` column, and purges rows written under a stale interval; ticker case normalizes to upper.
- `argus/data/pipeline.py`: `get_candles` moved inside `compress_all`'s try, `_buffer_warm` guards each ticker individually, both loops wrap their iteration body in try/except, `start()` cancels and awaits the sibling task in a `finally` when either loop ends, and `stop()` wakes both loops immediately via an `asyncio.Event` instead of waiting out the full interval.
- `argus/backtesting/replay.py`: `as_of` normalizes an aware fixture timestamp to naive ET, disarming a future `TypeError` in `compute_run_returns`'s sort once fixtures carry canonical offsets.

## Test plan

- [x] `ruff check .`
- [x] `mypy argus/`
- [x] `pytest tests/test_pipeline.py tests/test_cache.py tests/test_backtesting.py -q` (39 passed)
- [x] `pytest tests/ -q --ignore=tests/test_integration.py` (292 passed, pre-existing suite unaffected)

https://claude.ai/code/session_01Gne25JeWRKh81s8kdtDSuF