### PR TITLE
fix: measure /analyze freshness on bar time, not cache-write time

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -47,7 +47,7 @@ from pydantic import BaseModel, Field
 
 from argus.agents.macro import MacroStatisticalAgent
 from argus.config import settings
-from argus.data.pipeline import MFTDataPipeline
+from argus.data.pipeline import MFTDataPipeline, max_bar_age_seconds, session_state_ttl_seconds
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.collector import CollectionResult, run_collection_cycle
 from argus.orchestration.governor import REGISTERED_MODELS, RateLimitExceeded, UnregisteredModel, governor
@@ -63,9 +63,6 @@ logger = logging.getLogger("argus.api")
 
 _ET = ZoneInfo("America/New_York")
 
-# Entries older than _SESSION_STATE_TTL_SECONDS are treated as missing so a prior
-# session's stale intraday data is never injected silently
-_SESSION_STATE_TTL_SECONDS = 2100  # 35 min = default MFT_DECISION_INTERVAL_SECONDS + 5 min buffer
 _live_session_cache: dict[str, tuple[dict, datetime]] = {}
 
 # Initialized during lifespan startup; tickers are registered dynamically per
@@ -418,15 +415,22 @@ async def pipeline_status():
         df = _mft_pipeline.buffer.get_candles(ticker)
         buffer_depth[ticker] = 0 if df is None else len(df)
 
-    session_cache_age_seconds = {
-        ticker: (datetime.now() - updated_at).total_seconds()
+    now = datetime.now()
+    now_et = datetime.now(_ET)
+    cache_age_seconds = {
+        ticker: (now - updated_at).total_seconds()
         for ticker, (_, updated_at) in _live_session_cache.items()
+    }
+    bar_age_seconds = {
+        ticker: (now_et - datetime.fromisoformat(state["timestamp"])).total_seconds()
+        for ticker, (state, _) in _live_session_cache.items()
     }
 
     return {
         "tracked_tickers": list(_mft_pipeline.tickers),
         "buffer_depth": buffer_depth,
-        "session_cache_age_seconds": session_cache_age_seconds,
+        "cache_age_seconds": cache_age_seconds,
+        "bar_age_seconds": bar_age_seconds,
         "is_market_hours": _mft_pipeline.is_market_hours(),
         "collector_enabled": settings.ARGUS_COLLECTOR_ENABLED,
         "last_collection_result": (
@@ -463,8 +467,11 @@ async def analyze(req: AnalysisRequest):
             configured model (GOV-7) — retry after a short wait.
         HTTPException 503: If the kill switch is triggered, VIX is above the blackout
             threshold, the market is currently closed, the MFT cache has not yet
-            been populated for all requested tickers, or a configured model has no
-            rate-limit profile (a misconfiguration, not a transient condition).
+            been populated for all requested tickers, the cache hasn't been
+            refreshed recently (pipeline stalled), the cached bars are older
+            than expected (stale data survived a restart), or a configured
+            model has no rate-limit profile (a misconfiguration, not a
+            transient condition).
         HTTPException 500: If the LangGraph execution fails or produces no allocation.
     """
     ks = get_kill_switch()
@@ -483,24 +490,51 @@ async def analyze(req: AnalysisRequest):
     if _mft_pipeline is not None:
         _mft_pipeline.register_tickers(req.tickers)
 
-    # Daily bars would mismatch the resolution the technical agent expects
-    now = datetime.now()
-    missing_from_cache = [
-        t for t in req.tickers
-        if t not in _live_session_cache
-        or (now - _live_session_cache[t][1]).total_seconds() > _SESSION_STATE_TTL_SECONDS
-    ]
-    if missing_from_cache:
-        if _mft_pipeline is None or not _mft_pipeline.is_market_hours():
-            raise HTTPException(
-                503,
-                "US equity market is currently closed. MFT pipeline is idle. "
-                "Retry between 09:30 and 16:00 ET on a weekday.",
-            )
+    # Daily bars would mismatch the resolution the technical agent expects, so a
+    # closed market (checked first) means idle rather than a lower-resolution
+    # fallback. Checking it first also confines every age check below to a
+    # weekday 09:30-16:00 ET window, eliminating the weekend/holiday false positive.
+    if _mft_pipeline is None or not _mft_pipeline.is_market_hours():
         raise HTTPException(
             503,
-            f"MFT live cache not yet populated for: {missing_from_cache}. "
+            "US equity market is currently closed. MFT pipeline is idle. "
+            "Retry between 09:30 and 16:00 ET on a weekday.",
+        )
+
+    absent = [t for t in req.tickers if t not in _live_session_cache]
+    if absent:
+        raise HTTPException(
+            503,
+            f"MFT live cache not yet populated for: {absent}. "
             "The pipeline is warming up — retry after the next session cycle (~30 min after market open).",
+        )
+
+    now = datetime.now()
+    stalled = [
+        t for t in req.tickers
+        if (now - _live_session_cache[t][1]).total_seconds() > session_state_ttl_seconds()
+    ]
+    if stalled:
+        raise HTTPException(
+            503,
+            f"MFT pipeline appears stalled for: {stalled}. "
+            "The live cache hasn't been refreshed recently — check /pipeline/status.",
+        )
+
+    # Catches what a write-time TTL can't: a restart that republishes old candles
+    # under a fresh write timestamp (MFT-1)
+    now_et = datetime.now(_ET)
+    max_bar_age = max_bar_age_seconds(_mft_pipeline.interval_minutes)
+    stale = [
+        t for t in req.tickers
+        if (now_et - datetime.fromisoformat(_live_session_cache[t][0]["timestamp"])).total_seconds()
+        > max_bar_age
+    ]
+    if stale:
+        raise HTTPException(
+            503,
+            f"MFT cache data is stale for: {stale}. "
+            "The underlying candles are older than expected — check /pipeline/status.",
         )
 
     live_states = {t: _live_session_cache[t][0] for t in req.tickers}

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -107,6 +107,37 @@ def _derive_buffer_size(interval_minutes: int) -> int:
     return _bars_per_day(interval_minutes) * _FETCH_PERIOD_DAYS
 
 
+def session_state_ttl_seconds() -> int:
+    """Derives how old a live-cache entry's write time may be before api/main.py treats it as missing.
+
+    Owned here rather than in api/main.py because the budget is built from
+    `_FETCH_INTERVAL`, which this module owns; api/ is deliberately outside
+    `mypy argus/`'s scope.
+
+    Returns:
+        Budget in seconds: the decision cadence plus one fetch sweep plus a
+        fixed jitter margin.
+    """
+    return settings.MFT_DECISION_INTERVAL_SECONDS + _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
+
+
+def max_bar_age_seconds(interval_minutes: int) -> int:
+    """Derives how old a session state's own bar timestamp may be before it counts as stale.
+
+    Distinct from `session_state_ttl_seconds`: that budget catches a cache
+    entry that stopped being refreshed, this one catches a fresh write that
+    republishes an old bar (e.g. a restart replaying the persistent buffer).
+
+    Args:
+        interval_minutes: Native candle resolution in minutes.
+
+    Returns:
+        Budget in seconds: one fetch sweep plus two candle intervals plus a
+        fixed jitter margin.
+    """
+    return _FETCH_INTERVAL + 2 * interval_minutes * 60 + SYSTEM.freshness_margin_seconds
+
+
 def _resample_ohlcv(df: pd.DataFrame, interval_minutes: int, target_minutes: int) -> pd.DataFrame:
     """Resamples raw OHLCV candles to a coarser resolution.
 

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 8
+PARAMS_VERSION = 9
 
 
 class Provenance(str, Enum):
@@ -94,6 +94,12 @@ class SystemParams:
     )
     lookback_days: int = p(
         252, Provenance.LITERATURE, "252 = standard US trading days per year"
+    )
+    freshness_margin_seconds: int = p(
+        60,
+        Provenance.ARBITRARY,
+        "buffer against fetch/session timing jitter added to the MFT cache-write "
+        "and bar-age budgets in data/pipeline.py; not evaluated against alternatives",
     )
 
 

--- a/tests/test_api_freshness.py
+++ b/tests/test_api_freshness.py
@@ -1,0 +1,124 @@
+"""
+tests/test_api_freshness.py
+
+Tests for /analyze's freshness gate added in PR2 (MFT-1, API-5): the gate
+must reject on bar age, not just cache-write age, and must check market
+hours before either age check so bar-age is never evaluated outside a
+weekday 09:30-16:00 ET session.
+
+These exercise the route function directly via FastAPI's TestClient rather
+than going through the app's lifespan, so no MFT pipeline, collector, or
+reconcile loop needs to start. `_mft_pipeline` and `_live_session_cache`
+are set directly on the api.main module instead.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+import argus.risk.kill_switch as kill_switch_module
+
+_PAYLOAD = {"tickers": ["AAPL"], "total_wealth": 100_000, "invest_pct": 0.5}
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons(monkeypatch):
+    """Clears the kill-switch singleton and live session cache around each test."""
+    kill_switch_module._kill_switch = None
+    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    monkeypatch.setattr(api_main.settings, "ARGUS_API_KEY", "")
+    yield
+    kill_switch_module._kill_switch = None
+
+
+@pytest.fixture
+def client():
+    """A TestClient over api.main.app without running its lifespan startup."""
+    return TestClient(api_main.app)
+
+
+def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
+    """Installs a fake MFTDataPipeline as the module-level `_mft_pipeline`."""
+    fake = mock.Mock()
+    fake.is_market_hours.return_value = market_hours
+    fake.interval_minutes = interval_minutes
+    monkeypatch.setattr(api_main, "_mft_pipeline", fake)
+    return fake
+
+
+def _seed_cache(ticker: str, *, bar_age_seconds: float, write_age_seconds: float = 0.0):
+    """Populates `_live_session_cache` with a state whose bar and write times are both controlled."""
+    bar_ts = datetime.now(api_main._ET) - timedelta(seconds=bar_age_seconds)
+    write_ts = datetime.now() - timedelta(seconds=write_age_seconds)
+    api_main._live_session_cache[ticker] = ({"timestamp": bar_ts.isoformat()}, write_ts)
+
+
+def test_analyze_rejects_when_market_closed(client, monkeypatch):
+    """Market-closed is checked before any cache lookup, regardless of what's cached."""
+    _pipeline(monkeypatch, market_hours=False)
+    response = client.post("/analyze", json=_PAYLOAD)
+    assert response.status_code == 503
+    assert "closed" in response.json()["detail"].lower()
+
+
+def test_analyze_rejects_absent_ticker_as_warming_up(client, monkeypatch):
+    """A ticker never seen by the pipeline is reported as warming up, not stalled or stale."""
+    _pipeline(monkeypatch, market_hours=True)
+    response = client.post("/analyze", json=_PAYLOAD)
+    assert response.status_code == 503
+    assert "warming up" in response.json()["detail"].lower()
+
+
+def test_analyze_rejects_stalled_write_before_checking_bar_age(client, monkeypatch):
+    """A cache entry that stopped being refreshed is reported as stalled, even with a fresh bar."""
+    _pipeline(monkeypatch, market_hours=True)
+    _seed_cache("AAPL", bar_age_seconds=5, write_age_seconds=10_000)
+    response = client.post("/analyze", json=_PAYLOAD)
+    assert response.status_code == 503
+    assert "stalled" in response.json()["detail"].lower()
+
+
+def test_analyze_rejects_stale_bar_reproduced_case(client, monkeypatch):
+    """The reproduced MFT-1 case: a bar 9 days old, written just now, is rejected as stale."""
+    _pipeline(monkeypatch, market_hours=True)
+    _seed_cache("AAPL", bar_age_seconds=9 * 24 * 3600, write_age_seconds=5)
+    response = client.post("/analyze", json=_PAYLOAD)
+    assert response.status_code == 503
+    assert "stale" in response.json()["detail"].lower()
+
+
+def test_analyze_rejects_stale_bar_on_a_weekday_holiday(client, monkeypatch):
+    """is_market_hours only checks weekday, so a holiday's stale republished bar must fail-close."""
+    _pipeline(monkeypatch, market_hours=True)
+    _seed_cache("AAPL", bar_age_seconds=2 * 24 * 3600, write_age_seconds=5)
+    response = client.post("/analyze", json=_PAYLOAD)
+    assert response.status_code == 503
+    assert "stale" in response.json()["detail"].lower()
+
+
+def test_analyze_market_closed_outranks_bar_age(client, monkeypatch):
+    """A hopelessly stale bar still surfaces as market-closed, not stale, outside session hours."""
+    _pipeline(monkeypatch, market_hours=False)
+    _seed_cache("AAPL", bar_age_seconds=9 * 24 * 3600, write_age_seconds=9 * 24 * 3600)
+    response = client.post("/analyze", json=_PAYLOAD)
+    assert response.status_code == 503
+    assert "closed" in response.json()["detail"].lower()
+
+
+def test_analyze_passes_freshness_gate_with_a_current_bar(client, monkeypatch):
+    """A fresh write and a fresh bar clear every freshness check and reach the graph."""
+    _pipeline(monkeypatch, market_hours=True)
+    _seed_cache("AAPL", bar_age_seconds=5, write_age_seconds=5)
+    fake_graph = mock.Mock()
+    fake_graph.invoke.side_effect = RuntimeError("sentinel: freshness gate cleared")
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 500
+    assert "sentinel: freshness gate cleared" in response.json()["detail"]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -22,7 +22,10 @@ from argus.data.pipeline import (
     _derive_buffer_size,
     _parse_interval_minutes,
     _resample_ohlcv,
+    max_bar_age_seconds,
+    session_state_ttl_seconds,
 )
+from argus.params import SYSTEM
 from tests.helpers.candles import dst_straddling_candles, et_intraday_candles
 
 
@@ -185,6 +188,22 @@ def test_momentum_windows_scale_with_interval():
     result_5m = pipeline_5m._compress_candles(df_5m)
     assert result_5m["momentum_30m"] == pytest.approx(expected_momentum(closes_5m, 6, 100), abs=1e-6)
     assert result_5m["momentum_1d"] == pytest.approx(expected_momentum(closes_5m, 78, 100), abs=1e-6)
+
+
+def test_session_state_ttl_seconds_tracks_decision_interval(monkeypatch):
+    """The write-age TTL is derived from the configured decision interval, not hardcoded."""
+    monkeypatch.setattr(settings, "MFT_DECISION_INTERVAL_SECONDS", 1800)
+    assert session_state_ttl_seconds() == 1800 + _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
+
+    monkeypatch.setattr(settings, "MFT_DECISION_INTERVAL_SECONDS", 900)
+    assert session_state_ttl_seconds() == 900 + _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
+
+
+def test_max_bar_age_seconds_scales_with_interval():
+    """The bar-age budget grows with the candle interval, matching the issue's 480s-at-1m figure."""
+    assert max_bar_age_seconds(1) == _FETCH_INTERVAL + 2 * 1 * 60 + SYSTEM.freshness_margin_seconds
+    assert max_bar_age_seconds(1) == 480
+    assert max_bar_age_seconds(5) > max_bar_age_seconds(1)
 
 
 def test_inter_request_sleep_derives_spacing_from_universe_size():


### PR DESCRIPTION
## Summary
- Reorders `/analyze`'s freshness gate to market-closed → absent → write-age-stalled → bar-age-stale, closing MFT-1: a restart could republish old cached candles as live under a fresh write timestamp.
- Derives the session-state TTL and a new bar-age budget from pipeline config (`_FETCH_INTERVAL`, `MFT_DECISION_INTERVAL_SECONDS`, a new `SYSTEM.freshness_margin_seconds` param) instead of a hardcoded constant, closing API-5.
- `/pipeline/status` now reports both `cache_age_seconds` and `bar_age_seconds` per ticker.

## Test plan
- [x] `pytest tests/ -q` — 318 passed
- [x] `ruff check .` — clean
- [x] `mypy argus/` — clean
- [x] New `tests/test_api_freshness.py` covers the reproduced 9-day-stale-bar case, market-closed outranking bar-age, absent → warming-up, stalled write, and a fresh bar clearing the gate