### PR TITLE
fix: feature-contract integrity — stop fabricating indicators, fix momentum lookback (PR3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ flowchart TD
     subgraph PIPELINE["⚙️ MFT Data Pipeline (Background asyncio task)"]
         direction TB
         FL["_fetch_loop\nEvery ~5 min (derived from universe size) · bulk 1m candles\n2-day history on first fetch"]
-        BUF["OHLCVBuffer\nPersistent SQLite (data/) · 780-bar rolling (1m × 2d)\nINSERT OR REPLACE — safe for bulk re-insert"]
+        BUF["OHLCVBuffer\nPersistent SQLite (data/) · 1,173-bar rolling (1m × 2d + slack)\nINSERT OR REPLACE — safe for bulk re-insert"]
         SL["_session_loop\nEvery 30 min → compress_all\nResamples to 5m · RSI · MACD · BB · ATR · ADX · VWAP · Momentum"]
         CACHE["_live_session_cache\nIn-memory dict · ticker → feature dict\nUpdated via on_session_ready callback"]
     end

--- a/argus/agents/technical.py
+++ b/argus/agents/technical.py
@@ -28,24 +28,19 @@ import numpy as np
 
 from argus.config import settings
 from argus.params import TECHNICAL
-from argus.schemas.signals import Signal, TechnicalSignal
+from argus.schemas.signals import (
+    SESSION_STATE_REQUIRED_KEYS,
+    Signal,
+    TechnicalSignal,
+    missing_session_state_keys,
+)
 
 logger = logging.getLogger("argus.technical")
 
-# Minimum indicator keys required for a trustworthy signal. analyze() returns
-# None (instead of computing from fabricated defaults) when any key is absent.
-_REQUIRED_INDICATOR_KEYS: frozenset[str] = frozenset({
-    "rsi_14",
-    "macd_histogram",
-    "bb_percent_b",
-    "adx_14",
-    "vwap_distance",
-    "volume_ratio",
-    "atr_pct",
-    "momentum_30m",
-    "momentum_1d",
-    "close",
-})
+# Module alias — the contract itself lives in schemas/signals.py, shared with
+# data/pipeline.py's readiness gate. Kept so existing references here (and in
+# tests) don't need to import from schemas directly.
+_REQUIRED_INDICATOR_KEYS = SESSION_STATE_REQUIRED_KEYS
 
 
 def _score_rsi(s: dict) -> float:
@@ -223,26 +218,13 @@ class TechnicalStatisticalAgent:
             A validated TechnicalSignal, or None if required fields are missing or
             non-finite.
         """
-        missing = [
-            k for k in _REQUIRED_INDICATOR_KEYS
-            if session_state.get(k) is None
-        ]
+        missing = missing_session_state_keys(session_state)
         if missing:
             logger.warning(
-                "analyze[%s]: missing required indicator fields %s — skipping to avoid fake signal",
+                "analyze[%s]: missing or non-finite required indicator fields %s — "
+                "skipping to avoid fake signal",
                 ticker,
-                sorted(missing),
-            )
-            return None
-
-        required_values = np.array(
-            [float(session_state[k]) for k in _REQUIRED_INDICATOR_KEYS]
-        )
-        if not np.isfinite(required_values).all():
-            logger.warning(
-                "analyze[%s]: non-finite indicator value(s) in %s — skipping to avoid fake signal",
-                ticker,
-                sorted(_REQUIRED_INDICATOR_KEYS),
+                missing,
             )
             return None
 

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -26,10 +26,12 @@ import asyncio
 import contextlib
 import importlib.metadata  # noqa: F401 — pandas_ta.maps uses this without importing it
 import logging
+import math
 import re
 from collections.abc import Callable
 from datetime import datetime, time as dtime
 from pathlib import Path
+from typing import Optional
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -39,6 +41,7 @@ from argus.config import settings
 from argus.data.cache import OHLCVBuffer
 from argus.data.fetchers import fetch_ohlcv_intraday
 from argus.params import SYSTEM
+from argus.schemas.signals import missing_session_state_keys
 
 logger = logging.getLogger("argus.pipeline")
 
@@ -95,8 +98,9 @@ def _bars_per_day(interval_minutes: int) -> int:
 def _derive_buffer_size(interval_minutes: int) -> int:
     """Sizes the rolling buffer to hold `_FETCH_PERIOD_DAYS` of candles at the given interval.
 
-    Matches fetch_ohlcv_intraday's fetch period so a single sweep's candles
-    always fit without evicting same-day history.
+    One extra day and one extra bar of slack beyond a bare `_FETCH_PERIOD_DAYS`
+    fit so a routine session doesn't evict day-1's open before momentum_1d's
+    lookback (see `_return_since`) can reach it.
 
     Args:
         interval_minutes: Native candle resolution in minutes.
@@ -104,7 +108,93 @@ def _derive_buffer_size(interval_minutes: int) -> int:
     Returns:
         Buffer row capacity per ticker.
     """
-    return _bars_per_day(interval_minutes) * _FETCH_PERIOD_DAYS
+    return (_bars_per_day(interval_minutes) + 1) * (_FETCH_PERIOD_DAYS + 1)
+
+
+# MACD(12, 26, 9)'s measured pandas-ta warmup floor for a non-NaN histogram:
+# slow(26) + signal(9) - 1. Pinned as a literal rather than derived from the
+# call site so a pandas-ta upgrade that shifts this fails a test loudly
+# instead of silently changing what counts as "ready".
+_MACD_WARMUP_BARS = 34
+
+
+def _required_indicator_bars() -> int:
+    """Returns the minimum resampled-bar count for a non-NaN MACD histogram."""
+    return _MACD_WARMUP_BARS
+
+
+def _required_raw_bars(interval_minutes: int) -> int:
+    """Cheap pre-filter: minimum raw bars before a ticker is worth resampling.
+
+    Not authoritative — gaps make raw-bar count a lower bound on the
+    resampled count, not an equality, so `_compress_candles` re-checks the
+    resampled length itself before publishing.
+
+    Args:
+        interval_minutes: Native candle resolution in minutes.
+
+    Returns:
+        The larger of the indicator-resample floor and one full trading
+        day's worth of bars (momentum_1d's lookback).
+    """
+    indicator_floor = _required_indicator_bars() * math.ceil(
+        _INDICATOR_RESAMPLE_MINUTES / interval_minutes
+    )
+    momentum_floor = _bars_per_day(interval_minutes) + 1
+    return max(indicator_floor, momentum_floor)
+
+
+def _finite_or_none(value: Optional[float]) -> Optional[float]:
+    """Returns `value` unless it's None, NaN, or infinite.
+
+    Args:
+        value: A computed indicator value, or None.
+
+    Returns:
+        `value` unchanged, or None if it isn't a finite number.
+    """
+    if value is None or not math.isfinite(value):
+        return None
+    return value
+
+
+def _return_since(
+    close_s: pd.Series, delta: pd.Timedelta, *, same_session: bool
+) -> Optional[float]:
+    """Looks up a return from the closest bar at least `delta` before the last one.
+
+    Locating by elapsed time rather than a fixed bar count keeps the lookup
+    correct under any candle interval and immune to buffer gaps or eviction,
+    where a bar-count clamp is not.
+
+    Args:
+        close_s: Ascending-index close price series, ET-aware.
+        delta: Minimum lookback duration from the last bar's timestamp.
+        same_session: True requires the located bar share the last bar's ET
+            session date (momentum_30m); False requires it precede that date
+            (momentum_1d).
+
+    Returns:
+        `(last_close / located_close) - 1.0`, or None if no bar satisfies
+        the session constraint or the located close is zero.
+    """
+    last_ts = close_s.index[-1]
+    target_ts = last_ts - delta
+    pos = close_s.index.searchsorted(target_ts, side="right") - 1
+    if pos < 0:
+        return None
+
+    located_date = close_s.index[pos].date()
+    last_date = last_ts.date()
+    if same_session and located_date != last_date:
+        return None
+    if not same_session and located_date >= last_date:
+        return None
+
+    located_close = float(close_s.iloc[pos])
+    if located_close == 0:
+        return None
+    return (float(close_s.iloc[-1]) / located_close) - 1.0
 
 
 def session_state_ttl_seconds() -> int:
@@ -274,8 +364,8 @@ class MFTDataPipeline:
         compresses whatever the buffer already holds.
 
         Returns:
-            Mapping of ticker → technical feature dict. Tickers with fewer
-            than 14 buffered bars are omitted (see ``OHLCVBuffer.get_candles``).
+            Mapping of ticker → technical feature dict. Tickers that don't
+            clear ``compress_all``'s readiness floor are omitted.
         """
         if self._is_market_hours():
             await self._sweep_once()
@@ -439,16 +529,38 @@ class MFTDataPipeline:
     def compress_all(self) -> dict[str, dict]:
         """Compresses cached candle metrics across all universe symbols into a feature dictionary.
 
+        A ticker is only published once it clears both readiness checks:
+        enough raw bars to be worth resampling (`_required_raw_bars`), and —
+        the authoritative gate — enough resampled bars for a real MACD
+        histogram, plus every required key present and finite
+        (`missing_session_state_keys`). This is what makes "present in this
+        dict" mean the same thing as "usable" to a caller that never learns
+        what an indicator is.
+
         Returns:
             Mapping of ticker → technical feature dict (rsi_14, macd_histogram, etc.).
-            Failed tickers are omitted and logged as warnings.
+            Tickers below the readiness floor, or that failed compression,
+            are omitted and logged.
         """
         states: dict[str, dict] = {}
+        required_raw = _required_raw_bars(self.interval_minutes)
         for ticker in self.buffer.get_all_tickers():
             try:
                 df = self.buffer.get_candles(ticker)
-                if df is not None:
-                    states[ticker] = self._compress_candles(df)
+                if df is None or len(df) < required_raw:
+                    continue
+                state = self._compress_candles(df)
+                if state is None:
+                    continue
+                missing = missing_session_state_keys(state)
+                if missing:
+                    logger.warning(
+                        "compress_all: %s missing/non-finite required keys %s — omitting",
+                        ticker,
+                        missing,
+                    )
+                    continue
+                states[ticker] = state
             except Exception as exc:
                 logger.warning(
                     "compress_all: %s compression failed — %s: %s",
@@ -459,7 +571,7 @@ class MFTDataPipeline:
         logger.info("compress_all: %d tickers compressed", len(states))
         return states
 
-    def _compress_candles(self, df: pd.DataFrame) -> dict:
+    def _compress_candles(self, df: pd.DataFrame) -> Optional[dict]:
         """Calculates technical indicators on a DataFrame using pandas-ta.
 
         Args:
@@ -467,13 +579,17 @@ class MFTDataPipeline:
                 datetime index.
 
         Returns:
-            Dict with keys: rsi_14, macd_histogram, bb_percent_b, atr_pct, adx_14,
-            vwap_distance, volume_ratio, momentum_30m, momentum_1d, close, timestamp.
-            rsi_14, bb_percent_b, atr_pct, adx_14, vwap_distance, and volume_ratio
-            are None when pandas_ta cannot compute them; close and timestamp are
-            always populated.
+            None if the resampled frame doesn't clear `_required_indicator_bars()`
+            — too little data for a trustworthy MACD histogram. Otherwise a dict
+            with keys: rsi_14, macd_histogram, bb_percent_b, atr_pct, adx_14,
+            vwap_distance, volume_ratio, momentum_30m, momentum_1d, close,
+            timestamp. Every field but close/timestamp is None when pandas_ta
+            can't compute it or the result isn't finite — never a fabricated
+            default.
         """
         ind_df = _resample_ohlcv(df, self.interval_minutes, _INDICATOR_RESAMPLE_MINUTES)
+        if len(ind_df) < _required_indicator_bars():
+            return None
 
         rsi_series = ta.rsi(ind_df["close"], length=14)
         rsi_14 = (
@@ -481,12 +597,12 @@ class MFTDataPipeline:
         )
 
         macd_df = ta.macd(ind_df["close"], fast=12, slow=26, signal=9)
-        macd_hist = 0.0
+        macd_hist = None
         if macd_df is not None and not macd_df.empty:
             # pandas_ta names the histogram column with an 'h' suffix, e.g. MACDh_12_26_9
             hist_col = [c for c in macd_df.columns if c.upper().startswith("MACDH_")]
             if hist_col:
-                macd_hist = float(macd_df[hist_col[0]].iloc[-1])
+                macd_hist = _finite_or_none(float(macd_df[hist_col[0]].iloc[-1]))
             else:
                 logger.warning("_compress_candles: MACD histogram column not found in %s", list(macd_df.columns))
 
@@ -502,11 +618,9 @@ class MFTDataPipeline:
 
         atr_series = ta.atr(ind_df["high"], ind_df["low"], ind_df["close"], length=14)
         close_last = float(df["close"].iloc[-1])
-        atr_pct = (
-            (float(atr_series.iloc[-1]) / close_last)
-            if (atr_series is not None and not atr_series.empty and close_last)
-            else None
-        )
+        atr_pct = None
+        if atr_series is not None and not atr_series.empty and close_last:
+            atr_pct = _finite_or_none(float(atr_series.iloc[-1]) / close_last)
 
         adx_df = ta.adx(ind_df["high"], ind_df["low"], ind_df["close"], length=14)
         adx_14 = None
@@ -519,9 +633,9 @@ class MFTDataPipeline:
         try:
             vwap_series = ta.vwap(ind_df["high"], ind_df["low"], ind_df["close"], ind_df["volume"])
             if vwap_series is not None and not vwap_series.empty:
-                vwap_val = float(vwap_series.iloc[-1])
+                vwap_val = _finite_or_none(float(vwap_series.iloc[-1]))
                 if vwap_val and close_last:
-                    vwap_distance = (close_last - vwap_val) / vwap_val
+                    vwap_distance = _finite_or_none((close_last - vwap_val) / vwap_val)
         except Exception:
             # pandas_ta raises on zero-volume days; leave unset rather than fabricate 0.0
             pass
@@ -532,29 +646,24 @@ class MFTDataPipeline:
             if len(vol_series) >= 20
             else float(vol_series.mean())
         )
-        volume_ratio = (float(vol_series.iloc[-1]) / vol_mean) if vol_mean else None
+        volume_ratio = (
+            _finite_or_none(float(vol_series.iloc[-1]) / vol_mean) if vol_mean else None
+        )
 
         close_s = df["close"]
-        n = len(close_s)
-        momentum_30m_bars = max(1, 30 // self.interval_minutes)
-        momentum_1d_bars = _bars_per_day(self.interval_minutes)
-        momentum_30m = (
-            float(close_s.iloc[-1]) / float(close_s.iloc[max(-momentum_30m_bars, -n)])
-        ) - 1.0
-        momentum_1d = (
-            float(close_s.iloc[-1]) / float(close_s.iloc[max(-momentum_1d_bars, -n)])
-        ) - 1.0
+        momentum_30m = _return_since(close_s, pd.Timedelta(minutes=30), same_session=True)
+        momentum_1d = _return_since(close_s, pd.Timedelta(days=1), same_session=False)
 
         return {
             "rsi_14": round(rsi_14, 4) if rsi_14 is not None else None,
-            "macd_histogram": round(macd_hist, 6),
+            "macd_histogram": round(macd_hist, 6) if macd_hist is not None else None,
             "bb_percent_b": round(bb_pct_b, 4) if bb_pct_b is not None else None,
             "atr_pct": round(atr_pct, 6) if atr_pct is not None else None,
             "adx_14": round(adx_14, 4) if adx_14 is not None else None,
             "vwap_distance": round(vwap_distance, 6) if vwap_distance is not None else None,
             "volume_ratio": round(volume_ratio, 4) if volume_ratio is not None else None,
-            "momentum_30m": round(momentum_30m, 6),
-            "momentum_1d": round(momentum_1d, 6),
+            "momentum_30m": round(momentum_30m, 6) if momentum_30m is not None else None,
+            "momentum_1d": round(momentum_1d, 6) if momentum_1d is not None else None,
             "close": round(close_last, 4),
             "timestamp": df.index[-1].isoformat(),
         }

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -19,6 +19,7 @@ Dependencies:
 from __future__ import annotations
 
 import logging
+import math
 import uuid
 import warnings
 from datetime import date, datetime
@@ -83,6 +84,44 @@ class SectorSignal(str, Enum):
     GROWTH_FAVORED = "GROWTH_FAVORED"  # risk-on, lower rates
     VALUE_FAVORED = "VALUE_FAVORED"    # rising rates, reflation
     DEFENSIVE = "DEFENSIVE"            # high VIX / contraction regime
+
+
+SESSION_STATE_REQUIRED_KEYS: frozenset[str] = frozenset({
+    "rsi_14",
+    "macd_histogram",
+    "bb_percent_b",
+    "adx_14",
+    "vwap_distance",
+    "volume_ratio",
+    "atr_pct",
+    "momentum_30m",
+    "momentum_1d",
+    "close",
+})
+
+
+def missing_session_state_keys(state: dict) -> list[str]:
+    """Finds required session-state keys that are absent, None, or non-finite.
+
+    The contract a compressed technical feature dict must satisfy before a
+    consumer can trust it: data/pipeline.py's compress_all() uses this to
+    decide what "ready" means, and agents/technical.py's analyze() uses it
+    to decide what "usable" means, so both share one definition instead of
+    each re-deriving it.
+
+    Args:
+        state: A compressed technical feature dict.
+
+    Returns:
+        Sorted list of missing/invalid key names; empty if the state is
+        complete.
+    """
+    missing = [k for k in SESSION_STATE_REQUIRED_KEYS if state.get(k) is None]
+    if missing:
+        return sorted(missing)
+    return sorted(
+        k for k in SESSION_STATE_REQUIRED_KEYS if not math.isfinite(float(state[k]))
+    )
 
 
 _CONVICTION_MAX = 0.95
@@ -590,6 +629,8 @@ __all__ = [
     "VixRegime",
     "YieldCurve",
     "SectorSignal",
+    "SESSION_STATE_REQUIRED_KEYS",
+    "missing_session_state_keys",
     "MacroContext",
     "TechnicalSignal",
     "FundamentalSignal",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,11 +5,14 @@ Tests for the MFT Data Pipeline.
 import asyncio
 import importlib
 import logging
+import math
 import sys
 from pathlib import Path
 
 import pandas as pd
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 import argus.data.pipeline as pipeline_module
 from argus.config import settings
@@ -20,8 +23,12 @@ from argus.data.pipeline import (
     MFTDataPipeline,
     _bars_per_day,
     _derive_buffer_size,
+    _finite_or_none,
     _parse_interval_minutes,
+    _required_indicator_bars,
+    _required_raw_bars,
     _resample_ohlcv,
+    _return_since,
     max_bar_age_seconds,
     session_state_ttl_seconds,
 )
@@ -75,6 +82,8 @@ def test_compress_candles():
     assert result["close"] == 399.0
     # A monotonically rising close series saturates RSI at 100
     assert result["rsi_14"] == 100.0
+    # 400 1m bars resample to ~80 5m bars, well clear of the 34-bar MACD warmup floor
+    assert result["macd_histogram"] is not None
 
 
 def test_ohlcv_buffer_insertion():
@@ -111,20 +120,20 @@ def test_parse_interval_minutes_rejects_unsupported_shape():
 
 
 def test_derive_buffer_size_matches_fetch_period():
-    """Buffer size holds a full fetch period's candles at the given interval."""
+    """Buffer size holds a full fetch period's candles at the given interval, plus a day and a bar of slack."""
     assert _bars_per_day(1) == 390
     assert _bars_per_day(5) == 78
-    assert _derive_buffer_size(1) == 780
-    assert _derive_buffer_size(5) == 156
+    assert _derive_buffer_size(1) == 1173
+    assert _derive_buffer_size(5) == 237
 
 
 def test_pipeline_derives_buffer_size_from_interval():
     """MFTDataPipeline sizes its buffer from the candle interval when CANDLE_BUFFER_SIZE isn't overridden."""
     pipeline_1m = MFTDataPipeline([], interval="1m")
-    assert pipeline_1m.buffer._buffer_size == 780
+    assert pipeline_1m.buffer._buffer_size == 1173
 
     pipeline_5m = MFTDataPipeline([], interval="5m")
-    assert pipeline_5m.buffer._buffer_size == 156
+    assert pipeline_5m.buffer._buffer_size == 237
 
 
 def test_resample_ohlcv_aggregates_correctly():
@@ -161,22 +170,18 @@ def test_resample_ohlcv_is_a_noop_when_target_not_coarser():
 
 
 def test_momentum_windows_scale_with_interval():
-    """momentum_30m/momentum_1d convert minutes to bars using the pipeline's own interval, at 1m and 5m."""
-
-    def expected_momentum(closes: list[int], bars: int, n: int) -> float:
-        idx = max(-bars, -n)
-        return (closes[-1] / closes[idx]) - 1.0
-
+    """momentum_30m locates the bar exactly 30 minutes back at both 1m and 5m resolution."""
     dates_1m = pd.date_range("2024-01-01 09:30", periods=400, freq="1min")
     closes_1m = list(range(400))
     df_1m = pd.DataFrame({
         "open": closes_1m, "high": [c + 1 for c in closes_1m], "low": closes_1m,
         "close": closes_1m, "volume": [1000] * 400,
     }, index=dates_1m)
-    pipeline_1m = MFTDataPipeline([], interval="1m")
-    result_1m = pipeline_1m._compress_candles(df_1m)
-    assert result_1m["momentum_30m"] == pytest.approx(expected_momentum(closes_1m, 30, 400), abs=1e-6)
-    assert result_1m["momentum_1d"] == pytest.approx(expected_momentum(closes_1m, 390, 400), abs=1e-6)
+    result_1m = MFTDataPipeline([], interval="1m")._compress_candles(df_1m)
+    # Last bar is 09:30 + 399min = 16:09; 30 minutes back lands exactly on bar 369
+    assert result_1m["momentum_30m"] == pytest.approx((399 / 369) - 1.0, abs=1e-6)
+    # Every bar falls on 2024-01-01, so momentum_1d has no strictly-earlier session to reach
+    assert result_1m["momentum_1d"] is None
 
     dates_5m = pd.date_range("2024-01-01 09:30", periods=100, freq="5min")
     closes_5m = list(range(100))
@@ -184,10 +189,99 @@ def test_momentum_windows_scale_with_interval():
         "open": closes_5m, "high": [c + 1 for c in closes_5m], "low": closes_5m,
         "close": closes_5m, "volume": [1000] * 100,
     }, index=dates_5m)
-    pipeline_5m = MFTDataPipeline([], interval="5m")
-    result_5m = pipeline_5m._compress_candles(df_5m)
-    assert result_5m["momentum_30m"] == pytest.approx(expected_momentum(closes_5m, 6, 100), abs=1e-6)
-    assert result_5m["momentum_1d"] == pytest.approx(expected_momentum(closes_5m, 78, 100), abs=1e-6)
+    result_5m = MFTDataPipeline([], interval="5m")._compress_candles(df_5m)
+    # Last bar is 09:30 + 99*5min = 17:45; 30 minutes back lands exactly on bar 93
+    assert result_5m["momentum_30m"] == pytest.approx((99 / 93) - 1.0, abs=1e-6)
+    assert result_5m["momentum_1d"] is None
+
+
+def test_finite_or_none():
+    """Passes a finite value through unchanged; collapses None/NaN/inf to None."""
+    assert _finite_or_none(1.5) == 1.5
+    assert _finite_or_none(None) is None
+    assert _finite_or_none(float("nan")) is None
+    assert _finite_or_none(float("inf")) is None
+    assert _finite_or_none(float("-inf")) is None
+
+
+def test_required_indicator_bars_is_pinned_to_macd_warmup():
+    """The resampled-bar readiness floor is pinned to MACD(12,26,9)'s measured warmup."""
+    assert _required_indicator_bars() == 34
+
+
+def test_required_raw_bars_matches_the_issue_table():
+    """Raw-bar pre-filter: the larger of the indicator-resample floor and one day's momentum lookback."""
+    assert _required_raw_bars(1) == 391
+    assert _required_raw_bars(5) == 79
+    assert _required_raw_bars(15) == 34
+
+
+def test_compress_candles_readiness_cliff_at_macd_warmup_floor():
+    """33 resampled bars publish nothing; 34 publishes a real (non-None) MACD histogram."""
+    pipeline = MFTDataPipeline([], interval="5m")
+
+    dates_33 = pd.date_range("2024-01-01 09:30", periods=33, freq="5min")
+    df_33 = pd.DataFrame({
+        "open": range(33), "high": [c + 1 for c in range(33)], "low": range(33),
+        "close": range(33), "volume": [1000] * 33,
+    }, index=dates_33)
+    assert pipeline._compress_candles(df_33) is None
+
+    dates_34 = pd.date_range("2024-01-01 09:30", periods=34, freq="5min")
+    df_34 = pd.DataFrame({
+        "open": range(34), "high": [c + 1 for c in range(34)], "low": range(34),
+        "close": range(34), "volume": [1000] * 34,
+    }, index=dates_34)
+    result_34 = pipeline._compress_candles(df_34)
+    assert result_34 is not None
+    assert result_34["macd_histogram"] is not None
+
+
+def test_compress_candles_never_emits_nan():
+    """Every float field in a compressed dict is a real number or None, never NaN."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    dates = pd.date_range("2024-01-01 09:30", periods=400, freq="1min")
+    df = pd.DataFrame({
+        "open": range(400), "high": [c + 1 for c in range(400)], "low": range(400),
+        "close": range(400), "volume": [1000] * 400,
+    }, index=dates)
+    result = pipeline._compress_candles(df)
+    assert result is not None
+    for value in result.values():
+        if isinstance(value, float):
+            assert not math.isnan(value)
+
+
+def test_return_since_momentum_1d_none_without_a_prior_session():
+    """momentum_1d's lookup returns None when the series holds only one calendar day."""
+    close_s = et_intraday_candles(50)["close"]
+    assert _return_since(close_s, pd.Timedelta(days=1), same_session=False) is None
+
+
+def test_return_since_momentum_30m_does_not_reach_into_the_prior_session():
+    """At 09:34 with only 5 bars printed today, the 30-minute lookup doesn't fall back to yesterday's close."""
+    day1 = et_intraday_candles(390, start="2024-01-02 09:30")
+    day2 = et_intraday_candles(5, start="2024-01-03 09:30")
+    combined_close = pd.concat([day1["close"], day2["close"]])
+    assert _return_since(combined_close, pd.Timedelta(minutes=30), same_session=True) is None
+
+
+@given(drop=st.integers(min_value=0, max_value=10))
+def test_momentum_1d_is_stable_under_dropping_up_to_10_oldest_bars(drop: int):
+    """Locating momentum_1d by time is unaffected by pruning the buffer's oldest rows.
+
+    Args:
+        drop: Number of oldest bars removed from the series before re-checking.
+    """
+    day1 = et_intraday_candles(390, start="2024-01-02 09:30")
+    day2 = et_intraday_candles(50, start="2024-01-03 09:30")
+    close_s = pd.concat([day1["close"], day2["close"]])
+
+    baseline = _return_since(close_s, pd.Timedelta(days=1), same_session=False)
+    trimmed = _return_since(close_s.iloc[drop:], pd.Timedelta(days=1), same_session=False)
+
+    assert baseline is not None
+    assert trimmed == baseline
 
 
 def test_session_state_ttl_seconds_tracks_decision_interval(monkeypatch):
@@ -282,10 +376,27 @@ def _seed_buffer(pipeline: MFTDataPipeline, ticker: str, n: int = 20) -> None:
         pipeline.buffer.insert_candle(ticker, {"timestamp": idx, **row.to_dict()})
 
 
+def _seed_two_session_buffer(
+    pipeline: MFTDataPipeline, ticker: str, day1_bars: int = 390, day2_bars: int = 50
+) -> None:
+    """Inserts two calendar days of warm 1m candles for `ticker`.
+
+    Clears both the raw-bar readiness pre-filter and momentum_1d's
+    cross-session lookback (see argus/data/pipeline.py's `_return_since`),
+    unlike `_seed_buffer`'s single-day fixture.
+    """
+    day1 = et_intraday_candles(day1_bars, start="2024-01-02 09:30")
+    day2 = et_intraday_candles(day2_bars, start="2024-01-03 09:30")
+    combined = pd.concat([day1, day2])
+    combined[["open", "high", "low", "close"]] += 100
+    for idx, row in combined.iterrows():
+        pipeline.buffer.insert_candle(ticker, {"timestamp": idx, **row.to_dict()})
+
+
 def test_compress_all_skips_a_ticker_whose_get_candles_raises(monkeypatch):
     """compress_all catches a get_candles failure for one ticker and still returns the rest."""
     pipeline = MFTDataPipeline([], interval="1m")
-    _seed_buffer(pipeline, "GOOD")
+    _seed_two_session_buffer(pipeline, "GOOD")
 
     real_get_candles = pipeline.buffer.get_candles
 
@@ -301,6 +412,18 @@ def test_compress_all_skips_a_ticker_whose_get_candles_raises(monkeypatch):
 
     assert "GOOD" in states
     assert "BAD" not in states
+
+
+def test_compress_all_skips_a_ticker_below_the_readiness_floor():
+    """compress_all omits a ticker whose buffered bars don't clear the resampled MACD warmup floor."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    # 20 raw bars clear OHLCVBuffer's own 14-row floor but fall far short of
+    # _required_raw_bars(1) == 391
+    _seed_buffer(pipeline, "COLD", n=20)
+
+    states = pipeline.compress_all()
+
+    assert "COLD" not in states
 
 
 def test_buffer_warm_skips_a_ticker_whose_get_candles_raises(monkeypatch):

--- a/tests/test_technical.py
+++ b/tests/test_technical.py
@@ -7,7 +7,9 @@ import math
 import pytest
 from pydantic import ValidationError
 
+import argus.agents.technical as technical_module
 from argus.agents.technical import TechnicalStatisticalAgent
+from argus.schemas import signals as signals_module
 from argus.schemas.signals import Signal
 
 
@@ -17,6 +19,11 @@ def agent() -> TechnicalStatisticalAgent:
         A fresh TechnicalStatisticalAgent instance.
     """
     return TechnicalStatisticalAgent()
+
+
+def test_required_indicator_keys_is_the_shared_schema_contract():
+    """technical.py's frozenset is the same object as the schema's, not a copy that can drift."""
+    assert technical_module._REQUIRED_INDICATOR_KEYS is signals_module.SESSION_STATE_REQUIRED_KEYS
 
 
 def test_bullish_signal(agent: TechnicalStatisticalAgent) -> None:


### PR DESCRIPTION
## Summary
- Stops the pipeline fabricating `0.0`/leaking `NaN`: `macd_histogram`, `vwap_distance`, `atr_pct`, and `volume_ratio` are `None` whenever pandas-ta can't compute a real value, closing MFT-3 and MFT-11.
- Replaces bar-count momentum with a time-based, session-aware lookup (`_return_since`): `momentum_30m` requires the located bar share today's session, `momentum_1d` requires a strictly earlier one, closing MFT-4.
- `compress_all` now gates readiness on a resampled MACD-warmup floor (34 bars) plus a shared `missing_session_state_keys()` contract also used by `agents/technical.py`, so "present in the cache" and "usable by the technical agent" are the same test, closing MFT-5.
- Buffer sizing gains a day and a bar of slack so a routine session doesn't evict day-1's open before `momentum_1d` can reach it, closing MFT-8.

Stacked on #44 (PR2) — this branch is based on `fix/pipeline-freshness-gate`, not `main`, since PR3 is ordered after PR2 in issue #41.

## Test plan
- [x] `pytest tests/ -q` — 328 passed
- [x] `ruff check .` — clean
- [x] `mypy argus/` — clean
- [x] New/rewritten tests cover: the 34/33-bar MACD readiness cliff, the raw-bar pre-filter table (391/79/34 at 1m/5m/15m), `momentum_1d is None` without a prior session, `momentum_30m` not reaching into the prior session, a Hypothesis check that dropping up to 10 oldest bars leaves `momentum_1d` unchanged, no `NaN` surviving a compressed dict, and `compress_all` skipping a ticker below the readiness floor.