### PR TITLE
PR4: MFT pipeline event-loop and cadence hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ flowchart TD
     %% ── MFT Data Pipeline ────────────────────────────────────────────────
     subgraph PIPELINE["⚙️ MFT Data Pipeline (Background asyncio task)"]
         direction TB
-        FL["_fetch_loop\nEvery ~5 min (derived from universe size) · bulk 1m candles\n2-day history on first fetch"]
+        FL["_fetch_loop\nEvery 5 min (sweep duration subtracted from the wait) · bulk 1m candles\n2-day history on first fetch"]
         BUF["OHLCVBuffer\nPersistent SQLite (data/) · 1,173-bar rolling (1m × 2d + slack)\nINSERT OR REPLACE — safe for bulk re-insert"]
         SL["_session_loop\nEvery 30 min → compress_all\nResamples to 5m · RSI · MACD · BB · ATR · ADX · VWAP · Momentum"]
         CACHE["_live_session_cache\nIn-memory dict · ticker → feature dict\nUpdated via on_session_ready callback"]

--- a/api/main.py
+++ b/api/main.py
@@ -148,6 +148,45 @@ async def _collector_loop(pipeline: MFTDataPipeline, compiled_graph) -> None:
         await asyncio.sleep(settings.ARGUS_COLLECTOR_INTERVAL_SECONDS)
 
 
+def _reconcile_once() -> None:
+    """Runs one reconciliation pass: outcome backfill, paper-book update, kill-switch sync.
+
+    Synchronous by design — `_reconcile_loop` runs this via `asyncio.to_thread`
+    since it performs per-ticker yfinance fetches directly, which would
+    otherwise block the event loop for the whole app for the duration of a run.
+    """
+    decisions_log = f"{settings.ARGUS_DATA_DIR}/decisions.jsonl"
+    decisions = load_decisions_from_jsonl(decisions_log)
+    market_data = LiveMarketDataProvider()
+    stored = reconcile_decisions(
+        decisions,
+        market_data=market_data,
+        cultural=get_cultural_memory(),
+        horizon_days=RECONCILIATION.horizon_days,
+    )
+    logger.info("[Reconcile] stored %d/%d outcome(s)", stored, len(decisions))
+
+    try:
+        book_path = f"{settings.ARGUS_DATA_DIR}/paper_equity.json"
+        book = paper_book.load(book_path)
+        for run_timestamp, run_return in paper_book.compute_run_returns(
+            decisions, market_data, RECONCILIATION.horizon_days
+        ):
+            book.apply_run(run_timestamp, run_return)
+        paper_book.save(book, book_path)
+
+        ks = get_kill_switch()
+        if ks is not None:
+            ks.update_portfolio_value(book.equity)
+        logger.info(
+            "[Reconcile] paper equity=$%.2f (drawdown=%.1f%%)",
+            book.equity,
+            book.drawdown_from_peak() * 100,
+        )
+    except Exception:
+        logger.exception("[Reconcile] paper-book update failed")
+
+
 async def _reconcile_loop() -> None:
     """Runs reconcile_decisions once a day at settings.ARGUS_RECONCILE_HOUR_ET."""
     while True:
@@ -160,36 +199,7 @@ async def _reconcile_loop() -> None:
         await asyncio.sleep((target - now_et).total_seconds())
 
         try:
-            decisions_log = f"{settings.ARGUS_DATA_DIR}/decisions.jsonl"
-            decisions = load_decisions_from_jsonl(decisions_log)
-            market_data = LiveMarketDataProvider()
-            stored = reconcile_decisions(
-                decisions,
-                market_data=market_data,
-                cultural=get_cultural_memory(),
-                horizon_days=RECONCILIATION.horizon_days,
-            )
-            logger.info("[Reconcile] stored %d/%d outcome(s)", stored, len(decisions))
-
-            try:
-                book_path = f"{settings.ARGUS_DATA_DIR}/paper_equity.json"
-                book = paper_book.load(book_path)
-                for run_timestamp, run_return in paper_book.compute_run_returns(
-                    decisions, market_data, RECONCILIATION.horizon_days
-                ):
-                    book.apply_run(run_timestamp, run_return)
-                paper_book.save(book, book_path)
-
-                ks = get_kill_switch()
-                if ks is not None:
-                    ks.update_portfolio_value(book.equity)
-                logger.info(
-                    "[Reconcile] paper equity=$%.2f (drawdown=%.1f%%)",
-                    book.equity,
-                    book.drawdown_from_peak() * 100,
-                )
-            except Exception:
-                logger.exception("[Reconcile] paper-book update failed")
+            await asyncio.to_thread(_reconcile_once)
         except Exception:
             logger.exception("[Reconcile] cycle failed")
 
@@ -410,10 +420,7 @@ async def pipeline_status():
     if _mft_pipeline is None:
         raise HTTPException(503, "Pipeline not yet initialized.")
 
-    buffer_depth: dict[str, int] = {}
-    for ticker in _mft_pipeline.buffer.get_all_tickers():
-        df = _mft_pipeline.buffer.get_candles(ticker)
-        buffer_depth[ticker] = 0 if df is None else len(df)
+    buffer_depth = await asyncio.to_thread(_mft_pipeline.buffer.row_counts)
 
     now = datetime.now()
     now_et = datetime.now(_ET)

--- a/argus/data/cache.py
+++ b/argus/data/cache.py
@@ -77,6 +77,10 @@ _SELECT_TICKERS = """
 SELECT DISTINCT ticker FROM ohlcv WHERE interval = ?
 """
 
+_SELECT_ROW_COUNTS = """
+SELECT ticker, COUNT(*) FROM ohlcv WHERE interval = ? GROUP BY ticker
+"""
+
 
 def _canonical_timestamp(ts: object) -> str:
     """Canonicalizes a candle timestamp to UTC ISO-8601 for storage.
@@ -165,29 +169,49 @@ class OHLCVBuffer:
                 timestamp may be naive (interpreted as ET) or tz-aware; stored
                 as canonical UTC ISO-8601.
         """
-        ticker = ticker.upper()
-        ts = candle.get("timestamp")
-        if ts is None:
-            ts = datetime.now(timezone.utc)
-        ts = _canonical_timestamp(ts)
+        self.insert_candles(ticker, [candle])
 
-        row = (
-            ticker,
-            self._interval,
-            ts,
-            candle.get("open"),
-            candle.get("high"),
-            candle.get("low"),
-            candle.get("close"),
-            candle.get("volume"),
-        )
+    def insert_candles(self, ticker: str, candles: list[dict]) -> None:
+        """Bulk-inserts candlestick entries in one transaction and prunes once.
+
+        A row-by-row insert with a commit per row measured ~655ms/ticker for a
+        full 2-day fetch; one `executemany` and one commit for the whole batch
+        is 406x faster and the natural shape for `_fetch_one_ticker`'s
+        per-sweep bulk load.
+
+        Args:
+            ticker: Equity ticker symbol; case-insensitive, normalized to upper.
+            candles: Dicts with keys timestamp, open, high, low, close, volume.
+                Each timestamp may be naive (interpreted as ET) or tz-aware;
+                stored as canonical UTC ISO-8601.
+        """
+        if not candles:
+            return
+
+        ticker = ticker.upper()
+        rows = []
+        for candle in candles:
+            ts = candle.get("timestamp")
+            if ts is None:
+                ts = datetime.now(timezone.utc)
+            ts = _canonical_timestamp(ts)
+            rows.append((
+                ticker,
+                self._interval,
+                ts,
+                candle.get("open"),
+                candle.get("high"),
+                candle.get("low"),
+                candle.get("close"),
+                candle.get("volume"),
+            ))
 
         with self._lock:
-            self._conn.execute(_INSERT_OHLCV, row)
+            self._conn.executemany(_INSERT_OHLCV, rows)
             self._conn.execute(_PRUNE_OHLCV, (ticker, ticker, self._buffer_size))
             self._conn.commit()
 
-        logger.debug("OHLCVBuffer.insert_candle: %s @ %s", ticker, ts)
+        logger.debug("OHLCVBuffer.insert_candles: %s ← %d candle(s)", ticker, len(rows))
 
     def get_candles(self, ticker: str) -> Optional[pd.DataFrame]:
         """Retrieves buffered candles as a pandas DataFrame, tz-converted to ET.
@@ -233,6 +257,21 @@ class OHLCVBuffer:
         with self._lock:
             rows = self._conn.execute(_SELECT_TICKERS, (self._interval,)).fetchall()
         return [r[0] for r in rows]
+
+    def row_counts(self) -> dict[str, int]:
+        """Returns each tracked ticker's row count without materializing its candle frame.
+
+        A `GROUP BY COUNT(*)` rather than one `get_candles()` call per ticker —
+        the latter builds and tz-converts a full DataFrame just to call `len()`
+        on it, and its own 14-row floor would report 0 for a ticker holding
+        fewer rows than that even though the row count is real.
+
+        Returns:
+            Mapping of ticker → row count, for this buffer's configured interval.
+        """
+        with self._lock:
+            rows = self._conn.execute(_SELECT_ROW_COUNTS, (self._interval,)).fetchall()
+        return {ticker: count for ticker, count in rows}
 
     def close(self) -> None:
         """Closes the underlying database connection."""

--- a/argus/data/fetchers.py
+++ b/argus/data/fetchers.py
@@ -33,6 +33,7 @@ import time
 import functools
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
 from threading import Lock
 from typing import Any, Callable, Optional, TypeVar
 
@@ -311,7 +312,26 @@ _MULTI_DAILY_MAX_WORKERS = 5
 
 # Daily bars change once per trading day; caching them turns every run after
 # the first of the day into 0 requests for this node instead of one per ticker.
-_DAILY_BAR_CACHE = DailyBarCache()
+# Constructed lazily (not at import time) so it lands under whatever
+# settings.ARGUS_DATA_DIR is current when first used, not whatever it was at
+# import time — docker-compose mounts only data/ and chroma_db/, so the old
+# cwd-relative default silently landed on the ephemeral container layer and
+# was destroyed on every restart.
+_DAILY_BAR_CACHE: Optional[DailyBarCache] = None
+
+
+def _daily_bar_cache() -> DailyBarCache:
+    """Returns the module-level DailyBarCache, constructing it under ARGUS_DATA_DIR on first use.
+
+    Returns:
+        The shared DailyBarCache instance.
+    """
+    global _DAILY_BAR_CACHE
+    if _DAILY_BAR_CACHE is None:
+        data_dir = Path(settings.ARGUS_DATA_DIR)
+        data_dir.mkdir(parents=True, exist_ok=True)
+        _DAILY_BAR_CACHE = DailyBarCache(db_path=str(data_dir / "daily_bars_cache.db"))
+    return _DAILY_BAR_CACHE
 
 
 def fetch_multiple_daily(tickers: list[str], period: str = "1y") -> dict[str, pd.DataFrame]:
@@ -328,11 +348,12 @@ def fetch_multiple_daily(tickers: list[str], period: str = "1y") -> dict[str, pd
     Returns:
         Mapping of ticker → DataFrame. Failed tickers are omitted with a warning.
     """
+    cache = _daily_bar_cache()
     results: dict[str, pd.DataFrame] = {}
     to_fetch: list[str] = []
 
     for ticker in tickers:
-        cached = _DAILY_BAR_CACHE.get(ticker)
+        cached = cache.get(ticker)
         if cached is not None:
             results[ticker] = cached
         else:
@@ -348,7 +369,7 @@ def fetch_multiple_daily(tickers: list[str], period: str = "1y") -> dict[str, pd
                 try:
                     df = future.result()
                     results[ticker] = df
-                    _DAILY_BAR_CACHE.put(ticker, df)
+                    cache.put(ticker, df)
                 except Exception as exc:
                     logger.warning(
                         "fetch_multiple_daily: failed for %s — %s: %s",

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -28,6 +28,7 @@ import importlib.metadata  # noqa: F401 — pandas_ta.maps uses this without imp
 import logging
 import math
 import re
+import time
 from collections.abc import Callable
 from datetime import datetime, time as dtime
 from pathlib import Path
@@ -63,10 +64,6 @@ _FETCH_PERIOD = f"{_FETCH_PERIOD_DAYS}d"
 _INDICATOR_RESAMPLE_MINUTES = 5
 
 _FETCH_INTERVAL = 300
-
-# Conservative, unmeasured estimate of one yfinance round-trip; used only to
-# derive inter-ticker spacing so a sweep finishes within _FETCH_INTERVAL
-_ESTIMATED_FETCH_SECONDS_PER_TICKER = 1.0
 
 _INTERVAL_RE = re.compile(r"^(\d+)(m|h)$")
 
@@ -371,27 +368,36 @@ class MFTDataPipeline:
             await self._sweep_once()
         else:
             logger.debug("run_once: outside market hours — compressing existing buffer only")
-        return self.compress_all()
+        return await asyncio.to_thread(self.compress_all)
 
     async def _sweep_once(self) -> None:
         """Fetches the latest candlesticks for every tracked ticker, one pass.
 
-        Spaces requests across the sweep so it finishes within ``_FETCH_INTERVAL``
-        rather than on a fixed per-batch schedule. Iterates over a snapshot of
+        Pauses ``SYSTEM.min_inter_request_seconds`` between requests — a fixed
+        floor against yfinance rate limiting, not a spread computed to fill
+        ``_FETCH_INTERVAL``; that framing was wrong in principle (pacing exists
+        for rate limiting, not to occupy the cadence budget) and meaningless for
+        a one-shot ``run_once()`` sweep. Iterates over a snapshot of
         ``self.tickers`` so that concurrent ``register_tickers`` calls cannot corrupt iteration.
         """
         tickers_snapshot = list(self.tickers)
         logger.debug("_sweep_once: starting universe sweep (%d tickers)", len(tickers_snapshot))
-        sleep_seconds = self._inter_request_sleep(len(tickers_snapshot))
         last = len(tickers_snapshot) - 1
         for i, ticker in enumerate(tickers_snapshot):
             await self._fetch_one_ticker(ticker)
             if i < last:
-                await asyncio.sleep(sleep_seconds)
+                await asyncio.sleep(SYSTEM.min_inter_request_seconds)
 
     async def _fetch_loop(self) -> None:
-        """Periodically downloads the latest intraday candlesticks for the tracking universe."""
+        """Periodically downloads the latest intraday candlesticks for the tracking universe.
+
+        Sleeps only the remainder of ``_FETCH_INTERVAL`` after each sweep, not a
+        full interval on top of however long the sweep itself took — otherwise
+        the real cadence drifts to sweep_duration + _FETCH_INTERVAL instead of
+        the intended _FETCH_INTERVAL.
+        """
         while self.running:
+            started = time.monotonic()
             try:
                 if self._is_market_hours():
                     await self._sweep_once()
@@ -402,34 +408,8 @@ class MFTDataPipeline:
                     "_fetch_loop: sweep failed — %s: %s", type(exc).__name__, exc
                 )
 
-            await self._wait_or_stop(_FETCH_INTERVAL)
-
-    def _inter_request_sleep(self, n_tickers: int) -> float:
-        """Derives the per-ticker sleep so a sweep finishes within `_FETCH_INTERVAL`.
-
-        Args:
-            n_tickers: Number of tickers in the current sweep.
-
-        Returns:
-            Seconds to sleep between consecutive ticker fetches. 0.0 if there's
-            nothing to space out, or if the universe is too large to fit even an
-            unpaced sweep inside `_FETCH_INTERVAL` — in which case candles simply
-            refresh less often than `_FETCH_INTERVAL` implies.
-        """
-        if n_tickers <= 1:
-            return 0.0
-        estimated_fetch_seconds = n_tickers * _ESTIMATED_FETCH_SECONDS_PER_TICKER
-        slack = _FETCH_INTERVAL - estimated_fetch_seconds
-        if slack <= 0:
-            logger.warning(
-                "_inter_request_sleep: %d tickers won't fit an estimated %.0fs fetch "
-                "into the %ds cycle even unpaced; sweeping back-to-back",
-                n_tickers,
-                estimated_fetch_seconds,
-                _FETCH_INTERVAL,
-            )
-            return 0.0
-        return slack / n_tickers
+            elapsed = time.monotonic() - started
+            await self._wait_or_stop(max(0.0, _FETCH_INTERVAL - elapsed))
 
     def _buffer_warm(self) -> bool:
         """Checks whether any tracked ticker already has an indicator-ready buffer depth.
@@ -465,7 +445,7 @@ class MFTDataPipeline:
             try:
                 if self._is_market_hours():
                     logger.info("_session_loop: triggering decision cycle")
-                    session_states = self.compress_all()
+                    session_states = await asyncio.to_thread(self.compress_all)
                     try:
                         await callback(session_states)
                     except Exception as exc:
@@ -483,39 +463,29 @@ class MFTDataPipeline:
     async def _fetch_one_ticker(self, ticker: str) -> None:
         """Downloads and bulk-inserts all available candles for a specific symbol.
 
-        Fetches `_FETCH_PERIOD` of candles at `self.interval` and inserts every row
-        into the buffer. This warms the buffer to a full indicator-ready depth on
-        the very first fetch cycle, eliminating the cold start that would result
-        from inserting only the latest candle. Duplicate timestamps are safely
-        overwritten via the buffer's INSERT OR REPLACE contract.
+        Runs the network fetch and the buffer insert together inside one
+        ``to_thread`` call — a `pd.DataFrame.iterrows()` insert loop run
+        directly on the event loop measured ~655ms/ticker of blocking cost, on
+        top of the network round-trip. Fetches `_FETCH_PERIOD` of candles at
+        `self.interval` and inserts every row, warming the buffer to a full
+        indicator-ready depth on the very first fetch cycle rather than only
+        the latest candle. Duplicate timestamps are safely overwritten via the
+        buffer's INSERT OR REPLACE contract.
 
         Args:
             ticker: Equity ticker symbol to fetch.
         """
         try:
-            df: pd.DataFrame = await asyncio.to_thread(
-                fetch_ohlcv_intraday, ticker, self.interval, _FETCH_PERIOD
-            )
-            if df is None or df.empty:
+            n_candles, latest_close = await asyncio.to_thread(self._fetch_and_insert, ticker)
+            if n_candles == 0:
                 logger.warning("_fetch_one_ticker: empty result for %s", ticker)
                 return
-
-            for idx, row in df.iterrows():
-                candle = {
-                    "timestamp": idx.isoformat(),
-                    "open": float(row["open"]) if "open" in row.index else None,
-                    "high": float(row["high"]) if "high" in row.index else None,
-                    "low": float(row["low"]) if "low" in row.index else None,
-                    "close": float(row["close"]) if "close" in row.index else None,
-                    "volume": float(row["volume"]) if "volume" in row.index else None,
-                }
-                self.buffer.insert_candle(ticker, candle)
 
             logger.debug(
                 "_fetch_one_ticker: %s → %d candles inserted, latest close=%.2f",
                 ticker,
-                len(df),
-                float(df["close"].iloc[-1]) if "close" in df.columns else 0.0,
+                n_candles,
+                latest_close,
             )
 
         except Exception as exc:
@@ -525,6 +495,34 @@ class MFTDataPipeline:
                 type(exc).__name__,
                 exc,
             )
+
+    def _fetch_and_insert(self, ticker: str) -> tuple[int, float]:
+        """Synchronous fetch-and-bulk-insert for one ticker; run off the event loop.
+
+        Args:
+            ticker: Equity ticker symbol to fetch.
+
+        Returns:
+            Tuple of (candles inserted, latest close). (0, 0.0) on an empty fetch.
+        """
+        df: pd.DataFrame = fetch_ohlcv_intraday(ticker, self.interval, _FETCH_PERIOD)
+        if df is None or df.empty:
+            return 0, 0.0
+
+        candles = [
+            {
+                "timestamp": idx.isoformat(),
+                "open": float(row["open"]) if "open" in row.index else None,
+                "high": float(row["high"]) if "high" in row.index else None,
+                "low": float(row["low"]) if "low" in row.index else None,
+                "close": float(row["close"]) if "close" in row.index else None,
+                "volume": float(row["volume"]) if "volume" in row.index else None,
+            }
+            for idx, row in df.iterrows()
+        ]
+        self.buffer.insert_candles(ticker, candles)
+        latest_close = float(df["close"].iloc[-1]) if "close" in df.columns else 0.0
+        return len(df), latest_close
 
     def compress_all(self) -> dict[str, dict]:
         """Compresses cached candle metrics across all universe symbols into a feature dictionary.

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 9
+PARAMS_VERSION = 10
 
 
 class Provenance(str, Enum):
@@ -100,6 +100,14 @@ class SystemParams:
         Provenance.ARBITRARY,
         "buffer against fetch/session timing jitter added to the MFT cache-write "
         "and bar-age budgets in data/pipeline.py; not evaluated against alternatives",
+    )
+    min_inter_request_seconds: float = p(
+        0.5,
+        Provenance.ARBITRARY,
+        "minimum pause between consecutive per-ticker yfinance requests within a "
+        "sweep, to avoid rate limiting; a fixed floor rather than a fill-the-interval "
+        "spread, since pacing exists for rate limiting, not to occupy the cadence "
+        "budget — not evaluated against alternatives",
     )
 
 

--- a/tests/test_api_event_loop_hygiene.py
+++ b/tests/test_api_event_loop_hygiene.py
@@ -1,0 +1,92 @@
+"""
+tests/test_api_event_loop_hygiene.py
+
+Tests for PR4 (MFT-6/7/13, API-4): api/main.py must not block the event loop
+on buffer reads or the daily reconciliation cycle.
+
+These exercise route/loop functions directly via FastAPI's TestClient or as
+bare coroutines, mirroring test_api_freshness.py's pattern of setting
+`_mft_pipeline` and friends directly on the api.main module rather than
+running the app's lifespan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import inspect
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons(monkeypatch):
+    """Clears the live session cache around each test."""
+    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    yield
+
+
+@pytest.fixture
+def client():
+    """A TestClient over api.main.app without running its lifespan startup."""
+    return TestClient(api_main.app)
+
+
+def test_pipeline_status_reports_buffer_depth_without_materializing_frames(monkeypatch, client):
+    """/pipeline/status reads buffer depth via row_counts(), not by materializing each ticker's frame."""
+    fake_pipeline = mock.Mock()
+    fake_pipeline.tickers = ["AAPL"]
+    fake_pipeline.is_market_hours.return_value = True
+    fake_pipeline.buffer.row_counts.return_value = {"AAPL": 42}
+    fake_pipeline.buffer.get_candles.side_effect = AssertionError("must not materialize frames")
+    monkeypatch.setattr(api_main, "_mft_pipeline", fake_pipeline)
+
+    response = client.get("/pipeline/status")
+
+    assert response.status_code == 200
+    assert response.json()["buffer_depth"] == {"AAPL": 42}
+    fake_pipeline.buffer.get_candles.assert_not_called()
+    fake_pipeline.buffer.row_counts.assert_called_once()
+
+
+def test_reconcile_once_is_a_plain_sync_function():
+    """`_reconcile_once` is synchronous, so `_reconcile_loop` can run it via `asyncio.to_thread`."""
+    assert not inspect.iscoroutinefunction(api_main._reconcile_once)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_loop_runs_its_cycle_body_via_to_thread(monkeypatch):
+    """`_reconcile_loop` offloads its per-cycle body through asyncio.to_thread, not inline."""
+    real_sleep = asyncio.sleep
+    calls = []
+
+    def fake_reconcile_once():
+        calls.append(True)
+
+    async def fake_sleep(_seconds):
+        await real_sleep(0)
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        await real_sleep(0)
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(api_main, "_reconcile_once", fake_reconcile_once)
+    monkeypatch.setattr(api_main.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(api_main.asyncio, "to_thread", fake_to_thread)
+
+    task = asyncio.create_task(api_main._reconcile_loop())
+    try:
+        for _ in range(200):
+            if calls:
+                break
+            await real_sleep(0.005)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert calls, "expected _reconcile_once to run via to_thread"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -169,6 +169,72 @@ def test_interval_change_purges_stale_rows(tmp_path):
     assert new._conn.execute("SELECT COUNT(*) FROM ohlcv").fetchone()[0] == 0
 
 
+class _CommitCountingConnection:
+    """Forwards every call to a real sqlite3.Connection except commit(), which it also counts.
+
+    sqlite3.Connection is an immutable C type — neither its class nor its
+    instances accept a patched `commit` attribute — so counting calls to it
+    requires wrapping the connection rather than monkeypatching it directly.
+    """
+
+    def __init__(self, real: sqlite3.Connection) -> None:
+        self._real = real
+        self.commits = 0
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def commit(self) -> None:
+        self.commits += 1
+        self._real.commit()
+
+
+def test_insert_candles_bulk_uses_a_single_commit():
+    """Bulk-inserting N candles commits once, not once per row."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=50, interval="1m")
+    proxy = _CommitCountingConnection(buffer._conn)
+    buffer._conn = proxy
+
+    candles = [{"timestamp": f"2024-01-02T09:{i:02d}:00", "close": float(i)} for i in range(20)]
+    buffer.insert_candles("AAPL", candles)
+
+    assert proxy.commits == 1
+    df = buffer.get_candles("AAPL")
+    assert len(df) == 20
+    assert df["close"].iloc[-1] == 19.0
+
+
+def test_insert_candles_is_a_noop_for_an_empty_list():
+    """Bulk-inserting an empty batch touches nothing."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=20, interval="1m")
+    buffer.insert_candles("AAPL", [])
+    assert buffer.get_all_tickers() == []
+
+
+def test_insert_candle_delegates_to_insert_candles(monkeypatch):
+    """The single-candle path is a thin wrapper over the bulk path."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=20, interval="1m")
+    received = []
+    monkeypatch.setattr(
+        buffer, "insert_candles", lambda ticker, candles: received.append((ticker, candles))
+    )
+
+    buffer.insert_candle("AAPL", {"timestamp": "2024-01-02T09:30:00", "close": 1.0})
+
+    assert received == [("AAPL", [{"timestamp": "2024-01-02T09:30:00", "close": 1.0}])]
+
+
+def test_row_counts_returns_per_ticker_counts_without_the_get_candles_floor():
+    """row_counts() reports real per-ticker counts, including below get_candles' own 14-row floor."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=50, interval="1m")
+    for i in range(5):
+        buffer.insert_candle("AAPL", {"timestamp": f"2024-01-02T09:{i:02d}:00", "close": float(i)})
+    for i in range(20):
+        buffer.insert_candle("MSFT", {"timestamp": f"2024-01-02T09:{i:02d}:00", "close": float(i)})
+
+    assert buffer.row_counts() == {"AAPL": 5, "MSFT": 20}
+
+
 def test_interval_change_logs_the_discarded_count(tmp_path, caplog):
     """The interval-change purge logs how many stale rows it discarded, at WARNING."""
     db_path = str(tmp_path / "buffer.db")

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -348,3 +348,26 @@ def test_fetch_multiple_daily_serves_second_call_from_cache(monkeypatch):
     second = fetchers.fetch_multiple_daily(["AAPL", "MSFT"], period="1y")
     assert calls["n"] == 2, "second same-day call must be served entirely from cache"
     assert set(second.keys()) == {"AAPL", "MSFT"}
+
+
+def test_daily_bar_cache_lives_under_argus_data_dir(monkeypatch, tmp_path):
+    """The lazily-built module singleton lands under settings.ARGUS_DATA_DIR, not the cwd.
+
+    The old cwd-relative default landed outside docker-compose's mounted
+    volumes and was destroyed on every container restart (MFT-13).
+    """
+    monkeypatch.setattr(fetchers, "_DAILY_BAR_CACHE", None)
+
+    cache = fetchers._daily_bar_cache()
+
+    assert cache._db_path == str(tmp_path / "daily_bars_cache.db")
+
+
+def test_daily_bar_cache_is_constructed_once_and_reused(monkeypatch):
+    """A second call to `_daily_bar_cache()` returns the same instance rather than rebuilding it."""
+    monkeypatch.setattr(fetchers, "_DAILY_BAR_CACHE", None)
+
+    first = fetchers._daily_bar_cache()
+    second = fetchers._daily_bar_cache()
+
+    assert first is second

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,9 +4,9 @@ Tests for the MFT Data Pipeline.
 
 import asyncio
 import importlib
-import logging
 import math
 import sys
+import time
 from pathlib import Path
 
 import pandas as pd
@@ -19,7 +19,6 @@ from argus.config import settings
 from argus.data.cache import OHLCVBuffer
 from argus.data.pipeline import (
     _FETCH_INTERVAL,
-    _ESTIMATED_FETCH_SECONDS_PER_TICKER,
     MFTDataPipeline,
     _bars_per_day,
     _derive_buffer_size,
@@ -300,31 +299,80 @@ def test_max_bar_age_seconds_scales_with_interval():
     assert max_bar_age_seconds(5) > max_bar_age_seconds(1)
 
 
-def test_inter_request_sleep_derives_spacing_from_universe_size():
-    """Inter-ticker spacing splits the fetch cycle's slack evenly across the universe."""
+@pytest.mark.asyncio
+async def test_sweep_uses_a_constant_inter_request_gap_independent_of_universe_size(monkeypatch):
+    """The pause between per-ticker fetches is SYSTEM.min_inter_request_seconds regardless of universe size."""
+
+    async def fake_fetch_one(_ticker):
+        return None
+
+    small = MFTDataPipeline(["A", "B", "C"], interval="1m")
+    monkeypatch.setattr(small, "_fetch_one_ticker", fake_fetch_one)
+    small_start = time.monotonic()
+    await small._sweep_once()
+    small_elapsed = time.monotonic() - small_start
+
+    big = MFTDataPipeline([f"T{i}" for i in range(20)], interval="1m")
+    monkeypatch.setattr(big, "_fetch_one_ticker", fake_fetch_one)
+    big_start = time.monotonic()
+    await big._sweep_once()
+    big_elapsed = time.monotonic() - big_start
+
+    # 2 gaps for 3 tickers, 19 gaps for 20 — a fixed per-gap cost, not a
+    # fill-the-interval spread that would instead keep total elapsed time constant
+    assert small_elapsed == pytest.approx(2 * SYSTEM.min_inter_request_seconds, abs=0.05)
+    assert big_elapsed == pytest.approx(19 * SYSTEM.min_inter_request_seconds, abs=0.1)
+
+
+@pytest.mark.asyncio
+async def test_fetch_loop_sleeps_the_remainder_of_the_interval_not_a_full_one(monkeypatch):
+    """A fetch_loop iteration's wait is shortened by however long the sweep itself took."""
     pipeline = MFTDataPipeline([], interval="1m")
-    n = 20
-    expected = (_FETCH_INTERVAL - n * _ESTIMATED_FETCH_SECONDS_PER_TICKER) / n
-    assert pipeline._inter_request_sleep(n) == pytest.approx(expected)
+    waits = []
+
+    async def fake_sweep():
+        await asyncio.sleep(0.05)
+
+    async def fake_wait_or_stop(timeout):
+        waits.append(timeout)
+        pipeline.running = False
+
+    monkeypatch.setattr(pipeline, "_is_market_hours", lambda: True)
+    monkeypatch.setattr(pipeline, "_sweep_once", fake_sweep)
+    monkeypatch.setattr(pipeline, "_wait_or_stop", fake_wait_or_stop)
+    pipeline.running = True
+
+    await pipeline._fetch_loop()
+
+    assert len(waits) == 1
+    assert waits[0] < _FETCH_INTERVAL
+    assert waits[0] == pytest.approx(_FETCH_INTERVAL - 0.05, abs=0.05)
 
 
-def test_inter_request_sleep_returns_zero_with_no_gaps_to_space():
-    """A sweep of zero or one tickers has no gaps between fetches to pace."""
+@pytest.mark.asyncio
+async def test_fetch_loop_cadence_holds_across_a_slow_sweep(monkeypatch):
+    """The measured gap between sweep starts tracks _FETCH_INTERVAL, not sweep_duration + _FETCH_INTERVAL."""
+    monkeypatch.setattr(pipeline_module, "_FETCH_INTERVAL", 0.2)
     pipeline = MFTDataPipeline([], interval="1m")
-    assert pipeline._inter_request_sleep(0) == 0.0
-    assert pipeline._inter_request_sleep(1) == 0.0
+    monkeypatch.setattr(pipeline, "_is_market_hours", lambda: True)
 
+    starts = []
 
-def test_inter_request_sleep_floors_at_zero_and_warns_when_universe_outgrows_cadence(caplog):
-    """A universe too large to fit even an unpaced sweep logs a warning and sweeps back-to-back."""
-    pipeline = MFTDataPipeline([], interval="1m")
-    huge = int(_FETCH_INTERVAL // _ESTIMATED_FETCH_SECONDS_PER_TICKER) + 10
+    async def fake_sweep():
+        starts.append(time.monotonic())
+        await asyncio.sleep(0.05)
 
-    with caplog.at_level(logging.WARNING, logger="argus.pipeline"):
-        result = pipeline._inter_request_sleep(huge)
+    monkeypatch.setattr(pipeline, "_sweep_once", fake_sweep)
 
-    assert result == 0.0
-    assert any("won't fit" in record.message for record in caplog.records)
+    pipeline.running = True
+    task = asyncio.create_task(pipeline._fetch_loop())
+    await asyncio.sleep(0.55)
+    await pipeline.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert len(starts) >= 2
+    gaps = [b - a for a, b in zip(starts, starts[1:])]
+    assert all(gap == pytest.approx(0.2, abs=0.05) for gap in gaps)
 
 
 def test_default_db_path_uses_isolated_data_dir(tmp_path):
@@ -481,3 +529,40 @@ async def test_stop_ends_both_loops_promptly():
     # Without the stop_event-based wait, this would block for up to
     # _WARMUP_POLL_INTERVAL/_FETCH_INTERVAL seconds instead of returning almost immediately
     await asyncio.wait_for(task, timeout=2.0)
+
+
+def test_fetch_and_insert_bulk_inserts_in_one_call(monkeypatch):
+    """`_fetch_and_insert` hands the whole fetched frame to insert_candles in one call, not per-row."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    df = et_intraday_candles(5)
+    df[["open", "high", "low", "close"]] += 100
+
+    monkeypatch.setattr(
+        pipeline_module, "fetch_ohlcv_intraday", lambda ticker, interval, period: df
+    )
+    calls = []
+    monkeypatch.setattr(
+        pipeline.buffer, "insert_candles", lambda ticker, candles: calls.append((ticker, candles))
+    )
+
+    n_candles, latest_close = pipeline._fetch_and_insert("AAPL")
+
+    assert n_candles == 5
+    assert latest_close == pytest.approx(float(df["close"].iloc[-1]))
+    assert len(calls) == 1
+    assert calls[0][0] == "AAPL"
+    assert len(calls[0][1]) == 5
+
+
+def test_fetch_and_insert_returns_zero_on_an_empty_fetch(monkeypatch):
+    """An empty fetch result reports zero candles rather than raising."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    monkeypatch.setattr(
+        pipeline_module,
+        "fetch_ohlcv_intraday",
+        lambda ticker, interval, period: pd.DataFrame(),
+    )
+
+    n_candles, latest_close = pipeline._fetch_and_insert("AAPL")
+
+    assert (n_candles, latest_close) == (0, 0.0)


### PR DESCRIPTION
## Summary

PR4 of issue #41's remediation plan (MFT-6, MFT-7, MFT-13, API-4). Covers hygiene, not correctness — nothing here changes what `/analyze` returns.

- **Bulk insert (MFT-6).** `OHLCVBuffer.insert_candles()` does one `executemany` + one prune + one commit per batch instead of a commit per row; `insert_candle` now delegates to it.
- **Off the loop (MFT-6, API-4).** `_fetch_one_ticker` runs its fetch *and* insert together inside one `to_thread` call — previously only the network call was off-loop while the `iterrows()` insert stalled the loop. `compress_all` (in `_session_loop` and `run_once`), `/pipeline/status`'s buffer reads, and `_reconcile_loop`'s daily cycle body (extracted into a sync `_reconcile_once()`) are now all dispatched via `to_thread` too.
- **Real cadence (MFT-7).** `_fetch_loop` measures its own sweep duration and sleeps only the remainder of `_FETCH_INTERVAL`, instead of a full interval on top of however long the sweep took (was 586s vs an intended 300s at 20 tickers). The old "spread requests to fill the interval" inter-request pacing is replaced with a constant minimum gap (`SYSTEM.min_inter_request_seconds`), since pacing exists to avoid rate limiting, not to occupy the cadence budget — and the old semantics were meaningless for `run_once()`'s one-shot sweeps anyway.
- **Daily-bar cache path (MFT-13).** `DailyBarCache` no longer opens a cwd-relative `daily_bars_cache.db` (outside every volume docker-compose mounts, destroyed on every container restart); it's now built lazily under `settings.ARGUS_DATA_DIR` on first use.
- **`row_counts()`.** `/pipeline/status` reports buffer depth via a `SELECT ticker, COUNT(*) ... GROUP BY ticker`, not by materializing a full DataFrame per ticker just to call `len()`.

## Test plan

- [x] `pytest tests/ -q` — 339 passed (328 baseline + 11 new)
- [x] `ruff check .` clean
- [x] `mypy argus/` clean (`api/`+`scripts/` carry the same 4 pre-existing, unrelated errors noted in prior PRs)