### PR TITLE
PR5a: gateway input validation and error redaction

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -43,11 +43,12 @@ load_dotenv()
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from argus.agents.macro import MacroStatisticalAgent
 from argus.config import settings
 from argus.data.pipeline import MFTDataPipeline, max_bar_age_seconds, session_state_ttl_seconds
+from argus.data.tickers import TICKER_PATTERN
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.collector import CollectionResult, run_collection_cycle
 from argus.orchestration.governor import REGISTERED_MODELS, RateLimitExceeded, UnregisteredModel, governor
@@ -369,6 +370,32 @@ class AnalysisRequest(BaseModel):
     invest_pct: float = Field(gt=0.05, le=0.95)
     risk_tolerance: Literal["CONSERVATIVE", "MODERATE", "AGGRESSIVE"] = "MODERATE"
 
+    @field_validator("tickers")
+    @classmethod
+    def _normalize_tickers(cls, tickers: list[str]) -> list[str]:
+        """Strips whitespace, upper-cases, validates ticker shape, then dedupes (API-1, API-6).
+
+        Runs in that order deliberately: pydantic's StringConstraints checks
+        `pattern` against the raw, pre-transform string even when combined
+        with `to_upper`/`strip_whitespace`, so a case/whitespace-only field
+        constraint can't do this — the transform has to happen before the
+        pattern check runs.
+
+        Raises:
+            ValueError: If any entry doesn't match TICKER_PATTERN after normalization.
+        """
+        normalized = [t.strip().upper() for t in tickers]
+        invalid = [t for t in normalized if not TICKER_PATTERN.match(t)]
+        if invalid:
+            raise ValueError(f"Invalid ticker symbol(s): {invalid}")
+        seen: set[str] = set()
+        deduped = []
+        for t in normalized:
+            if t not in seen:
+                seen.add(t)
+                deduped.append(t)
+        return deduped
+
 
 class AnalysisResponse(BaseModel):
     """Synthesized portfolio allocation recommendation and system diagnostics."""
@@ -581,8 +608,9 @@ async def analyze(req: AnalysisRequest):
         logger.error("[API] Model configuration error: %s", e)
         raise HTTPException(503, f"Model configuration error: {e}")
     except Exception as e:
-        logger.error("[API] Graph error: %s", e)
-        raise HTTPException(500, f"Agent graph error: {str(e)}")
+        ref = uuid4()
+        logger.error("[API] Graph error (ref %s): %s", ref, e, exc_info=True)
+        raise HTTPException(500, f"Agent graph error (ref {ref})")
 
     allocation = final_state.get("portfolio_allocation")
     if not allocation:

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -41,6 +41,7 @@ import pandas_ta as ta
 from argus.config import settings
 from argus.data.cache import OHLCVBuffer
 from argus.data.fetchers import fetch_ohlcv_intraday
+from argus.data.tickers import is_valid_ticker
 from argus.params import SYSTEM
 from argus.schemas.signals import missing_session_state_keys
 
@@ -275,7 +276,6 @@ class MFTDataPipeline:
                 a process restart resumes with a warm buffer instead of the
                 cold start a fresh buffer would otherwise incur.
         """
-        self.tickers = tickers
         self.interval = interval or settings.MFT_CANDLE_INTERVAL
         self.interval_minutes = _parse_interval_minutes(self.interval)
         self.session_interval_seconds = settings.MFT_DECISION_INTERVAL_SECONDS
@@ -287,9 +287,15 @@ class MFTDataPipeline:
         self.buffer = OHLCVBuffer(db_path=db_path, buffer_size=buffer_size, interval=self.interval)
         self.running = False
         self._stop_event = asyncio.Event()
+        # Routed through register_tickers rather than a bare assignment, so the
+        # ticker-shape and universe-cap invariants apply uniformly here, to
+        # run_collection_cycle, and to collect_session.py's --universe CLI arg
+        # (API-1) — not just to /analyze's already-validated request tickers
+        self.tickers: list[str] = []
+        self.register_tickers(tickers)
         logger.info(
             "MFTDataPipeline initialised: %d tickers, interval=%s, buffer_size=%d, buffer=%s",
-            len(tickers),
+            len(self.tickers),
             self.interval,
             buffer_size,
             db_path,
@@ -332,18 +338,39 @@ class MFTDataPipeline:
 
         Safe to call while the pipeline is running. The ``_fetch_loop`` reads
         ``self.tickers`` on every iteration, so new entries are picked up within
-        ``_FETCH_INTERVAL`` seconds.
+        ``_FETCH_INTERVAL`` seconds. This is the single enforcement point for
+        ticker-shape validation and the SYSTEM.max_tracked_tickers cap (API-1):
+        __init__ routes its initial universe through here too.
 
         Args:
-            tickers: Ticker symbols to add. Duplicates are silently ignored.
+            tickers: Ticker symbols to add. Malformed symbols and duplicates
+                are dropped; entries beyond the tracked-universe cap are
+                dropped too, both logged at WARNING.
         """
-        new = [t for t in tickers if t not in self.tickers]
-        if new:
-            self.tickers.extend(new)
+        valid = [t for t in tickers if is_valid_ticker(t)]
+        invalid = [t for t in tickers if t not in valid]
+        if invalid:
+            logger.warning(
+                "MFTDataPipeline.register_tickers: rejected malformed ticker(s): %s", invalid
+            )
+
+        new = [t for t in valid if t not in self.tickers]
+        room = max(SYSTEM.max_tracked_tickers - len(self.tickers), 0)
+        accepted, dropped = new[:room], new[room:]
+        if dropped:
+            logger.warning(
+                "MFTDataPipeline.register_tickers: universe cap (%d) reached; dropping %d "
+                "ticker(s): %s",
+                SYSTEM.max_tracked_tickers,
+                len(dropped),
+                dropped,
+            )
+        if accepted:
+            self.tickers.extend(accepted)
             logger.info(
                 "MFTDataPipeline.register_tickers: added %d ticker(s): %s",
-                len(new),
-                new,
+                len(accepted),
+                accepted,
             )
 
     async def stop(self) -> None:

--- a/argus/data/tickers.py
+++ b/argus/data/tickers.py
@@ -1,0 +1,36 @@
+"""
+argus/data/tickers.py
+
+Ticker symbol validation shared across every entry point that grows the
+tracked universe: /analyze's request schema, MFTDataPipeline.register_tickers,
+run_collection_cycle, and collect_session.py's --universe CLI arg.
+
+Responsibilities:
+  - Define the accepted equity ticker symbol pattern
+  - Validate a candidate ticker string against it
+
+Not responsible for:
+  - Case normalization or deduplication (see api/main.py's AnalysisRequest)
+  - Universe size limits (see argus/params.py's SYSTEM.max_tracked_tickers)
+"""
+
+from __future__ import annotations
+
+import re
+
+# 1-5 letter root, optional one-or-two-letter share-class suffix (BRK.B, BRK-B).
+# Deliberately excludes ^GSPC-style indices and BTC-USD-style pairs: neither
+# has the GICS sector or financials the risk and fundamental agents fetch.
+TICKER_PATTERN = re.compile(r"^[A-Z]{1,5}(?:[.-][A-Z]{1,2})?$")
+
+
+def is_valid_ticker(ticker: str) -> bool:
+    """Checks whether ticker matches the accepted equity symbol shape.
+
+    Args:
+        ticker: Candidate ticker symbol, expected already upper-cased.
+
+    Returns:
+        True if ticker matches TICKER_PATTERN.
+    """
+    return bool(TICKER_PATTERN.match(ticker))

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 10
+PARAMS_VERSION = 11
 
 
 class Provenance(str, Enum):
@@ -108,6 +108,13 @@ class SystemParams:
         "sweep, to avoid rate limiting; a fixed floor rather than a fill-the-interval "
         "spread, since pacing exists for rate limiting, not to occupy the cadence "
         "budget — not evaluated against alternatives",
+    )
+    max_tracked_tickers: int = p(
+        100,
+        Provenance.ARBITRARY,
+        "ceiling on MFTDataPipeline.tickers enforced in register_tickers; stops "
+        "unbounded universe growth from repeated /analyze requests (API-1) — not "
+        "evaluated against alternatives",
     )
 
 

--- a/tests/test_api_freshness.py
+++ b/tests/test_api_freshness.py
@@ -120,5 +120,9 @@ def test_analyze_passes_freshness_gate_with_a_current_bar(client, monkeypatch):
 
     response = client.post("/analyze", json=_PAYLOAD)
 
+    # A 500 (rather than any of the 503 freshness variants) proves every gate
+    # above was cleared and the graph itself was reached; the exception text
+    # is redacted behind a correlation ref (API-7, see test_api_validation.py)
+    # so it isn't asserted here.
     assert response.status_code == 500
-    assert "sentinel: freshness gate cleared" in response.json()["detail"]
+    assert fake_graph.invoke.called

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -1,0 +1,118 @@
+"""
+tests/test_api_validation.py
+
+Tests for PR5a: AnalysisRequest's ticker validation, normalization, and
+dedupe (API-1, API-6 gateway half), and /analyze's redaction of internal
+exception details behind a correlation ref (API-7).
+
+These exercise the route function directly via FastAPI's TestClient rather
+than going through the app's lifespan, so no MFT pipeline, collector, or
+reconcile loop needs to start.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+import argus.risk.kill_switch as kill_switch_module
+
+_PAYLOAD = {"tickers": ["AAPL"], "total_wealth": 100_000, "invest_pct": 0.5}
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons(monkeypatch):
+    """Clears the kill-switch singleton and live session cache around each test."""
+    kill_switch_module._kill_switch = None
+    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    monkeypatch.setattr(api_main.settings, "ARGUS_API_KEY", "")
+    yield
+    kill_switch_module._kill_switch = None
+
+
+@pytest.fixture
+def client():
+    """A TestClient over api.main.app without running its lifespan startup."""
+    return TestClient(api_main.app)
+
+
+def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
+    """Installs a fake MFTDataPipeline as the module-level `_mft_pipeline`."""
+    fake = mock.Mock()
+    fake.is_market_hours.return_value = market_hours
+    fake.interval_minutes = interval_minutes
+    monkeypatch.setattr(api_main, "_mft_pipeline", fake)
+    return fake
+
+
+def _seed_cache(ticker: str, *, bar_age_seconds: float, write_age_seconds: float = 0.0):
+    """Populates `_live_session_cache` with a state whose bar and write times are both controlled."""
+    bar_ts = datetime.now(api_main._ET) - timedelta(seconds=bar_age_seconds)
+    write_ts = datetime.now() - timedelta(seconds=write_age_seconds)
+    api_main._live_session_cache[ticker] = ({"timestamp": bar_ts.isoformat()}, write_ts)
+
+
+@pytest.mark.parametrize(
+    "ticker",
+    [
+        "",
+        "A" * 500,
+        "'; DROP TABLE ohlcv; --",
+        "../../etc/passwd",
+        "AAPLLL",
+        ".B",
+        "AAPL.",
+        "^GSPC",
+        "BTC-USD",
+    ],
+)
+def test_analyze_rejects_malformed_ticker_with_422(client, ticker):
+    """A hostile or malformed ticker is rejected by pydantic before any handler runs."""
+    response = client.post(
+        "/analyze",
+        json={"tickers": [ticker], "total_wealth": 100_000, "invest_pct": 0.5},
+    )
+    assert response.status_code == 422
+
+
+def test_analyze_accepts_share_class_tickers(client, monkeypatch):
+    """Dotted and hyphenated share-class symbols pass validation and reach the pipeline."""
+    fake_pipeline = _pipeline(monkeypatch, market_hours=False)
+    response = client.post(
+        "/analyze",
+        json={"tickers": ["BRK.B", "BRK-B"], "total_wealth": 100_000, "invest_pct": 0.5},
+    )
+    assert response.status_code == 503
+    fake_pipeline.register_tickers.assert_called_once_with(["BRK.B", "BRK-B"])
+
+
+def test_analyze_upcases_and_dedupes_tickers(client, monkeypatch):
+    """Lowercase, whitespace-padded, and repeated tickers collapse to one upper-cased entry each."""
+    fake_pipeline = _pipeline(monkeypatch, market_hours=False)
+    response = client.post(
+        "/analyze",
+        json={"tickers": [" aapl ", "AAPL", "msft"], "total_wealth": 100_000, "invest_pct": 0.5},
+    )
+    assert response.status_code == 503
+    fake_pipeline.register_tickers.assert_called_once_with(["AAPL", "MSFT"])
+
+
+def test_analyze_redacts_internal_exception_details(client, monkeypatch):
+    """A raw graph exception never reaches the client; only a correlation ref does (API-7)."""
+    _pipeline(monkeypatch, market_hours=True)
+    _seed_cache("AAPL", bar_age_seconds=5, write_age_seconds=5)
+    fake_graph = mock.Mock()
+    fake_graph.invoke.side_effect = RuntimeError("api_key=sk-secret123 at /etc/passwd")
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 500
+    detail = response.json()["detail"]
+    assert "sk-secret123" not in detail
+    assert "/etc/passwd" not in detail
+    assert detail.startswith("Agent graph error (ref ")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -3,6 +3,7 @@ Tests for the MFT Data Pipeline.
 """
 
 import asyncio
+import dataclasses
 import importlib
 import math
 import sys
@@ -46,6 +47,31 @@ def test_register_tickers():
     pipeline.register_tickers(["AAPL", "TSLA"])
     assert len(pipeline.tickers) == 3
     assert "TSLA" in pipeline.tickers
+
+
+def test_register_tickers_rejects_malformed_symbols():
+    """A malformed ticker is dropped; well-formed siblings in the same call still register."""
+    pipeline = MFTDataPipeline([])
+    pipeline.register_tickers(["AAPL", "", "'; DROP TABLE ohlcv; --", "../../etc/passwd", "aapl"])
+    assert pipeline.tickers == ["AAPL"]
+
+
+def test_register_tickers_caps_the_tracked_universe(monkeypatch):
+    """Registrations beyond SYSTEM.max_tracked_tickers are dropped, not appended (API-1)."""
+    monkeypatch.setattr(pipeline_module, "SYSTEM", dataclasses.replace(SYSTEM, max_tracked_tickers=3))
+    pipeline = MFTDataPipeline([])
+    pipeline.register_tickers(["AAPL", "MSFT", "TSLA", "NVDA", "GOOGL"])
+    assert pipeline.tickers == ["AAPL", "MSFT", "TSLA"]
+
+    pipeline.register_tickers(["NVDA"])
+    assert pipeline.tickers == ["AAPL", "MSFT", "TSLA"]
+
+
+def test_init_routes_initial_universe_through_register_tickers(monkeypatch):
+    """A malformed ticker in the constructor's initial universe is dropped, not stored raw."""
+    monkeypatch.setattr(pipeline_module, "SYSTEM", dataclasses.replace(SYSTEM, max_tracked_tickers=2))
+    pipeline = MFTDataPipeline(["AAPL", "not-a-ticker!", "MSFT", "TSLA"])
+    assert pipeline.tickers == ["AAPL", "MSFT"]
 
 
 def test_compress_candles():
@@ -312,7 +338,7 @@ async def test_sweep_uses_a_constant_inter_request_gap_independent_of_universe_s
     await small._sweep_once()
     small_elapsed = time.monotonic() - small_start
 
-    big = MFTDataPipeline([f"T{i}" for i in range(20)], interval="1m")
+    big = MFTDataPipeline([f"T{chr(65 + i)}" for i in range(20)], interval="1m")
     monkeypatch.setattr(big, "_fetch_one_ticker", fake_fetch_one)
     big_start = time.monotonic()
     await big._sweep_once()

--- a/tests/test_tickers.py
+++ b/tests/test_tickers.py
@@ -1,0 +1,52 @@
+"""
+tests/test_tickers.py
+
+Tests for argus/data/tickers.py's is_valid_ticker, the shared validator
+behind AnalysisRequest and MFTDataPipeline.register_tickers (PR5a, API-1).
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from argus.data.tickers import is_valid_ticker
+
+_REPRO_REJECTIONS = [
+    "",
+    "A" * 500,
+    "'; DROP TABLE ohlcv; --",
+    "../../etc/passwd",
+    "AAPLLL",
+    ".B",
+    "AAPL.",
+]
+
+
+@given(st.sampled_from(_REPRO_REJECTIONS))
+def test_rejects_the_repro_set(ticker):
+    """Every string from the audit's hostile-ticker repro set is rejected."""
+    assert not is_valid_ticker(ticker)
+
+
+_ACCEPTED = [
+    "AAPL", "MSFT", "BRK.B", "BRK-B", "BF-B", "F", "T", "V", "UNH", "GOOGL",
+]
+
+
+@given(st.sampled_from(_ACCEPTED))
+def test_accepts_the_class_share_set(ticker):
+    """Plain tickers and dotted/hyphenated share-class symbols are accepted."""
+    assert is_valid_ticker(ticker)
+
+
+@given(st.sampled_from(["^GSPC", "^DJI", "BTC-USD", "ETH-USD"]))
+def test_rejects_indices_and_crypto_pairs(ticker):
+    """Indices and crypto pairs are deliberately excluded: no GICS sector or financials."""
+    assert not is_valid_ticker(ticker)
+
+
+@given(st.text(alphabet=" '\"/\x00", min_size=1, max_size=10))
+def test_rejects_any_string_with_whitespace_quote_slash_or_nul(s):
+    """Any string built only from whitespace, quote, slash, or NUL characters is rejected."""
+    assert not is_valid_ticker(s)


### PR DESCRIPTION
## Summary

PR5a of issue #41's remediation plan (API-1, API-6 gateway half, API-7). Parallelizable with PR1-PR4, all now merged.

- **Ticker validation (API-1).** `argus/data/tickers.py` defines the accepted symbol shape (`^[A-Z]{1,5}(?:[.-][A-Z]{1,2})?$`) — 1-5 letter root plus an optional share-class suffix (`BRK.B`, `BRK-B`), excluding index (`^GSPC`) and crypto-pair (`BTC-USD`) forms. `AnalysisRequest.tickers` strips, upper-cases, validates, and dedupes every entry, which also fixes API-6's gateway half.
- **Universe cap (API-1).** `MFTDataPipeline.register_tickers` is now the single enforcement point for both the ticker-shape invariant and a new `SYSTEM.max_tracked_tickers` cap (default 100) — `__init__` routes its initial universe through it too, so `run_collection_cycle`, `collect_session.py --universe`, and `settings.ARGUS_UNIVERSE` all get the same guard pydantic only covers for `/analyze`.
- **Error redaction (API-7).** `/analyze`'s catch-all exception handler now logs the full exception under a `uuid4` correlation ref and returns only `f"Agent graph error (ref {ref})"` to the client, instead of the raw exception text (which could carry API keys or filesystem paths).

## Test plan
- [x] `ruff check .`
- [x] `mypy argus/`
- [x] `pytest tests/ -v` (358 passed)
- [x] Parameterized rejection over the audit's hostile-ticker repro set, plus indices/crypto and the class-share accept set (`tests/test_tickers.py`, `tests/test_api_validation.py`)
- [x] `register_tickers` rejects malformed symbols and caps the universe (`tests/test_pipeline.py`)
- [x] A redacted 500 body carries the ref and none of the underlying exception text (`tests/test_api_validation.py`)