### PR TITLE
PR5b: /analyze concurrency and process safety

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -19,6 +19,8 @@ Responsibilities:
   - Optionally run the unattended collector and daily reconciliation loops
     (ARGUS_COLLECTOR_ENABLED / ARGUS_RECONCILE_ENABLED) so the system keeps
     accumulating decisions and outcomes without a human calling /analyze
+  - Serialize graph invocations across /analyze and the collector loop, and
+    guard against a second process sharing this one's data directory
 
 Not responsible for:
   - Agent logic (see argus/agents/)
@@ -27,11 +29,14 @@ Not responsible for:
 """
 
 import asyncio
+import fcntl
 import logging
+import os
 import sys
 from contextlib import asynccontextmanager, suppress
 from dataclasses import asdict
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Literal, Optional
 from uuid import uuid4
 from zoneinfo import ZoneInfo
@@ -55,7 +60,7 @@ from argus.orchestration.governor import REGISTERED_MODELS, RateLimitExceeded, U
 from argus.orchestration.graph import build_graph
 from argus.orchestration.reconciliation import load_decisions_from_jsonl, reconcile_decisions
 from argus.orchestration.state import ARGUSState
-from argus.params import RECONCILIATION
+from argus.params import RECONCILIATION, SYSTEM
 from argus.risk import paper_book
 from argus.risk.kill_switch import get_kill_switch, initialize_kill_switch
 from argus.seams import LiveMarketDataProvider
@@ -73,6 +78,16 @@ _pipeline_task: asyncio.Task | None = None
 _collector_task: asyncio.Task | None = None
 _reconcile_task: asyncio.Task | None = None
 _last_collection_result: CollectionResult | None = None
+
+# Serializes graph invocations across /analyze and the unattended collector
+# loop (API-3) — both call the same governor-gated graph, and a second
+# concurrent run only pushes both toward RateLimitExceeded rather than adding
+# real throughput. Held only around the graph invoke itself.
+_analyze_semaphore = asyncio.Semaphore(1)
+
+# Holds the open file object backing the process-exclusivity flock (API-2) for
+# as long as this process runs; garbage-collecting it would release the lock
+_process_lock_file = None
 
 # Built once in lifespan startup, pointed at the same persistent checkpoint
 # path the collector loop uses, so /analyze and the unattended collector
@@ -99,6 +114,16 @@ async def _mft_session_callback(session_states: dict) -> None:
     now = datetime.now()
     for ticker, state in session_states.items():
         _live_session_cache[ticker] = (state, now)
+
+    # Drops entries for tickers no longer tracked (API-9) — without this the
+    # cache only ever grows, holding a stale allocation-eligible entry for any
+    # ticker that was ever registered even after it stops being tracked
+    if _mft_pipeline is not None:
+        tracked = set(_mft_pipeline.tickers)
+        for ticker in list(_live_session_cache):
+            if ticker not in tracked:
+                del _live_session_cache[ticker]
+
     logger.info("[MFT] Live session cache updated: %d ticker(s)", len(_live_session_cache))
 
 
@@ -142,6 +167,7 @@ async def _collector_loop(pipeline: MFTDataPipeline, compiled_graph) -> None:
                 pipeline=pipeline,
                 compiled_graph=compiled_graph,
                 decisions_log_path=f"{settings.ARGUS_DATA_DIR}/decisions.jsonl",
+                analyze_lock=_analyze_semaphore,
             )
             logger.info("[Collector] cycle result: %s", _last_collection_result)
         except Exception:
@@ -206,7 +232,7 @@ async def _reconcile_loop() -> None:
 
 
 def _assert_single_worker() -> None:
-    """Fails fast if launched with more than one uvicorn worker.
+    """Fails fast on the two argv/env spellings of "more than one worker" this can detect.
 
     The rate governor and kill switch are in-process singletons (see
     argus/orchestration/governor.py). A second worker process would run its
@@ -216,8 +242,16 @@ def _assert_single_worker() -> None:
     independent governor against that same key, and this assertion exists so
     a deployment doesn't add a third by accident. See Dockerfile.api's CMD.
 
+    This is a best-effort pre-flight only, not the real guard: it can't see
+    gunicorn's `-w`, a gunicorn config file, or a programmatic
+    `uvicorn.run(workers=N)`. `_acquire_process_lock` (API-2) is what actually
+    catches those, and the case that costs real money — two containers on one
+    data volume — which no argv/env spelling of "workers" describes at all.
+
     Raises:
-        RuntimeError: If ``--workers`` appears in argv with a value other than "1".
+        RuntimeError: If ``--workers``/``--workers=N`` in argv, or
+            ``WEB_CONCURRENCY`` in the environment, requests a value other
+            than "1".
     """
     argv = sys.argv
     if "--workers" in argv:
@@ -227,6 +261,52 @@ def _assert_single_worker() -> None:
                 f"ARGUS must run with --workers 1 (in-process governor/kill-switch "
                 f"singletons); got --workers {argv[idx + 1]}"
             )
+    for arg in argv:
+        if arg.startswith("--workers=") and arg.removeprefix("--workers=") != "1":
+            raise RuntimeError(
+                f"ARGUS must run with --workers 1 (in-process governor/kill-switch "
+                f"singletons); got {arg}"
+            )
+
+    web_concurrency = os.environ.get("WEB_CONCURRENCY")
+    if web_concurrency is not None and web_concurrency != "1":
+        raise RuntimeError(
+            f"ARGUS must run with WEB_CONCURRENCY=1 (in-process governor/kill-switch "
+            f"singletons); got WEB_CONCURRENCY={web_concurrency}"
+        )
+
+
+def _acquire_process_lock() -> None:
+    """Takes an exclusive, non-blocking flock on ``${ARGUS_DATA_DIR}/argus.lock`` (API-2).
+
+    This is the real single-process guard, unlike `_assert_single_worker`'s
+    argv/env pre-flight: it catches every way two ARGUS processes could end up
+    sharing one data directory — including two whole containers — not just
+    the worker-count spellings that pre-flight can parse. Note this only runs
+    during lifespan startup, so ``uvicorn --reload``'s parent process (which
+    doesn't run lifespan) is not itself protected; the reloaded child is.
+    Scoping the lock file to ``ARGUS_DATA_DIR`` also correctly leaves
+    ``scripts/collect_session.py``'s GitHub Actions runner unblocked — it
+    writes to its own runner-local directory, not this deployment's, and is
+    already an accepted second governor/kill-switch process (see
+    ``argus/orchestration/collector.py``'s module docstring).
+
+    Raises:
+        RuntimeError: If another process already holds the lock.
+    """
+    global _process_lock_file
+    lock_path = Path(settings.ARGUS_DATA_DIR) / "argus.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = open(lock_path, "w")
+    try:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        lock_file.close()
+        raise RuntimeError(
+            f"Another ARGUS process already holds {lock_path} — refusing to start a "
+            f"second process against the same data directory."
+        ) from exc
+    _process_lock_file = lock_file
 
 
 def _assert_registered_models() -> None:
@@ -256,6 +336,7 @@ async def lifespan(app: FastAPI):
 
     _assert_single_worker()
     _assert_registered_models()
+    _acquire_process_lock()
 
     _graph = build_graph(checkpoint_db_path=f"{settings.ARGUS_DATA_DIR}/argus_graph.db")
 
@@ -330,6 +411,11 @@ async def lifespan(app: FastAPI):
 
     if _mft_pipeline is not None:
         _mft_pipeline.buffer.close()
+
+    if _process_lock_file is not None:
+        fcntl.flock(_process_lock_file, fcntl.LOCK_UN)
+        _process_lock_file.close()
+
     logger.info("[Shutdown] Complete.")
 
 
@@ -498,8 +584,11 @@ async def analyze(req: AnalysisRequest):
     Raises:
         HTTPException 401: If ARGUS_API_KEY is set and the X-API-Key header doesn't match.
         HTTPException 429: If the governor's rate budget is exhausted for a
-            configured model (GOV-7) — retry after a short wait.
-        HTTPException 503: If the kill switch is triggered, VIX is above the blackout
+            configured model (GOV-7), or another analysis (a concurrent
+            /analyze call or the unattended collector) is already in progress
+            (API-3) — retry after a short wait.
+        HTTPException 503: If the graph hasn't finished initializing, the kill switch
+            is triggered (before or after the graph run), VIX is above the blackout
             threshold, the market is currently closed, the MFT cache has not yet
             been populated for all requested tickers, the cache hasn't been
             refreshed recently (pipeline stalled), the cached bars are older
@@ -597,10 +686,24 @@ async def analyze(req: AnalysisRequest):
         errors=[],
     )
 
+    if _graph is None:
+        raise HTTPException(503, "Agent graph not yet initialized.")
+
     config = {"configurable": {"thread_id": str(uuid4())}}
 
+    # No await between this check and the acquire below, so nothing can slip
+    # in between them (API-3) — Semaphore.acquire returns synchronously when
+    # unlocked, and a later refactor that inserts an await here breaks that.
+    if _analyze_semaphore.locked():
+        raise HTTPException(
+            429,
+            "Another analysis is already in progress. Retry shortly.",
+            headers={"Retry-After": str(SYSTEM.analyze_retry_after_seconds)},
+        )
+
     try:
-        final_state = await asyncio.to_thread(_graph.invoke, state, config)
+        async with _analyze_semaphore:
+            final_state = await asyncio.to_thread(_graph.invoke, state, config)
     except RateLimitExceeded as e:
         logger.warning("[API] Governor rate limit exhausted: %s", e)
         raise HTTPException(429, f"Rate limit exhausted: {e}")
@@ -611,6 +714,15 @@ async def analyze(req: AnalysisRequest):
         ref = uuid4()
         logger.error("[API] Graph error (ref %s): %s", ref, e, exc_info=True)
         raise HTTPException(500, f"Agent graph error (ref {ref})")
+
+    # Re-checked rather than trusted from before the (potentially many-second)
+    # graph run: the kill switch is process-global and the reconcile loop can
+    # trip it mid-run (API-8)
+    ks = get_kill_switch()
+    if ks and ks.is_halted:
+        raise HTTPException(
+            503, "System halted during analysis. Kill switch triggered. Manual reset required."
+        )
 
     allocation = final_state.get("portfolio_allocation")
     if not allocation:

--- a/argus/data/cache.py
+++ b/argus/data/cache.py
@@ -258,6 +258,33 @@ class OHLCVBuffer:
             rows = self._conn.execute(_SELECT_TICKERS, (self._interval,)).fetchall()
         return [r[0] for r in rows]
 
+    def prune_untracked(self, tracked_tickers: set[str]) -> int:
+        """Deletes every row for a ticker outside the given tracked set (API-9/API-10).
+
+        Without this, a ticker fetched once (e.g. a one-off `/analyze` request)
+        keeps being swept and compressed forever, since `compress_all` used to
+        iterate every ticker ever inserted rather than the tracked universe.
+
+        Args:
+            tracked_tickers: Tickers that should be retained; empty is treated
+                as "unknown universe" and skipped rather than wiping the buffer.
+
+        Returns:
+            Row count deleted.
+        """
+        if not tracked_tickers:
+            return 0
+        tracked = {t.upper() for t in tracked_tickers}
+        placeholders = ",".join("?" for _ in tracked)
+        with self._lock:
+            cursor = self._conn.execute(
+                f"DELETE FROM ohlcv WHERE ticker NOT IN ({placeholders})", tuple(tracked)
+            )
+            self._conn.commit()
+        if cursor.rowcount:
+            logger.info("OHLCVBuffer.prune_untracked: discarded %d row(s)", cursor.rowcount)
+        return cursor.rowcount
+
     def row_counts(self) -> dict[str, int]:
         """Returns each tracked ticker's row count without materializing its candle frame.
 

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -562,6 +562,11 @@ class MFTDataPipeline:
         dict" mean the same thing as "usable" to a caller that never learns
         what an indicator is.
 
+        Only iterates tickers still in `self.tickers` (API-10) — the buffer
+        can otherwise hold rows for a ticker fetched once by a past `/analyze`
+        request and never tracked again. Also prunes the buffer of any such
+        untracked rows (API-9's underlying leak), at this method's cadence.
+
         Returns:
             Mapping of ticker → technical feature dict (rsi_14, macd_histogram, etc.).
             Tickers below the readiness floor, or that failed compression,
@@ -569,7 +574,8 @@ class MFTDataPipeline:
         """
         states: dict[str, dict] = {}
         required_raw = _required_raw_bars(self.interval_minutes)
-        for ticker in self.buffer.get_all_tickers():
+        tracked = set(self.tickers)
+        for ticker in tracked & set(self.buffer.get_all_tickers()):
             try:
                 df = self.buffer.get_candles(ticker)
                 if df is None or len(df) < required_raw:
@@ -593,6 +599,7 @@ class MFTDataPipeline:
                     type(exc).__name__,
                     exc,
                 )
+        self.buffer.prune_untracked(tracked)
         logger.info("compress_all: %d tickers compressed", len(states))
         return states
 

--- a/argus/orchestration/collector.py
+++ b/argus/orchestration/collector.py
@@ -85,6 +85,7 @@ async def run_collection_cycle(
     pipeline: MFTDataPipeline,
     compiled_graph,
     decisions_log_path: str = "data/decisions.jsonl",
+    analyze_lock: asyncio.Semaphore | None = None,
 ) -> CollectionResult:
     """Runs one unattended fetch → analyze → log cycle for the given universe.
 
@@ -118,6 +119,14 @@ async def run_collection_cycle(
             still opens its own checkpoint connection — see
             graph.py's ``_CheckpointedGraph``.
         decisions_log_path: JSONL file each cycle's decisions are appended to.
+        analyze_lock: The same semaphore api/main.py's `/analyze` guards its
+            graph invocation with (API-3) — the collector is a third caller of
+            the same graph and governor, so it shares the slot rather than
+            invoking concurrently with a live `/analyze` run. It skips rather
+            than waits: an unattended cycle has nowhere to be on time, so
+            blocking it against a slow foreground request buys nothing.
+            None for a standalone caller with no `/analyze` to coordinate
+            with (scripts/collect_session.py's one-shot Actions runner).
 
     Returns:
         A CollectionResult summarizing what happened.
@@ -159,6 +168,11 @@ async def run_collection_cycle(
         errors=[],
     )
 
+    if analyze_lock is not None and analyze_lock.locked():
+        reason = "analysis already in progress"
+        logger.info("run_collection_cycle: skipping graph invocation — %s", reason)
+        return CollectionResult(ran=False, reason=reason)
+
     config = {"configurable": {"thread_id": f"collector-{datetime.now().strftime('%Y%m%d%H%M%S')}"}}
 
     logger.info(
@@ -167,8 +181,14 @@ async def run_collection_cycle(
         len(universe),
     )
     # SqliteSaver checkpoints synchronously (see graph.py's module docstring), so
-    # invoke() blocks — run it off the event loop rather than stalling this coroutine
-    final_state = await asyncio.to_thread(compiled_graph.invoke, state, config)
+    # invoke() blocks — run it off the event loop rather than stalling this coroutine.
+    # No await between the locked() check above and this acquire (API-3's race-free
+    # pattern), so a concurrent /analyze can't slip in between the check and the hold.
+    if analyze_lock is not None:
+        async with analyze_lock:
+            final_state = await asyncio.to_thread(compiled_graph.invoke, state, config)
+    else:
+        final_state = await asyncio.to_thread(compiled_graph.invoke, state, config)
 
     decisions: list[ARGUSDecision] = final_state.get("decisions") or []
     logged = _append_decisions_jsonl(decisions, decisions_log_path)

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 11
+PARAMS_VERSION = 12
 
 
 class Provenance(str, Enum):
@@ -115,6 +115,12 @@ class SystemParams:
         "ceiling on MFTDataPipeline.tickers enforced in register_tickers; stops "
         "unbounded universe growth from repeated /analyze requests (API-1) — not "
         "evaluated against alternatives",
+    )
+    analyze_retry_after_seconds: int = p(
+        5,
+        Provenance.ARBITRARY,
+        "Retry-After header value on /analyze's 429 when a run is already in "
+        "progress; a guess at a graph run's typical duration, not measured",
     )
 
 

--- a/tests/test_api_concurrency.py
+++ b/tests/test_api_concurrency.py
@@ -1,0 +1,166 @@
+"""
+tests/test_api_concurrency.py
+
+Tests for PR5b's /analyze concurrency and process-safety additions:
+  - API-3: a semaphore of 1 around the graph invocation, 429 + Retry-After
+    when a run is already in progress, released even when the graph raises
+  - API-8: the kill switch is re-checked after the graph returns, not just
+    before it
+  - the graph-not-yet-initialized guard (`_graph is None` -> 503)
+  - API-9: `_mft_session_callback` evicts live-cache entries for tickers no
+    longer tracked
+
+These exercise the route function and callback directly via FastAPI's
+TestClient / a bare coroutine call rather than going through the app's
+lifespan, so no MFT pipeline, collector, or reconcile loop needs to start.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest import mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api.main as api_main
+import argus.risk.kill_switch as kill_switch_module
+from argus.risk.kill_switch import KillSwitch
+
+_PAYLOAD = {"tickers": ["AAPL"], "total_wealth": 100_000, "invest_pct": 0.5}
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons(monkeypatch):
+    """Clears the kill-switch singleton and live session cache around each test."""
+    kill_switch_module._kill_switch = None
+    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    monkeypatch.setattr(api_main.settings, "ARGUS_API_KEY", "")
+    monkeypatch.setattr(api_main, "_analyze_semaphore", asyncio.Semaphore(1))
+    yield
+    kill_switch_module._kill_switch = None
+
+
+@pytest.fixture
+def client():
+    """A TestClient over api.main.app without running its lifespan startup."""
+    return TestClient(api_main.app)
+
+
+def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
+    """Installs a fake MFTDataPipeline as the module-level `_mft_pipeline`."""
+    fake = mock.Mock()
+    fake.is_market_hours.return_value = market_hours
+    fake.interval_minutes = interval_minutes
+    monkeypatch.setattr(api_main, "_mft_pipeline", fake)
+    return fake
+
+
+def _seed_cache(ticker: str, *, bar_age_seconds: float, write_age_seconds: float = 0.0):
+    """Populates `_live_session_cache` with a state whose bar and write times are both controlled."""
+    bar_ts = datetime.now(api_main._ET) - timedelta(seconds=bar_age_seconds)
+    write_ts = datetime.now() - timedelta(seconds=write_age_seconds)
+    api_main._live_session_cache[ticker] = ({"timestamp": bar_ts.isoformat()}, write_ts)
+
+
+def _ready(client, monkeypatch):
+    """Clears every freshness gate ahead of /analyze so a request reaches the graph."""
+    _pipeline(monkeypatch, market_hours=True)
+    _seed_cache("AAPL", bar_age_seconds=5, write_age_seconds=5)
+
+
+# ---------------------------------------------------------------------------
+# API-3: semaphore
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_rejects_a_concurrent_run_with_429(client, monkeypatch):
+    """A held semaphore is reported as 429 with a Retry-After header, not run against the graph."""
+    _ready(client, monkeypatch)
+    fake_graph = mock.Mock()
+    fake_graph.invoke.side_effect = AssertionError("must not run while another analysis holds the slot")
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    held = mock.Mock()
+    held.locked.return_value = True
+    monkeypatch.setattr(api_main, "_analyze_semaphore", held)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"]
+    fake_graph.invoke.assert_not_called()
+
+
+def test_analyze_releases_the_semaphore_when_the_graph_raises(client, monkeypatch):
+    """The slot is released on a graph exception, not just on success — easy to wedge permanently."""
+    _ready(client, monkeypatch)
+    fake_graph = mock.Mock()
+    fake_graph.invoke.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 500
+    assert not api_main._analyze_semaphore.locked()
+
+
+# ---------------------------------------------------------------------------
+# Graph-not-initialized guard
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_rejects_when_graph_not_yet_initialized(client, monkeypatch):
+    """A None _graph (before lifespan startup finishes) is a 503, not an AttributeError."""
+    _ready(client, monkeypatch)
+    monkeypatch.setattr(api_main, "_graph", None)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 503
+    assert "graph" in response.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# API-8: kill switch re-checked after the graph returns
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_rejects_when_kill_switch_trips_during_the_graph_run(client, monkeypatch):
+    """A halt that lands while the graph is running is caught after invoke() returns, not missed."""
+    _ready(client, monkeypatch)
+    ks = KillSwitch("MODERATE")
+    kill_switch_module._kill_switch = ks
+
+    def _trip_and_return(*args, **kwargs):
+        ks._halted.set()
+        return {"portfolio_allocation": None, "errors": []}
+
+    fake_graph = mock.Mock()
+    fake_graph.invoke.side_effect = _trip_and_return
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 503
+    assert "halted" in response.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# API-9: live cache eviction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mft_session_callback_evicts_untracked_tickers(monkeypatch):
+    """A ticker that dropped out of the tracked universe is dropped from the live cache too."""
+    fake_pipeline = mock.Mock()
+    fake_pipeline.tickers = ["AAPL"]
+    monkeypatch.setattr(api_main, "_mft_pipeline", fake_pipeline)
+    api_main._live_session_cache["MSFT"] = ({"timestamp": "stale"}, datetime.now())
+
+    await api_main._mft_session_callback({"AAPL": {"timestamp": "2024-01-02T09:30:00-05:00"}})
+
+    assert "MSFT" not in api_main._live_session_cache
+    assert "AAPL" in api_main._live_session_cache

--- a/tests/test_api_startup.py
+++ b/tests/test_api_startup.py
@@ -5,9 +5,15 @@ Tests for api/main.py's PR3 boot-time assertions: the single-worker invariant
 (GOV-8) and the configured-model registration check (GOV-11). Both run pure
 sys.argv/settings checks, so they're exercised directly rather than through
 the app's lifespan.
+
+Also covers PR5b's API-2 additions: `_assert_single_worker`'s extension to
+`--workers=N` and `WEB_CONCURRENCY`, and `_acquire_process_lock`'s real
+cross-process guard (an exclusive flock on `${ARGUS_DATA_DIR}/argus.lock`).
 """
 
 from __future__ import annotations
+
+import fcntl
 
 import pytest
 
@@ -43,3 +49,64 @@ def test_assert_registered_models_rejects_unregistered_model(monkeypatch):
     monkeypatch.setattr(api_main.settings, "ARGUS_SENTIMENT_MODEL", "not-a-real-model")
     with pytest.raises(api_main.UnregisteredModel):
         api_main._assert_registered_models()
+
+
+def test_assert_single_worker_allows_explicit_one_equals_form(monkeypatch):
+    """--workers=1 passes, the equals-sign spelling of the space-separated form."""
+    monkeypatch.setattr(api_main.sys, "argv", ["uvicorn", "api.main:app", "--workers=1"])
+    api_main._assert_single_worker()
+
+
+def test_assert_single_worker_rejects_multiple_equals_form(monkeypatch):
+    """--workers=4 raises just like the space-separated --workers 4 does."""
+    monkeypatch.setattr(api_main.sys, "argv", ["uvicorn", "api.main:app", "--workers=4"])
+    with pytest.raises(RuntimeError):
+        api_main._assert_single_worker()
+
+
+def test_assert_single_worker_allows_web_concurrency_one(monkeypatch):
+    """WEB_CONCURRENCY=1 in the environment passes."""
+    monkeypatch.setattr(api_main.sys, "argv", ["uvicorn", "api.main:app"])
+    monkeypatch.setenv("WEB_CONCURRENCY", "1")
+    api_main._assert_single_worker()
+
+
+def test_assert_single_worker_rejects_web_concurrency_above_one(monkeypatch):
+    """WEB_CONCURRENCY=4 is a fourth bypass of the single-worker invariant argv alone can't see."""
+    monkeypatch.setattr(api_main.sys, "argv", ["uvicorn", "api.main:app"])
+    monkeypatch.setenv("WEB_CONCURRENCY", "4")
+    with pytest.raises(RuntimeError):
+        api_main._assert_single_worker()
+
+
+def test_acquire_process_lock_succeeds_and_creates_the_lock_file(monkeypatch, tmp_path):
+    """A clean data directory gets an exclusive lock file created under it."""
+    monkeypatch.setattr(api_main.settings, "ARGUS_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(api_main, "_process_lock_file", None)
+
+    api_main._acquire_process_lock()
+
+    assert (tmp_path / "argus.lock").exists()
+    assert api_main._process_lock_file is not None
+    fcntl.flock(api_main._process_lock_file, fcntl.LOCK_UN)
+    api_main._process_lock_file.close()
+    api_main._process_lock_file = None
+
+
+def test_acquire_process_lock_rejects_a_second_holder(monkeypatch, tmp_path):
+    """A second process (simulated: a second fd) can't also acquire the same lock file."""
+    monkeypatch.setattr(api_main.settings, "ARGUS_DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(api_main, "_process_lock_file", None)
+
+    lock_path = tmp_path / "argus.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    other_fd = open(lock_path, "w")
+    fcntl.flock(other_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    try:
+        with pytest.raises(RuntimeError):
+            api_main._acquire_process_lock()
+    finally:
+        fcntl.flock(other_fd, fcntl.LOCK_UN)
+        other_fd.close()
+        api_main._process_lock_file = None

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -235,6 +235,40 @@ def test_row_counts_returns_per_ticker_counts_without_the_get_candles_floor():
     assert buffer.row_counts() == {"AAPL": 5, "MSFT": 20}
 
 
+def test_prune_untracked_deletes_rows_outside_the_given_set():
+    """prune_untracked removes every row for a ticker not in the tracked set (API-9/API-10)."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=50, interval="1m")
+    buffer.insert_candle("AAPL", {"timestamp": "2024-01-02T09:30:00", "close": 1.0})
+    buffer.insert_candle("ORPHAN", {"timestamp": "2024-01-02T09:30:00", "close": 1.0})
+
+    deleted = buffer.prune_untracked({"AAPL"})
+
+    assert deleted == 1
+    assert buffer.get_all_tickers() == ["AAPL"]
+
+
+def test_prune_untracked_is_case_insensitive():
+    """A lowercase tracked-set entry still matches the upper-cased stored ticker."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=50, interval="1m")
+    buffer.insert_candle("AAPL", {"timestamp": "2024-01-02T09:30:00", "close": 1.0})
+
+    deleted = buffer.prune_untracked({"aapl"})
+
+    assert deleted == 0
+    assert buffer.get_all_tickers() == ["AAPL"]
+
+
+def test_prune_untracked_skips_an_empty_tracked_set():
+    """An empty tracked set is treated as 'unknown universe' rather than wiping the buffer."""
+    buffer = OHLCVBuffer(db_path=":memory:", buffer_size=50, interval="1m")
+    buffer.insert_candle("AAPL", {"timestamp": "2024-01-02T09:30:00", "close": 1.0})
+
+    deleted = buffer.prune_untracked(set())
+
+    assert deleted == 0
+    assert buffer.get_all_tickers() == ["AAPL"]
+
+
 def test_interval_change_logs_the_discarded_count(tmp_path, caplog):
     """The interval-change purge logs how many stale rows it discarded, at WARNING."""
     db_path = str(tmp_path / "buffer.db")

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1,0 +1,97 @@
+"""
+tests/test_collector.py
+
+Tests for argus/orchestration/collector.py's `analyze_lock` parameter (PR5b,
+API-3): the unattended collector shares /analyze's concurrency slot rather
+than invoking the graph alongside a live /analyze run, and skips rather than
+waits when the slot is already held.
+
+Not responsible for:
+  - The kill-switch gate (KS-2), covered in tests/test_kill_switch.py's
+    "Collector gate" section
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from argus.orchestration.collector import run_collection_cycle
+
+
+def _pipeline(session_states: dict) -> mock.Mock:
+    """Builds a fake MFTDataPipeline whose run_once() returns the given session states."""
+    pipeline = mock.Mock()
+    pipeline.run_once = mock.AsyncMock(return_value=session_states)
+    return pipeline
+
+
+def _graph() -> mock.Mock:
+    """Builds a fake compiled graph whose invoke() returns a minimal final_state dict."""
+    graph = mock.Mock()
+    graph.invoke = mock.Mock(return_value={"decisions": [], "errors": [], "macro_context": None})
+    return graph
+
+
+@pytest.mark.asyncio
+async def test_run_collection_cycle_skips_when_analyze_lock_is_held():
+    """A held analyze_lock makes the collector skip rather than invoke the graph."""
+    lock = asyncio.Semaphore(1)
+    await lock.acquire()
+    graph = _graph()
+    graph.invoke.side_effect = AssertionError("must not run while /analyze holds the lock")
+
+    result = await run_collection_cycle(
+        universe=["AAPL"],
+        total_wealth=100_000.0,
+        invest_pct=0.5,
+        risk_tolerance="MODERATE",
+        pipeline=_pipeline({"AAPL": {"timestamp": "2024-01-02T09:30:00-05:00"}}),
+        compiled_graph=graph,
+        analyze_lock=lock,
+    )
+
+    assert result.ran is False
+    assert "already in progress" in result.reason
+    graph.invoke.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_collection_cycle_runs_when_analyze_lock_is_free():
+    """A free analyze_lock lets the collector acquire it and invoke the graph normally."""
+    lock = asyncio.Semaphore(1)
+    graph = _graph()
+
+    result = await run_collection_cycle(
+        universe=["AAPL"],
+        total_wealth=100_000.0,
+        invest_pct=0.5,
+        risk_tolerance="MODERATE",
+        pipeline=_pipeline({"AAPL": {"timestamp": "2024-01-02T09:30:00-05:00"}}),
+        compiled_graph=graph,
+        analyze_lock=lock,
+    )
+
+    assert result.ran is True
+    graph.invoke.assert_called_once()
+    assert not lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_run_collection_cycle_runs_unguarded_when_analyze_lock_is_none():
+    """No analyze_lock (scripts/collect_session.py's standalone caller) runs unguarded."""
+    graph = _graph()
+
+    result = await run_collection_cycle(
+        universe=["AAPL"],
+        total_wealth=100_000.0,
+        invest_pct=0.5,
+        risk_tolerance="MODERATE",
+        pipeline=_pipeline({"AAPL": {"timestamp": "2024-01-02T09:30:00-05:00"}}),
+        compiled_graph=graph,
+    )
+
+    assert result.ran is True
+    graph.invoke.assert_called_once()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -469,7 +469,7 @@ def _seed_two_session_buffer(
 
 def test_compress_all_skips_a_ticker_whose_get_candles_raises(monkeypatch):
     """compress_all catches a get_candles failure for one ticker and still returns the rest."""
-    pipeline = MFTDataPipeline([], interval="1m")
+    pipeline = MFTDataPipeline(["BAD", "GOOD"], interval="1m")
     _seed_two_session_buffer(pipeline, "GOOD")
 
     real_get_candles = pipeline.buffer.get_candles
@@ -488,9 +488,33 @@ def test_compress_all_skips_a_ticker_whose_get_candles_raises(monkeypatch):
     assert "BAD" not in states
 
 
+def test_compress_all_ignores_an_untracked_ticker(monkeypatch):
+    """compress_all only considers tickers still in self.tickers (API-10)."""
+    pipeline = MFTDataPipeline(["GOOD"], interval="1m")
+    _seed_two_session_buffer(pipeline, "GOOD")
+    _seed_two_session_buffer(pipeline, "ORPHAN")
+
+    states = pipeline.compress_all()
+
+    assert "GOOD" in states
+    assert "ORPHAN" not in states
+
+
+def test_compress_all_prunes_untracked_buffer_rows():
+    """compress_all deletes buffered rows for a ticker no longer in self.tickers (API-9)."""
+    pipeline = MFTDataPipeline(["GOOD"], interval="1m")
+    _seed_two_session_buffer(pipeline, "GOOD")
+    _seed_two_session_buffer(pipeline, "ORPHAN")
+
+    pipeline.compress_all()
+
+    assert "ORPHAN" not in pipeline.buffer.get_all_tickers()
+    assert "GOOD" in pipeline.buffer.get_all_tickers()
+
+
 def test_compress_all_skips_a_ticker_below_the_readiness_floor():
     """compress_all omits a ticker whose buffered bars don't clear the resampled MACD warmup floor."""
-    pipeline = MFTDataPipeline([], interval="1m")
+    pipeline = MFTDataPipeline(["COLD"], interval="1m")
     # 20 raw bars clear OHLCVBuffer's own 14-row floor but fall far short of
     # _required_raw_bars(1) == 391
     _seed_buffer(pipeline, "COLD", n=20)


### PR DESCRIPTION
Closes the last PR (PR5b) of #41's remediation plan: API-3, API-2, API-8, API-9, API-10.

## Summary
- `/analyze` and the unattended collector share a semaphore of 1 around the graph invocation (API-3): a concurrent request gets `429` + `Retry-After` instead of both callers racing the same governor; the collector checks the slot and skips rather than waits.
- `${ARGUS_DATA_DIR}/argus.lock` is taken as an exclusive, non-blocking `flock` during lifespan startup (API-2) — the real cross-process guard, since `--workers`/`WEB_CONCURRENCY`/gunicorn `-w`/two containers are five different spellings argv parsing can't all see. The existing argv pre-flight is kept and extended to `--workers=N` and `WEB_CONCURRENCY`.
- The kill switch is re-checked after the graph returns, not just before it (API-8) — a multi-second run can be halted mid-flight by the reconcile loop.
- `compress_all` only iterates `self.tickers`, not every ticker ever inserted into the buffer, and prunes buffer rows for anything outside that set at its own cadence (API-10). The live session cache drops entries for untracked tickers on the same cadence (API-9).

## Test plan
- [x] `pytest tests/ -q` — 377 passed (358 baseline + 19 new)
- [x] `ruff check .`
- [x] `mypy argus/` clean; `mypy api/ scripts/` carries the same 3 pre-existing, unrelated errors in `scripts/remediate_macro_regime_tags.py`