### PR TITLE
Observability: make the process report what it is doing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -231,6 +231,24 @@ async def _reconcile_loop() -> None:
             logger.exception("[Reconcile] cycle failed")
 
 
+def _configure_logging() -> None:
+    """Attaches a stream handler to the ``argus`` logger tree so ARGUS_LOG_LEVEL takes effect (OBS-1).
+
+    Under uvicorn the root logger has no handlers at level WARNING, so every
+    argus.* `logger.info`/`debug` call is silently dropped and
+    ARGUS_LOG_LEVEL is inert. `propagate = False` stops uvicorn's own
+    logging config from resetting this. Idempotent, so re-running lifespan
+    (e.g. across tests) doesn't stack duplicate handlers.
+    """
+    argus_logger = logging.getLogger("argus")
+    argus_logger.setLevel(settings.ARGUS_LOG_LEVEL)
+    argus_logger.propagate = False
+    if not argus_logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+        argus_logger.addHandler(handler)
+
+
 def _assert_single_worker() -> None:
     """Fails fast on the two argv/env spellings of "more than one worker" this can detect.
 
@@ -334,6 +352,7 @@ async def lifespan(app: FastAPI):
     """Starts background tasks on startup and stops them cleanly on shutdown."""
     global _mft_pipeline, _pipeline_task, _collector_task, _reconcile_task, _graph, _macro_status_agent
 
+    _configure_logging()
     _assert_single_worker()
     _assert_registered_models()
     _acquire_process_lock()
@@ -497,17 +516,65 @@ class AnalysisResponse(BaseModel):
     errors: list[str] = []
 
 
+def _background_task_status(task: asyncio.Task | None) -> dict:
+    """Reports a background task's liveness, distinguishing "never enabled" from "died" (OBS-2).
+
+    Args:
+        task: The task to inspect, or None if the loop it would run was never
+            started (e.g. ARGUS_COLLECTOR_ENABLED is False).
+
+    Returns:
+        Dict with ``enabled``, ``alive``, and — only when dead — ``error``.
+    """
+    if task is None:
+        return {"enabled": False, "alive": True}
+    if not task.done():
+        return {"enabled": True, "alive": True}
+    if task.cancelled():
+        error = "task was cancelled"
+    else:
+        exc = task.exception()
+        error = str(exc) if exc else "task exited unexpectedly"
+    return {"enabled": True, "alive": False, "error": error}
+
+
 @app.get("/health")
 async def health():
-    """Validates connectivity to model backends, API quotas, and system diagnostics."""
+    """Validates connectivity to model backends, API quotas, and system diagnostics.
+
+    Unlike the P0 gaps it replaces, this reads background-task liveness, the
+    kill switch's halt state, and cache freshness — not just in-memory
+    governor counters — so a dead pipeline/collector/reconcile loop shows up
+    here instead of staying invisible behind a green /health (OBS-2).
+
+    Raises:
+        HTTPException 503: If any background task (MFT pipeline, collector,
+            or reconciliation loop) has stopped running.
+    """
     try:
         llama_cap = governor.get_remaining_capacity(settings.ARGUS_PORTFOLIO_MODEL)
         can_make_calls = llama_cap > 0
     except Exception:
         can_make_calls = False
 
-    return {
-        "status": "ok",
+    background_tasks = {
+        "mft_pipeline": _background_task_status(_pipeline_task),
+        "collector": _background_task_status(_collector_task),
+        "reconcile": _background_task_status(_reconcile_task),
+    }
+    dead_tasks = [name for name, status in background_tasks.items() if not status["alive"]]
+
+    ks = get_kill_switch()
+
+    newest_cache_entry_age_seconds = None
+    if _mft_pipeline is not None and _mft_pipeline.is_market_hours() and _live_session_cache:
+        now = datetime.now()
+        newest_cache_entry_age_seconds = min(
+            (now - updated_at).total_seconds() for _, updated_at in _live_session_cache.values()
+        )
+
+    body = {
+        "status": "ok" if not dead_tasks else "degraded",
         "model_versions": {
             "synthesis": settings.ARGUS_PORTFOLIO_MODEL,
             "sentiment": settings.ARGUS_SENTIMENT_MODEL,
@@ -516,7 +583,14 @@ async def health():
         },
         "can_make_calls": can_make_calls,
         "governor_report": governor.get_usage_report(),
+        "background_tasks": background_tasks,
+        "kill_switch_halted": ks.is_halted if ks else False,
+        "newest_cache_entry_age_seconds": newest_cache_entry_age_seconds,
     }
+
+    if dead_tasks:
+        raise HTTPException(503, f"Background task(s) not running: {', '.join(dead_tasks)}")
+    return body
 
 
 @app.get("/pipeline/status")

--- a/tests/test_api_startup.py
+++ b/tests/test_api_startup.py
@@ -9,15 +9,27 @@ the app's lifespan.
 Also covers PR5b's API-2 additions: `_assert_single_worker`'s extension to
 `--workers=N` and `WEB_CONCURRENCY`, and `_acquire_process_lock`'s real
 cross-process guard (an exclusive flock on `${ARGUS_DATA_DIR}/argus.lock`).
+
+Also covers PR 1 of the release-remediation issue: `_configure_logging`
+(OBS-1) and `/health`'s background-task liveness reporting (OBS-2).
 """
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import fcntl
+import logging
+from datetime import datetime
+from unittest import mock
 
 import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
 
 import api.main as api_main
+import argus.risk.kill_switch as kill_switch_module
+from argus.risk.kill_switch import KillSwitch
 
 
 def test_assert_single_worker_allows_default_argv(monkeypatch):
@@ -110,3 +122,145 @@ def test_acquire_process_lock_rejects_a_second_holder(monkeypatch, tmp_path):
         fcntl.flock(other_fd, fcntl.LOCK_UN)
         other_fd.close()
         api_main._process_lock_file = None
+
+
+@pytest.fixture(autouse=True)
+def _reset_argus_logger():
+    """Clears the "argus" logger's handlers around each test in this module."""
+    argus_logger = logging.getLogger("argus")
+    original_handlers = list(argus_logger.handlers)
+    original_level = argus_logger.level
+    original_propagate = argus_logger.propagate
+    argus_logger.handlers = []
+    yield
+    argus_logger.handlers = original_handlers
+    argus_logger.level = original_level
+    argus_logger.propagate = original_propagate
+
+
+def test_configure_logging_attaches_a_handler_at_the_configured_level(monkeypatch):
+    """_configure_logging (OBS-1) makes ARGUS_LOG_LEVEL take effect on the argus logger tree."""
+    monkeypatch.setattr(api_main.settings, "ARGUS_LOG_LEVEL", "DEBUG")
+
+    api_main._configure_logging()
+
+    argus_logger = logging.getLogger("argus")
+    assert len(argus_logger.handlers) == 1
+    assert argus_logger.level == logging.DEBUG
+    assert argus_logger.propagate is False
+
+
+def test_configure_logging_is_idempotent():
+    """Calling _configure_logging twice (e.g. across repeated lifespans) doesn't stack handlers."""
+    api_main._configure_logging()
+    api_main._configure_logging()
+
+    assert len(logging.getLogger("argus").handlers) == 1
+
+
+@pytest.fixture
+def health_client():
+    """A TestClient over api.main.app without running its lifespan startup."""
+    return TestClient(api_main.app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_health_globals(monkeypatch):
+    """Clears the module-level state /health reads, so tests don't leak into each other."""
+    monkeypatch.setattr(api_main, "_pipeline_task", None)
+    monkeypatch.setattr(api_main, "_collector_task", None)
+    monkeypatch.setattr(api_main, "_reconcile_task", None)
+    monkeypatch.setattr(api_main, "_mft_pipeline", None)
+    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    kill_switch_module._kill_switch = None
+    yield
+    kill_switch_module._kill_switch = None
+
+
+def test_health_reports_ok_when_no_background_tasks_are_configured(health_client):
+    """Loops that were never started (e.g. collector/reconcile disabled) aren't a failure (OBS-2)."""
+    response = health_client.get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["background_tasks"] == {
+        "mft_pipeline": {"enabled": False, "alive": True},
+        "collector": {"enabled": False, "alive": True},
+        "reconcile": {"enabled": False, "alive": True},
+    }
+    assert body["kill_switch_halted"] is False
+    assert body["newest_cache_entry_age_seconds"] is None
+
+
+@pytest.mark.asyncio
+async def test_health_returns_503_naming_a_crashed_background_task(monkeypatch):
+    """A task that died with an exception makes /health a 503 naming it (OBS-2)."""
+
+    async def _boom():
+        raise RuntimeError("pipeline exploded")
+
+    task = asyncio.create_task(_boom())
+    with contextlib.suppress(RuntimeError):
+        await task
+    monkeypatch.setattr(api_main, "_pipeline_task", task)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await api_main.health()
+
+    assert exc_info.value.status_code == 503
+    assert "mft_pipeline" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_health_returns_503_naming_a_cancelled_background_task(monkeypatch):
+    """A task that stopped via cancellation (not just an exception) is also reported dead."""
+
+    async def _spin():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(_spin())
+    await asyncio.sleep(0)
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    monkeypatch.setattr(api_main, "_collector_task", task)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await api_main.health()
+
+    assert exc_info.value.status_code == 503
+    assert "collector" in exc_info.value.detail
+
+
+def test_health_reports_kill_switch_halted_state(health_client):
+    """kill_switch_halted mirrors the KillSwitch singleton's is_halted flag."""
+    ks = KillSwitch("MODERATE")
+    ks._portfolio_inception_value = 100_000.0
+    ks._current_portfolio_value = 50_000.0
+    ks._high_water_mark = 100_000.0
+    with mock.patch("argus.data.fetchers.fetch_vix", return_value=18.0):
+        ks._check()
+    kill_switch_module._kill_switch = ks
+
+    response = health_client.get("/health")
+
+    assert response.json()["kill_switch_halted"] is True
+
+
+def test_health_reports_newest_cache_entry_age_during_market_hours(monkeypatch, health_client):
+    """newest_cache_entry_age_seconds surfaces the freshest live-cache entry's age."""
+    fake_pipeline = mock.Mock()
+    fake_pipeline.is_market_hours.return_value = True
+    monkeypatch.setattr(api_main, "_mft_pipeline", fake_pipeline)
+    monkeypatch.setattr(
+        api_main,
+        "_live_session_cache",
+        {"AAPL": ({}, datetime.now())},
+    )
+
+    response = health_client.get("/health")
+
+    age = response.json()["newest_cache_entry_age_seconds"]
+    assert age is not None
+    assert age < 5


### PR DESCRIPTION
## Summary
- OBS-1: `lifespan` now attaches a StreamHandler to the `argus` logger at `ARGUS_LOG_LEVEL` with `propagate = False`, so INFO/DEBUG logging isn't silently dropped under uvicorn's bare root config.
- OBS-2: `/health` now reports background-task liveness (`_pipeline_task`, `_collector_task`, `_reconcile_task`), kill-switch halt state, and the freshest live-cache entry's age during market hours, returning 503 naming any dead task.

Part of #49 (PR 1 of 9).

## Test plan
- [x] `pytest tests/test_api_startup.py -q` — 18 tests covering `_configure_logging` (idempotent, correct level/propagate) and `/health` (ok when no tasks configured, 503 naming a crashed task, 503 naming a cancelled task, kill-switch state, cache-age reporting)
- [x] Full suite: `pytest -q` — 384 passed
- [x] `ruff check` / `mypy` clean on changed files
- [x] Manually verified a simulated uvicorn root (`WARNING`-level, no handlers) still surfaces `argus.*` INFO/DEBUG lines once `_configure_logging` runs