### PR TITLE
DIAGNOSTIC 3: pyproject.toml comment only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [project]
+# diag: comment-only touch, no dependency change
 name = "argus"
 version = "2.0.0"
 description = "Multi-agent financial intelligence system orchestrating specialist LLMs and statistical models for quantitative equity research."


### PR DESCRIPTION
Isolating whether merely touching pyproject.toml (no dependency change) reproduces the FRED_API_KEY secret issue, vs. it being specific to the version pins. Will close after.