### PR TITLE
PR3: gateway freshness and the tracked universe

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -122,6 +122,25 @@ async def _mft_session_callback(session_states: dict) -> None:
     logger.info("[MFT] Live session cache updated: %d ticker(s)", len(_live_session_cache))
 
 
+def _bar_age_seconds(state: dict, now_et: datetime) -> Optional[float]:
+    """Computes a session state's bar age in seconds, failing closed on a bad timestamp (API-11).
+
+    A missing, malformed, or naive ``timestamp`` must not raise out of
+    /analyze or /pipeline/status — it's treated as staleness instead.
+
+    Args:
+        state: A compressed technical feature dict from the live cache.
+        now_et: Current time, ET-aware, to measure age against.
+
+    Returns:
+        Age in seconds, or None if ``timestamp`` can't be parsed against `now_et`.
+    """
+    try:
+        return (now_et - datetime.fromisoformat(state["timestamp"])).total_seconds()
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
 def _log_task_exception(task: asyncio.Task, name: str) -> None:
     """Logs a background task's exception instead of letting it vanish silently.
 
@@ -632,8 +651,7 @@ async def pipeline_status():
         for ticker, (_, updated_at) in _live_session_cache.items()
     }
     bar_age_seconds = {
-        ticker: (now_et - datetime.fromisoformat(state["timestamp"])).total_seconds()
-        for ticker, (state, _) in _live_session_cache.items()
+        ticker: _bar_age_seconds(state, now_et) for ticker, (state, _) in _live_session_cache.items()
     }
 
     return {
@@ -700,9 +718,6 @@ async def analyze(req: AnalysisRequest):
             ks.risk_tolerance,
         )
 
-    if _mft_pipeline is not None:
-        _mft_pipeline.register_tickers(req.tickers)
-
     # Daily bars would mismatch the resolution the technical agent expects, so a
     # closed market (checked first) means idle rather than a lower-resolution
     # fallback. Checking it first also confines every age check below to a
@@ -713,6 +728,11 @@ async def analyze(req: AnalysisRequest):
             "US equity market is currently closed. MFT pipeline is idle. "
             "Retry between 09:30 and 16:00 ET on a weekday.",
         )
+
+    # Registered only once every earlier gate has cleared (API-12) — a
+    # rejected request must not mutate pipeline state or spend a slot in the
+    # tracked-universe cap
+    _mft_pipeline.register_tickers(req.tickers)
 
     absent = [t for t in req.tickers if t not in _live_session_cache]
     if absent:
@@ -735,13 +755,13 @@ async def analyze(req: AnalysisRequest):
         )
 
     # Catches what a write-time TTL can't: a restart that republishes old candles
-    # under a fresh write timestamp (MFT-1)
+    # under a fresh write timestamp (MFT-1). A timestamp that fails to parse
+    # fails closed as stale rather than raising (API-11).
     now_et = datetime.now(_ET)
     max_bar_age = max_bar_age_seconds(_mft_pipeline.interval_minutes)
     stale = [
         t for t in req.tickers
-        if (now_et - datetime.fromisoformat(_live_session_cache[t][0]["timestamp"])).total_seconds()
-        > max_bar_age
+        if (age := _bar_age_seconds(_live_session_cache[t][0], now_et)) is None or age > max_bar_age
     ]
     if stale:
         raise HTTPException(

--- a/argus/config.py
+++ b/argus/config.py
@@ -105,7 +105,6 @@ class Settings(BaseSettings):
     # against any rate limit — see data/pipeline.py for how coarser resolutions
     # are derived locally via resampling rather than fetched separately
     MFT_CANDLE_INTERVAL: str = "1m"
-    MFT_DECISION_INTERVAL_SECONDS: int = SYSTEM.mft_decision_interval_seconds
     # None means "derive from MFT_CANDLE_INTERVAL" (see data/pipeline.py's
     # _derive_buffer_size); set explicitly only to override that derivation
     CANDLE_BUFFER_SIZE: Optional[int] = None

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -30,7 +30,7 @@ import math
 import re
 import time
 from collections.abc import Callable
-from datetime import datetime, time as dtime
+from datetime import datetime, time as dtime, timedelta
 from pathlib import Path
 from typing import Optional
 from zoneinfo import ZoneInfo
@@ -203,10 +203,10 @@ def session_state_ttl_seconds() -> int:
     `mypy argus/`'s scope.
 
     Returns:
-        Budget in seconds: the decision cadence plus one fetch sweep plus a
-        fixed jitter margin.
+        Budget in seconds: two fetch sweeps — tolerating one missed sweep
+        before a cache entry counts as stalled — plus a fixed jitter margin.
     """
-    return settings.MFT_DECISION_INTERVAL_SECONDS + _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
+    return 2 * _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
 
 
 def max_bar_age_seconds(interval_minutes: int) -> int:
@@ -246,17 +246,14 @@ def _resample_ohlcv(df: pd.DataFrame, interval_minutes: int, target_minutes: int
     return resampled.dropna(subset=["close"])
 
 
-# Cold-start warmup poll cadence — much shorter than a real session interval so
-# a fresh buffer doesn't sit idle for the whole interval before its first compress
-_WARMUP_POLL_INTERVAL = 60
-
-
 class MFTDataPipeline:
     """Asynchronous mid-frequency data pipeline coordinating candlestick updates and feature extraction.
 
-    Runs two concurrent asyncio loops: one that periodically fetches intraday
-    candles for all tracked tickers, and one that fires a decision-cycle callback
-    at a longer interval. Both loops only execute during US equity market hours.
+    Runs a single asyncio loop that periodically fetches intraday candles for
+    all tracked tickers, then republishes compressed session state from the
+    same pass (MFT-14) — publication used to sit on its own, much longer
+    timer, so a live-cache entry was fresh for only a fraction of each cycle.
+    The loop only runs during US equity market hours.
     """
 
     def __init__(
@@ -278,7 +275,6 @@ class MFTDataPipeline:
         """
         self.interval = interval or settings.MFT_CANDLE_INTERVAL
         self.interval_minutes = _parse_interval_minutes(self.interval)
-        self.session_interval_seconds = settings.MFT_DECISION_INTERVAL_SECONDS
         buffer_size = settings.CANDLE_BUFFER_SIZE or _derive_buffer_size(self.interval_minutes)
         if db_path is None:
             data_dir = Path(settings.ARGUS_DATA_DIR)
@@ -292,7 +288,13 @@ class MFTDataPipeline:
         # run_collection_cycle, and to collect_session.py's --universe CLI arg
         # (API-1) — not just to /analyze's already-validated request tickers
         self.tickers: list[str] = []
+        self.last_requested_at: dict[str, datetime] = {}
         self.register_tickers(tickers)
+        # The constructor's own universe is pinned against _evict_stale_tickers
+        # (API-12) — the unattended collector never calls register_tickers to
+        # "touch" these, so a TTL applied uniformly would silently starve the
+        # universe it exists to track
+        self._pinned_tickers: frozenset[str] = frozenset(self.tickers)
         logger.info(
             "MFTDataPipeline initialised: %d tickers, interval=%s, buffer_size=%d, buffer=%s",
             len(self.tickers),
@@ -302,27 +304,15 @@ class MFTDataPipeline:
         )
 
     async def start(self, on_session_ready: Callable) -> None:
-        """Starts concurrent fetch and session cycles, blocking until stopped.
+        """Starts the fetch loop, blocking until stopped.
 
         Args:
             on_session_ready: Async callback invoked with compressed session states
-                after each session interval elapses during market hours.
+                after each sweep during market hours (MFT-14).
         """
         self.running = True
-        logger.info("MFTDataPipeline.start: launching fetch and session loops")
-        tasks = [
-            asyncio.create_task(self._fetch_loop()),
-            asyncio.create_task(self._session_loop(on_session_ready)),
-        ]
-        try:
-            await asyncio.gather(*tasks)
-        finally:
-            # Either task ending (return or raise) must not orphan the other —
-            # cancel and await both so a dead fetch loop can't leave the session
-            # loop sweeping into a closed buffer, or vice versa
-            for task in tasks:
-                task.cancel()
-            await asyncio.gather(*tasks, return_exceptions=True)
+        logger.info("MFTDataPipeline.start: launching fetch loop")
+        await self._fetch_loop(on_session_ready)
 
     async def _wait_or_stop(self, timeout: float) -> None:
         """Sleeps up to `timeout` seconds, waking immediately if `stop()` is called.
@@ -373,6 +363,41 @@ class MFTDataPipeline:
                 accepted,
             )
 
+        # Touches every already-tracked ticker too, not just newly-accepted
+        # ones (API-12) — a repeatedly-requested ticker must never look
+        # unused to _evict_stale_tickers just because it was already tracked
+        now = datetime.now(_ET)
+        for ticker in valid:
+            if ticker in self.tickers:
+                self.last_requested_at[ticker] = now
+
+    def _evict_stale_tickers(self) -> None:
+        """Drops tracked tickers unused beyond SYSTEM.tracked_ticker_ttl_seconds (API-12).
+
+        Without this, `register_tickers` only ever appends: repeated one-off
+        `/analyze` requests for different tickers permanently saturate
+        `SYSTEM.max_tracked_tickers` with no eviction and no new ticker ever
+        admitted. Exempts `self._pinned_tickers` — the pipeline's own seed
+        universe — since the unattended collector never calls
+        `register_tickers` to refresh their `last_requested_at`.
+        """
+        cutoff = datetime.now(_ET) - timedelta(seconds=SYSTEM.tracked_ticker_ttl_seconds)
+        stale = [
+            t
+            for t in self.tickers
+            if t not in self._pinned_tickers and self.last_requested_at.get(t, cutoff) < cutoff
+        ]
+        if not stale:
+            return
+        for ticker in stale:
+            self.tickers.remove(ticker)
+            self.last_requested_at.pop(ticker, None)
+        logger.info(
+            "MFTDataPipeline._evict_stale_tickers: evicted %d unused ticker(s): %s",
+            len(stale),
+            stale,
+        )
+
     async def stop(self) -> None:
         """Signals active loops to stop execution."""
         self.running = False
@@ -407,6 +432,7 @@ class MFTDataPipeline:
         a one-shot ``run_once()`` sweep. Iterates over a snapshot of
         ``self.tickers`` so that concurrent ``register_tickers`` calls cannot corrupt iteration.
         """
+        self._evict_stale_tickers()
         tickers_snapshot = list(self.tickers)
         logger.debug("_sweep_once: starting universe sweep (%d tickers)", len(tickers_snapshot))
         last = len(tickers_snapshot) - 1
@@ -415,19 +441,35 @@ class MFTDataPipeline:
             if i < last:
                 await asyncio.sleep(SYSTEM.min_inter_request_seconds)
 
-    async def _fetch_loop(self) -> None:
-        """Periodically downloads the latest intraday candlesticks for the tracking universe.
+    async def _fetch_loop(self, on_session_ready: Callable) -> None:
+        """Periodically downloads intraday candlesticks and republishes compressed session state.
 
-        Sleeps only the remainder of ``_FETCH_INTERVAL`` after each sweep, not a
-        full interval on top of however long the sweep itself took — otherwise
-        the real cadence drifts to sweep_duration + _FETCH_INTERVAL instead of
-        the intended _FETCH_INTERVAL.
+        Publication is merged into this loop (MFT-14) rather than living on
+        a separate, much longer timer: the old split meant a live-cache entry
+        was only fresh for a fraction of each publish cycle, since
+        ``max_bar_age_seconds`` was sized off the fetch cadence while
+        publication ran on a slower one. Sleeps only the remainder of
+        ``_FETCH_INTERVAL`` after each pass, not a full interval on top of
+        however long the pass itself took — otherwise the real cadence drifts
+        to pass_duration + _FETCH_INTERVAL instead of the intended
+        _FETCH_INTERVAL.
+
+        Args:
+            on_session_ready: Async callable receiving the ``session_states`` dict
+                after each sweep during market hours.
         """
         while self.running:
             started = time.monotonic()
             try:
                 if self._is_market_hours():
                     await self._sweep_once()
+                    session_states = await asyncio.to_thread(self.compress_all)
+                    try:
+                        await on_session_ready(session_states)
+                    except Exception as exc:
+                        logger.error(
+                            "_fetch_loop: callback raised %s: %s", type(exc).__name__, exc
+                        )
                 else:
                     logger.debug("_fetch_loop: outside market hours — idle")
             except Exception as exc:
@@ -443,8 +485,7 @@ class MFTDataPipeline:
 
         Returns:
             True once at least one ticker holds >= 14 rows (``OHLCVBuffer.get_candles``'
-            own floor), letting callers skip waiting a full session interval on a
-            cold start.
+            own floor).
         """
         for ticker in self.buffer.get_all_tickers():
             try:
@@ -455,37 +496,6 @@ class MFTDataPipeline:
                     "_buffer_warm: %s check failed — %s: %s", ticker, type(exc).__name__, exc
                 )
         return False
-
-    async def _session_loop(self, callback: Callable) -> None:
-        """Periodically compiles buffered candlesticks and triggers downstream agent actions.
-
-        Args:
-            callback: Async callable receiving the ``session_states`` dict.
-        """
-        # A fresh buffer sleeping a full session interval before its first
-        # compress would leave the live cache empty for that whole stretch for
-        # no reason; poll faster until there's actually something to compress
-        while self.running and not self._buffer_warm():
-            await self._wait_or_stop(_WARMUP_POLL_INTERVAL)
-
-        while self.running:
-            try:
-                if self._is_market_hours():
-                    logger.info("_session_loop: triggering decision cycle")
-                    session_states = await asyncio.to_thread(self.compress_all)
-                    try:
-                        await callback(session_states)
-                    except Exception as exc:
-                        logger.error(
-                            "_session_loop: callback raised %s: %s",
-                            type(exc).__name__,
-                            exc,
-                        )
-            except Exception as exc:
-                logger.error(
-                    "_session_loop: iteration failed — %s: %s", type(exc).__name__, exc
-                )
-            await self._wait_or_stop(self.session_interval_seconds)
 
     async def _fetch_one_ticker(self, ticker: str) -> None:
         """Downloads and bulk-inserts all available candles for a specific symbol.

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 12
+PARAMS_VERSION = 13
 
 
 class Provenance(str, Enum):
@@ -70,9 +70,6 @@ def p(value: Any, provenance: Provenance, note: str = "") -> Any:
 class SystemParams:
     """Timing, universe, and hard-limit parameters formerly inline in config.py."""
 
-    mft_decision_interval_seconds: int = p(
-        1800, Provenance.ARBITRARY, "30-minute decision cadence; not evaluated against alternatives"
-    )
     candle_buffer_days_retained: int = p(
         2,
         Provenance.CONVENTION,
@@ -115,6 +112,14 @@ class SystemParams:
         "ceiling on MFTDataPipeline.tickers enforced in register_tickers; stops "
         "unbounded universe growth from repeated /analyze requests (API-1) — not "
         "evaluated against alternatives",
+    )
+    tracked_ticker_ttl_seconds: int = p(
+        86400,
+        Provenance.ARBITRARY,
+        "how long a non-seed ticker (one registered by an /analyze request rather "
+        "than the pipeline's initial universe) stays tracked without being "
+        "re-requested before register_tickers evicts it (API-12) — not evaluated "
+        "against alternatives",
     )
     analyze_retry_after_seconds: int = p(
         5,

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -97,7 +97,14 @@ SESSION_STATE_REQUIRED_KEYS: frozenset[str] = frozenset({
     "momentum_30m",
     "momentum_1d",
     "close",
+    "timestamp",
 })
+
+# timestamp is a required key but not a numeric indicator (API-11) — it's
+# checked for presence like every other key, but exempt from the
+# finite-float check below, which would otherwise raise trying to float() an
+# ISO string
+_NUMERIC_SESSION_STATE_KEYS = SESSION_STATE_REQUIRED_KEYS - {"timestamp"}
 
 
 def missing_session_state_keys(state: dict) -> list[str]:
@@ -120,7 +127,7 @@ def missing_session_state_keys(state: dict) -> list[str]:
     if missing:
         return sorted(missing)
     return sorted(
-        k for k in SESSION_STATE_REQUIRED_KEYS if not math.isfinite(float(state[k]))
+        k for k in _NUMERIC_SESSION_STATE_KEYS if not math.isfinite(float(state[k]))
     )
 
 

--- a/tests/test_api_freshness.py
+++ b/tests/test_api_freshness.py
@@ -6,6 +6,11 @@ must reject on bar age, not just cache-write age, and must check market
 hours before either age check so bar-age is never evaluated outside a
 weekday 09:30-16:00 ET session.
 
+Also covers PR3's MFT-14 (publication merged into the fetch loop, so a bar
+published a full fetch interval ago still clears the gate) and API-11 (a
+malformed or naive bar timestamp fails closed as staleness instead of
+raising).
+
 These exercise the route function directly via FastAPI's TestClient rather
 than going through the app's lifespan, so no MFT pipeline, collector, or
 reconcile loop needs to start. `_mft_pipeline` and `_live_session_cache`
@@ -22,6 +27,7 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 import argus.risk.kill_switch as kill_switch_module
+from argus.data.pipeline import _FETCH_INTERVAL
 
 _PAYLOAD = {"tickers": ["AAPL"], "total_wealth": 100_000, "invest_pct": 0.5}
 
@@ -126,3 +132,44 @@ def test_analyze_passes_freshness_gate_with_a_current_bar(client, monkeypatch):
     # so it isn't asserted here.
     assert response.status_code == 500
     assert fake_graph.invoke.called
+
+
+def test_analyze_passes_freshness_gate_with_a_bar_one_full_fetch_interval_old(client, monkeypatch):
+    """MFT-14: publication now runs on the same cadence as the fetch sweep, so a bar as old as one
+    full _FETCH_INTERVAL still clears max_bar_age_seconds — the case that a slower, decoupled
+    publish timer used to miss for most of each cycle.
+    """
+    _pipeline(monkeypatch, market_hours=True)
+    _seed_cache("AAPL", bar_age_seconds=_FETCH_INTERVAL, write_age_seconds=5)
+    fake_graph = mock.Mock()
+    fake_graph.invoke.side_effect = RuntimeError("sentinel: freshness gate cleared")
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 500
+    assert fake_graph.invoke.called
+
+
+def test_analyze_rejects_a_malformed_bar_timestamp_as_stale(client, monkeypatch):
+    """API-11: a non-ISO timestamp fails closed as staleness (503) instead of raising a 500."""
+    _pipeline(monkeypatch, market_hours=True)
+    write_ts = datetime.now()
+    api_main._live_session_cache["AAPL"] = ({"timestamp": "not-a-timestamp"}, write_ts)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 503
+    assert "stale" in response.json()["detail"].lower()
+
+
+def test_analyze_rejects_a_naive_bar_timestamp_as_stale(client, monkeypatch):
+    """API-11: a naive (tz-less) timestamp fails closed as staleness rather than raising a TypeError."""
+    _pipeline(monkeypatch, market_hours=True)
+    write_ts = datetime.now()
+    api_main._live_session_cache["AAPL"] = ({"timestamp": datetime.now().isoformat()}, write_ts)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 503
+    assert "stale" in response.json()["detail"].lower()

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -80,8 +80,13 @@ def test_analyze_rejects_malformed_ticker_with_422(client, ticker):
 
 
 def test_analyze_accepts_share_class_tickers(client, monkeypatch):
-    """Dotted and hyphenated share-class symbols pass validation and reach the pipeline."""
-    fake_pipeline = _pipeline(monkeypatch, market_hours=False)
+    """Dotted and hyphenated share-class symbols pass validation and reach the pipeline.
+
+    Market is open here (rather than closed) because register_tickers now only
+    runs once the market-hours gate clears (API-12) — a rejected request must
+    not mutate pipeline state.
+    """
+    fake_pipeline = _pipeline(monkeypatch, market_hours=True)
     response = client.post(
         "/analyze",
         json={"tickers": ["BRK.B", "BRK-B"], "total_wealth": 100_000, "invest_pct": 0.5},
@@ -92,7 +97,7 @@ def test_analyze_accepts_share_class_tickers(client, monkeypatch):
 
 def test_analyze_upcases_and_dedupes_tickers(client, monkeypatch):
     """Lowercase, whitespace-padded, and repeated tickers collapse to one upper-cased entry each."""
-    fake_pipeline = _pipeline(monkeypatch, market_hours=False)
+    fake_pipeline = _pipeline(monkeypatch, market_hours=True)
     response = client.post(
         "/analyze",
         json={"tickers": [" aapl ", "AAPL", "msft"], "total_wealth": 100_000, "invest_pct": 0.5},

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,6 +8,7 @@ import importlib
 import math
 import sys
 import time
+from datetime import datetime, timedelta
 from pathlib import Path
 
 import pandas as pd
@@ -71,6 +72,52 @@ def test_init_routes_initial_universe_through_register_tickers(monkeypatch):
     """A malformed ticker in the constructor's initial universe is dropped, not stored raw."""
     monkeypatch.setattr(pipeline_module, "SYSTEM", dataclasses.replace(SYSTEM, max_tracked_tickers=2))
     pipeline = MFTDataPipeline(["AAPL", "not-a-ticker!", "MSFT", "TSLA"])
+    assert pipeline.tickers == ["AAPL", "MSFT"]
+
+
+def test_register_tickers_refreshes_last_requested_at_for_already_tracked_tickers():
+    """A repeat request for an already-tracked ticker still bumps its last_requested_at (API-12)."""
+    pipeline = MFTDataPipeline(["AAPL"])
+    stale = datetime.now(pipeline_module._ET) - timedelta(days=10)
+    pipeline.last_requested_at["AAPL"] = stale
+
+    pipeline.register_tickers(["AAPL"])
+
+    assert pipeline.last_requested_at["AAPL"] > stale
+
+
+def test_evict_stale_tickers_drops_a_non_seed_ticker_unused_beyond_the_ttl(monkeypatch):
+    """A ticker registered outside the pipeline's seed universe expires after the TTL (API-12)."""
+    monkeypatch.setattr(pipeline_module, "SYSTEM", dataclasses.replace(SYSTEM, tracked_ticker_ttl_seconds=60))
+    pipeline = MFTDataPipeline(["AAPL"])
+    pipeline.register_tickers(["MSFT"])
+    pipeline.last_requested_at["MSFT"] = datetime.now(pipeline_module._ET) - timedelta(seconds=120)
+
+    pipeline._evict_stale_tickers()
+
+    assert pipeline.tickers == ["AAPL"]
+    assert "MSFT" not in pipeline.last_requested_at
+
+
+def test_evict_stale_tickers_exempts_the_seed_universe(monkeypatch):
+    """The pipeline's own seed tickers survive the TTL even if never re-requested (API-12)."""
+    monkeypatch.setattr(pipeline_module, "SYSTEM", dataclasses.replace(SYSTEM, tracked_ticker_ttl_seconds=60))
+    pipeline = MFTDataPipeline(["AAPL"])
+    pipeline.last_requested_at["AAPL"] = datetime.now(pipeline_module._ET) - timedelta(seconds=120)
+
+    pipeline._evict_stale_tickers()
+
+    assert pipeline.tickers == ["AAPL"]
+
+
+def test_evict_stale_tickers_keeps_a_recently_requested_ticker(monkeypatch):
+    """A ticker requested within the TTL window is not evicted (API-12)."""
+    monkeypatch.setattr(pipeline_module, "SYSTEM", dataclasses.replace(SYSTEM, tracked_ticker_ttl_seconds=3600))
+    pipeline = MFTDataPipeline(["AAPL"])
+    pipeline.register_tickers(["MSFT"])
+
+    pipeline._evict_stale_tickers()
+
     assert pipeline.tickers == ["AAPL", "MSFT"]
 
 
@@ -309,13 +356,9 @@ def test_momentum_1d_is_stable_under_dropping_up_to_10_oldest_bars(drop: int):
     assert trimmed == baseline
 
 
-def test_session_state_ttl_seconds_tracks_decision_interval(monkeypatch):
-    """The write-age TTL is derived from the configured decision interval, not hardcoded."""
-    monkeypatch.setattr(settings, "MFT_DECISION_INTERVAL_SECONDS", 1800)
-    assert session_state_ttl_seconds() == 1800 + _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
-
-    monkeypatch.setattr(settings, "MFT_DECISION_INTERVAL_SECONDS", 900)
-    assert session_state_ttl_seconds() == 900 + _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
+def test_session_state_ttl_seconds_tolerates_one_missed_sweep():
+    """The write-age TTL covers two fetch sweeps (MFT-14), not one decision cycle's worth."""
+    assert session_state_ttl_seconds() == 2 * _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
 
 
 def test_max_bar_age_seconds_scales_with_interval():
@@ -350,6 +393,10 @@ async def test_sweep_uses_a_constant_inter_request_gap_independent_of_universe_s
     assert big_elapsed == pytest.approx(19 * SYSTEM.min_inter_request_seconds, abs=0.1)
 
 
+async def _noop_callback(states: dict) -> None:
+    """A no-op on_session_ready callback for _fetch_loop tests that don't care about publication."""
+
+
 @pytest.mark.asyncio
 async def test_fetch_loop_sleeps_the_remainder_of_the_interval_not_a_full_one(monkeypatch):
     """A fetch_loop iteration's wait is shortened by however long the sweep itself took."""
@@ -365,10 +412,11 @@ async def test_fetch_loop_sleeps_the_remainder_of_the_interval_not_a_full_one(mo
 
     monkeypatch.setattr(pipeline, "_is_market_hours", lambda: True)
     monkeypatch.setattr(pipeline, "_sweep_once", fake_sweep)
+    monkeypatch.setattr(pipeline, "compress_all", lambda: {})
     monkeypatch.setattr(pipeline, "_wait_or_stop", fake_wait_or_stop)
     pipeline.running = True
 
-    await pipeline._fetch_loop()
+    await pipeline._fetch_loop(_noop_callback)
 
     assert len(waits) == 1
     assert waits[0] < _FETCH_INTERVAL
@@ -381,6 +429,7 @@ async def test_fetch_loop_cadence_holds_across_a_slow_sweep(monkeypatch):
     monkeypatch.setattr(pipeline_module, "_FETCH_INTERVAL", 0.2)
     pipeline = MFTDataPipeline([], interval="1m")
     monkeypatch.setattr(pipeline, "_is_market_hours", lambda: True)
+    monkeypatch.setattr(pipeline, "compress_all", lambda: {})
 
     starts = []
 
@@ -391,7 +440,7 @@ async def test_fetch_loop_cadence_holds_across_a_slow_sweep(monkeypatch):
     monkeypatch.setattr(pipeline, "_sweep_once", fake_sweep)
 
     pipeline.running = True
-    task = asyncio.create_task(pipeline._fetch_loop())
+    task = asyncio.create_task(pipeline._fetch_loop(_noop_callback))
     await asyncio.sleep(0.55)
     await pipeline.stop()
     await asyncio.wait_for(task, timeout=1.0)
@@ -399,6 +448,30 @@ async def test_fetch_loop_cadence_holds_across_a_slow_sweep(monkeypatch):
     assert len(starts) >= 2
     gaps = [b - a for a, b in zip(starts, starts[1:])]
     assert all(gap == pytest.approx(0.2, abs=0.05) for gap in gaps)
+
+
+@pytest.mark.asyncio
+async def test_fetch_loop_publishes_compressed_state_after_each_sweep():
+    """Publication is merged into the fetch loop (MFT-14): one sweep, one compress, one callback."""
+    pipeline = MFTDataPipeline(["AAPL"], interval="1m")
+    _seed_two_session_buffer(pipeline, "AAPL")
+    pipeline._is_market_hours = lambda: True
+    received = []
+
+    async def fake_sweep():
+        return None
+
+    pipeline._sweep_once = fake_sweep
+
+    async def stop_after_one(states: dict) -> None:
+        received.append(states)
+        await pipeline.stop()
+
+    pipeline.running = True
+    await pipeline._fetch_loop(stop_after_one)
+
+    assert len(received) == 1
+    assert "AAPL" in received[0]
 
 
 def test_default_db_path_uses_isolated_data_dir(tmp_path):
@@ -543,41 +616,31 @@ def test_buffer_warm_skips_a_ticker_whose_get_candles_raises(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_start_cancels_the_sibling_loop_when_one_dies(monkeypatch):
-    """If one loop raises out of start()'s gather, the other is cancelled rather than orphaned."""
+async def test_start_propagates_a_fetch_loop_exception(monkeypatch):
+    """start() surfaces _fetch_loop's exception rather than swallowing it (single loop now, MFT-14)."""
     pipeline = MFTDataPipeline([], interval="1m")
-    session_loop_cancelled = asyncio.Event()
 
-    async def dying_fetch_loop():
+    async def dying_fetch_loop(on_session_ready):
         raise RuntimeError("simulated crash")
 
-    async def long_session_loop(callback):
-        try:
-            await asyncio.sleep(10)
-        except asyncio.CancelledError:
-            session_loop_cancelled.set()
-            raise
-
     monkeypatch.setattr(pipeline, "_fetch_loop", dying_fetch_loop)
-    monkeypatch.setattr(pipeline, "_session_loop", long_session_loop)
 
     with pytest.raises(RuntimeError):
-        await pipeline.start(on_session_ready=lambda states: None)
-
-    assert session_loop_cancelled.is_set()
+        await pipeline.start(on_session_ready=_noop_callback)
 
 
 @pytest.mark.asyncio
-async def test_stop_ends_both_loops_promptly():
-    """stop() wakes both loops immediately rather than waiting out their full interval."""
+async def test_stop_ends_the_loop_promptly(monkeypatch):
+    """stop() wakes the loop immediately rather than waiting out its full interval."""
     pipeline = MFTDataPipeline([], interval="1m")
-    task = asyncio.create_task(pipeline.start(on_session_ready=lambda states: None))
+    monkeypatch.setattr(pipeline, "_is_market_hours", lambda: False)
+    task = asyncio.create_task(pipeline.start(on_session_ready=_noop_callback))
     await asyncio.sleep(0.05)
 
     await pipeline.stop()
 
     # Without the stop_event-based wait, this would block for up to
-    # _WARMUP_POLL_INTERVAL/_FETCH_INTERVAL seconds instead of returning almost immediately
+    # _FETCH_INTERVAL seconds instead of returning almost immediately
     await asyncio.wait_for(task, timeout=2.0)
 
 

--- a/tests/test_technical.py
+++ b/tests/test_technical.py
@@ -39,6 +39,7 @@ def test_bullish_signal(agent: TechnicalStatisticalAgent) -> None:
         "momentum_30m": 0.012,
         "momentum_1d": 0.025,
         "close": 100.0,
+        "timestamp": "2024-01-02T10:00:00-05:00",
     }
     result = agent.analyze("TEST", session_state)
     assert result.signal == Signal.BULLISH
@@ -59,6 +60,7 @@ def test_bearish_signal(agent: TechnicalStatisticalAgent) -> None:
         "momentum_30m": -0.012,  # Opposite
         "momentum_1d": -0.025,  # Opposite
         "close": 100.0,
+        "timestamp": "2024-01-02T10:00:00-05:00",
     }
     result = agent.analyze("TEST", session_state)
     assert result.signal == Signal.BEARISH
@@ -79,6 +81,7 @@ def test_neutral_signal(agent: TechnicalStatisticalAgent) -> None:
         "momentum_30m": 0.0,
         "momentum_1d": 0.0,
         "close": 100.0,
+        "timestamp": "2024-01-02T10:00:00-05:00",
     }
     result = agent.analyze("TEST", session_state)
     assert result.signal == Signal.NEUTRAL
@@ -98,6 +101,7 @@ def test_zero_api_calls(agent: TechnicalStatisticalAgent) -> None:
         "momentum_30m": 0.0,
         "momentum_1d": 0.0,
         "close": 100.0,
+        "timestamp": "2024-01-02T10:00:00-05:00",
     }
     result = agent.analyze("TEST", session_state)
     assert result.api_calls_used == 0
@@ -116,6 +120,7 @@ def test_batch_analyze_reports_dropped_tickers_in_errors(agent: TechnicalStatist
         "momentum_30m": 0.0,
         "momentum_1d": 0.0,
         "close": 100.0,
+        "timestamp": "2024-01-02T10:00:00-05:00",
     }
     incomplete_state = {k: v for k, v in complete_state.items() if k != "adx_14"}
 
@@ -141,6 +146,7 @@ def _complete_state(**overrides: float) -> dict:
         "momentum_30m": 0.0,
         "momentum_1d": 0.0,
         "close": 100.0,
+        "timestamp": "2024-01-02T10:00:00-05:00",
     }
     base.update(overrides)
     return base


### PR DESCRIPTION
Part of #49. Covers MFT-14, API-11, API-12: publication now runs inside `_fetch_loop` right after each sweep instead of on `_session_loop`'s separate 1800s timer, so `session_state_ttl_seconds()` (now `2 * _FETCH_INTERVAL + margin`) actually matches the cadence data gets refreshed at — previously the two timers disagreed badly enough that `/analyze` rejected most in-hours requests as stale. `SESSION_STATE_REQUIRED_KEYS` now includes `timestamp`, and `/analyze`/`/pipeline/status` fail closed as staleness on a missing/naive/malformed bar timestamp instead of raising. `MFTDataPipeline` now tracks `last_requested_at` per ticker and evicts anything outside its pinned seed universe that goes unrequested past `SYSTEM.tracked_ticker_ttl_seconds`, and `/analyze` only calls `register_tickers` after the market-hours gate so a rejected request can't mutate pipeline state.

`_session_loop` and the now-decoupled `MFT_DECISION_INTERVAL_SECONDS` / `SystemParams.mft_decision_interval_seconds` are retired; `_buffer_warm` is kept (still directly tested) even though nothing in the merged loop calls it anymore.

## Test plan
- [x] `ruff check .` — clean
- [x] `mypy argus/` — clean
- [x] `pytest -q` — 395 passed
- [ ] Live verification against `/analyze` during market hours (needs a real trading session)