### PR TITLE
Safety layer: a drawdown number that means something

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Every secret field defaults to an empty string (see `argus/config.py`) — the p
 | `GET` | `/memory/stats` | Summary stats from the ChromaDB cultural-memory vault. |
 | `GET` | `/governor/report` | Per-model request/token usage against rate limits. |
 | `GET` | `/kill-switch/status` | Current halt/blackout state, drawdown, and last-observed VIX. |
-| `POST` | `/kill-switch/reset` | Clears an active halt, re-bases the tracked portfolio value, and deletes persisted halt dumps. Requires `X-API-Key` if `ARGUS_API_KEY` is set. |
+| `POST` | `/kill-switch/reset` | Clears an active halt, re-bases both the in-memory drawdown base and the persisted paper-equity curve to the given value, and deletes persisted halt dumps. Requires `X-API-Key` if `ARGUS_API_KEY` is set. |
 
 `/analyze` is the primary entrypoint. It only serves requests once the MFT pipeline has warmed up for the requested tickers, and only during US equity market hours:
 

--- a/api/main.py
+++ b/api/main.py
@@ -873,6 +873,10 @@ async def reset_kill_switch(new_inception_value: float = Query(gt=1000)):
 
     Also deletes any persisted halt-dump files (see KillSwitch.reset), so a
     subsequent restart can't silently re-apply a halt this call just resolved.
+    Rebases the persisted paper-equity curve to new_inception_value in the same
+    operation (KS-15) — otherwise the next reconcile pass would call
+    update_portfolio_value with the stale, already-drawn-down equity and
+    re-halt within check_interval_seconds.
 
     Args:
         new_inception_value: New portfolio value to use as the drawdown base
@@ -887,6 +891,10 @@ async def reset_kill_switch(new_inception_value: float = Query(gt=1000)):
     """
     ks = get_kill_switch()
     if ks:
+        book_path = f"{settings.ARGUS_DATA_DIR}/paper_equity.json"
+        book = paper_book.load(book_path)
+        book.rebase(new_inception_value)
+        paper_book.save(book, book_path)
         ks.reset(new_inception_value)
         return {"status": "Reset successful"}
     raise HTTPException(404, "Kill switch not initialized")

--- a/argus/risk/paper_book.py
+++ b/argus/risk/paper_book.py
@@ -10,13 +10,17 @@ rebalance: within a run, decisions that took a position are weighted by
 allocation_pct and averaged into that run's realized return once at least one
 matured decision's outcome is known, then compounded onto the running equity
 curve. A run with only some decisions matured is not diluted with fabricated
-zeros for the rest — it's averaged over the matured subset only.
+zeros for the rest — it's averaged over the matured subset only. Runs are
+compounded at most once per horizon_days window, so a decision made every
+session doesn't compound the same overlapping days many times over (KS-14).
 
 Responsibilities:
   - compute_run_returns: group decisions by run (shared session_timestamp),
-    weight-average each run's matured outcomes into one compounding return
+    weight-average each non-overlapping run's matured outcomes into one
+    compounding return
   - PaperBook: equity/high-water-mark/applied-runs state, with idempotent
-    run application
+    run application and manual rebasing (see rebase(), used by
+    KillSwitch.reset())
   - load / save: JSON round trip at a caller-supplied path
 
 Not responsible for:
@@ -31,7 +35,7 @@ import json
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
@@ -67,16 +71,23 @@ def compute_run_returns(
         (run_timestamp, weighted_return) pairs, one per run with at least one
         matured, priceable decision, sorted by run_timestamp. A run with no
         matured decisions yet, or whose tickers all failed to fetch, is
-        omitted rather than reported as a 0.0 return.
+        omitted rather than reported as a 0.0 return. Runs falling inside a
+        previously kept run's horizon window are also omitted (not zeroed) so
+        overlapping runs are never compounded together (KS-14).
     """
     by_run: dict[datetime, list[ARGUSDecision]] = defaultdict(list)
     for decision in decisions:
         if _needs_reconciliation(decision):
             by_run[decision.session_timestamp].append(decision)
 
+    horizon = timedelta(days=horizon_days)
     prices_by_ticker: dict[str, Optional[pd.Series]] = {}
     results: list[tuple[datetime, float]] = []
+    last_kept_timestamp: Optional[datetime] = None
     for run_timestamp in sorted(by_run):
+        if last_kept_timestamp is not None and run_timestamp < last_kept_timestamp + horizon:
+            continue
+
         weighted_sum = 0.0
         weight_total = 0.0
         for decision in by_run[run_timestamp]:
@@ -105,6 +116,7 @@ def compute_run_returns(
 
         if weight_total > 0:
             results.append((run_timestamp, weighted_sum / weight_total))
+            last_kept_timestamp = run_timestamp
 
     return results
 
@@ -120,6 +132,8 @@ class PaperBook:
     """ISO-formatted session_timestamps of runs already compounded in, so a
     re-run of compute_run_returns over a growing decision history doesn't
     double-apply one already reflected in equity."""
+    rebased_at: Optional[datetime] = None
+    """When this book was last manually rebased via reset() (KS-15), if ever."""
 
     def apply_run(self, run_timestamp: datetime, run_return: float) -> bool:
         """Compounds one run's weighted return onto the curve, unless already applied.
@@ -148,6 +162,24 @@ class PaperBook:
             return 0.0
         return max(0.0, (self.high_water_mark - self.equity) / self.high_water_mark)
 
+    def rebase(self, new_inception_value: float, rebased_at: Optional[datetime] = None) -> None:
+        """Rebases equity and high-water mark to a new inception value in place (KS-15).
+
+        Called alongside KillSwitch.reset() so an operator's manual reset is
+        reflected in the persisted curve, not just the in-memory kill switch —
+        otherwise the next reconcile pass calls update_portfolio_value with the
+        stale, already-drawn-down equity and re-halts within
+        check_interval_seconds. runs_applied is left untouched, so runs already
+        compounded into the old curve are never re-applied against the new base.
+
+        Args:
+            new_inception_value: Replacement equity and high-water-mark value.
+            rebased_at: Timestamp of the rebase; defaults to now.
+        """
+        self.equity = new_inception_value
+        self.high_water_mark = new_inception_value
+        self.rebased_at = rebased_at or datetime.now()
+
 
 def load(path: str) -> PaperBook:
     """Loads a persisted PaperBook, or starts a fresh one at ARGUS_TOTAL_WEALTH.
@@ -172,11 +204,13 @@ def load(path: str) -> PaperBook:
         with open(file_path, encoding="utf-8") as f:
             raw = json.load(f)
         last_run_raw = raw.get("last_run_timestamp")
+        rebased_at_raw = raw.get("rebased_at")
         return PaperBook(
             equity=raw["equity"],
             high_water_mark=raw["high_water_mark"],
             last_run_timestamp=datetime.fromisoformat(last_run_raw) if last_run_raw else None,
             runs_applied=set(raw.get("runs_applied", [])),
+            rebased_at=datetime.fromisoformat(rebased_at_raw) if rebased_at_raw else None,
         )
     except Exception as exc:
         logger.warning("[PaperBook] failed to load %s, starting fresh: %s", path, exc)
@@ -201,6 +235,7 @@ def save(book: PaperBook, path: str) -> None:
             book.last_run_timestamp.isoformat() if book.last_run_timestamp else None
         ),
         "runs_applied": sorted(book.runs_applied),
+        "rebased_at": book.rebased_at.isoformat() if book.rebased_at else None,
     }
     with open(file_path, "w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2)

--- a/tests/test_api_kill_switch.py
+++ b/tests/test_api_kill_switch.py
@@ -19,6 +19,7 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 import argus.risk.kill_switch as kill_switch_module
+from argus.risk import paper_book
 from argus.risk.kill_switch import KillSwitch
 
 
@@ -75,6 +76,24 @@ def test_kill_switch_reset_accepts_matching_api_key(client, monkeypatch):
         headers={"X-API-Key": "secret123"},
     )
     assert response.status_code == 200
+
+
+def test_kill_switch_reset_rebases_the_persisted_paper_book(client, monkeypatch, tmp_path):
+    """KS-15: reset rebases paper_equity.json, not just the in-memory kill switch —
+    otherwise the next reconcile pass would feed the stale, drawn-down equity back in
+    and re-halt within check_interval_seconds."""
+    monkeypatch.setattr(api_main.settings, "ARGUS_API_KEY", "")
+    kill_switch_module._kill_switch = KillSwitch("MODERATE")
+    book_path = tmp_path / "paper_equity.json"  # ARGUS_DATA_DIR is this tmp_path (conftest)
+    paper_book.save(paper_book.PaperBook(equity=80_000.0, high_water_mark=100_000.0), str(book_path))
+
+    response = client.post("/kill-switch/reset", params={"new_inception_value": 150_000})
+
+    assert response.status_code == 200
+    rebased = paper_book.load(str(book_path))
+    assert rebased.equity == pytest.approx(150_000.0)
+    assert rebased.high_water_mark == pytest.approx(150_000.0)
+    assert rebased.rebased_at is not None
 
 
 def test_kill_switch_reset_rejects_value_at_or_below_floor(client, monkeypatch):

--- a/tests/test_kill_switch.py
+++ b/tests/test_kill_switch.py
@@ -12,7 +12,7 @@ findings originally.
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import mock
 
 import pandas as pd
@@ -436,6 +436,61 @@ def test_compute_run_returns_skips_decisions_that_took_no_position():
     assert compute_run_returns([zero_weight], prices, horizon_days=5) == []
 
 
+def test_compute_run_returns_skips_runs_inside_the_previous_kept_runs_horizon():
+    """KS-14: a run timestamped inside the previous kept run's horizon is omitted, not compounded."""
+    run1 = datetime(2026, 1, 1)
+    run2 = run1 + timedelta(days=2)  # inside run1's 5-day horizon
+    d1 = _decision("AAA", run1, price=100.0, pct=0.1)
+    d2 = _decision("AAA", run2, price=100.0, pct=0.1)
+    prices = _FakePrices({"AAA": _series(run1, 100.0, days=20, drift=1.0)})
+
+    results = compute_run_returns([d1, d2], prices, horizon_days=5)
+
+    assert [r[0] for r in results] == [run1]
+
+
+def test_compute_run_returns_keeps_runs_exactly_horizon_days_apart():
+    """A run landing exactly on the previous kept run's horizon boundary is kept, not skipped."""
+    run1 = datetime(2026, 1, 1)
+    run2 = run1 + timedelta(days=5)
+    d1 = _decision("AAA", run1, price=100.0, pct=0.1)
+    d2 = _decision("AAA", run2, price=100.0, pct=0.1)
+    prices = _FakePrices({"AAA": _series(run1, 100.0, days=20, drift=1.0)})
+
+    results = compute_run_returns([d1, d2], prices, horizon_days=5)
+
+    assert [r[0] for r in results] == [run1, run2]
+
+
+def test_compute_run_returns_and_paperbook_survive_the_audit_simulation():
+    """KS-14: 120 daily runs at -0.1%/day must compound to their true cumulative decline,
+    not a MODERATE-halt-tripping blowup from compounding ~24x overlapping 5-day windows."""
+    start = datetime(2026, 1, 1)
+    decay = 0.999
+    days = 130
+    closes = pd.Series(
+        [100.0 * (decay**i) for i in range(days)],
+        index=pd.date_range(start=start, periods=days, freq="D"),
+    )
+    prices = _FakePrices({"AAA": closes})
+    decisions = [
+        _decision("AAA", start + timedelta(days=i), price=100.0 * (decay**i), pct=0.15)
+        for i in range(120)
+    ]
+
+    results = compute_run_returns(decisions, prices, horizon_days=5)
+
+    # Non-overlapping: one kept run every 5 days, not one per day
+    assert len(results) == 24
+
+    book = PaperBook(equity=100_000.0, high_water_mark=100_000.0)
+    for run_timestamp, run_return in results:
+        book.apply_run(run_timestamp, run_return)
+
+    assert book.drawdown_from_peak() == pytest.approx(1 - decay**120, abs=1e-4)
+    assert book.drawdown_from_peak() < kill_switch_module.KILL_SWITCH.moderate_drawdown_halt
+
+
 # ---------------------------------------------------------------------------
 # paper_book: PaperBook
 # ---------------------------------------------------------------------------
@@ -481,6 +536,46 @@ def test_paperbook_save_load_round_trip(tmp_path):
     assert loaded.high_water_mark == pytest.approx(110_000.0)
     assert loaded.last_run_timestamp == datetime(2026, 1, 1)
     assert loaded.runs_applied == {"2026-01-01T00:00:00"}
+
+
+def test_paperbook_rebase_sets_equity_and_hwm_and_leaves_runs_applied():
+    """KS-15: rebase() replaces equity/high_water_mark but leaves runs_applied untouched,
+    so a run already compounded into the old curve is never re-applied against the new base."""
+    book = PaperBook(
+        equity=88_000.0, high_water_mark=100_000.0, runs_applied={"2026-01-01T00:00:00"}
+    )
+
+    book.rebase(120_000.0, rebased_at=datetime(2026, 2, 1))
+
+    assert book.equity == pytest.approx(120_000.0)
+    assert book.high_water_mark == pytest.approx(120_000.0)
+    assert book.rebased_at == datetime(2026, 2, 1)
+    assert book.runs_applied == {"2026-01-01T00:00:00"}
+
+
+def test_paperbook_rebase_then_reapplying_an_already_applied_run_is_a_noop():
+    """After a rebase, re-running compute_run_returns over old decisions can't drag the
+    rebased equity back down, since the run is already in runs_applied (KS-15)."""
+    book = PaperBook(equity=100_000.0, high_water_mark=100_000.0)
+    ts = datetime(2026, 1, 1)
+    book.apply_run(ts, -0.12)
+
+    book.rebase(150_000.0)
+
+    assert book.apply_run(ts, -0.12) is False
+    assert book.equity == pytest.approx(150_000.0)
+
+
+def test_paperbook_save_load_round_trip_includes_rebased_at(tmp_path):
+    """rebased_at survives a save/load round trip."""
+    path = str(tmp_path / "paper_equity.json")
+    book = PaperBook(equity=100_000.0, high_water_mark=100_000.0)
+    book.rebase(150_000.0, rebased_at=datetime(2026, 2, 1))
+
+    paper_book.save(book, path)
+    loaded = paper_book.load(path)
+
+    assert loaded.rebased_at == datetime(2026, 2, 1)
 
 
 def test_paperbook_load_missing_file_starts_fresh_at_total_wealth(tmp_path):


### PR DESCRIPTION
PR 4 of issue #49's release remediation. Fixes KS-14 (compute_run_returns compounded every overlapping daily run instead of one per horizon_days window, turning a mild market decline into a MODERATE-threshold-tripping drawdown) and KS-15 (kill-switch reset rebased the in-memory equity but not paper_equity.json, so the next reconcile pass fed the stale drawn-down equity back in and re-halted).

Refs #49.