### PR TITLE
PR5: close the outcome loop

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,9 @@ that is genuinely available.
 
 Responsibilities:
   - Route analysis requests to the LangGraph execution pipeline
+  - Append every /analyze decision to the same decisions.jsonl log the
+    unattended collector writes to (see argus/orchestration/collector.py),
+    so reconciliation sees both entry points into the graph
   - Enforce kill-switch and VIX blackout checks before every allocation request
   - Expose health, memory, governor, and kill-switch management endpoints
   - Host the MFT pipeline as a background asyncio task and maintain a live
@@ -50,7 +53,11 @@ from argus.config import settings
 from argus.data.pipeline import MFTDataPipeline, max_bar_age_seconds, session_state_ttl_seconds
 from argus.data.tickers import TICKER_PATTERN
 from argus.memory.cultural import get_cultural_memory
-from argus.orchestration.collector import CollectionResult, run_collection_cycle
+from argus.orchestration.collector import (
+    CollectionResult,
+    append_decisions_jsonl,
+    run_collection_cycle,
+)
 from argus.orchestration.governor import REGISTERED_MODELS, RateLimitExceeded, UnregisteredModel, governor
 from argus.orchestration.graph import build_graph
 from argus.orchestration.reconciliation import load_decisions_from_jsonl, reconcile_decisions
@@ -824,6 +831,14 @@ async def analyze(req: AnalysisRequest):
         ref = uuid4()
         logger.error("[API] Graph error (ref %s): %s", ref, e, exc_info=True)
         raise HTTPException(500, f"Agent graph error (ref {ref})")
+
+    # /analyze is the other entry point into the graph besides the unattended
+    # collector (RE-11) — without this, decisions.jsonl (the only source
+    # reconcile_decisions reads) never sees a request served through this
+    # endpoint, and an API-only deployment reconciles nothing
+    append_decisions_jsonl(
+        final_state.get("decisions") or [], f"{settings.ARGUS_DATA_DIR}/decisions.jsonl"
+    )
 
     # Re-checked rather than trusted from before the (potentially many-second)
     # graph run: the kill switch is process-global and the reconcile loop can

--- a/argus/memory/cultural.py
+++ b/argus/memory/cultural.py
@@ -342,9 +342,14 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
     def summary_stats(self) -> dict:
         """Compiles aggregate performance statistics and regime diagnostics from the memory database.
 
+        avg_return_pct averages over settled rows only (SUCCESSFUL/FAILED/FLAT
+        outcomes carry a real return_pct; PENDING snapshots don't). Dividing by
+        total_stored instead — which includes every still-open PENDING
+        snapshot — structurally biases the average toward 0.0 (MEM-2).
+
         Returns:
             Dict with keys: total_stored, successful_count, failed_count,
-            avg_return_pct, best_regime_for_wins.
+            pending_count, avg_return_pct, best_regime_for_wins.
         """
         count = self.collection.count()
         if count == 0:
@@ -352,6 +357,7 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
                 "total_stored": 0,
                 "successful_count": 0,
                 "failed_count": 0,
+                "pending_count": 0,
                 "avg_return_pct": 0.0,
                 "best_regime_for_wins": "N/A",
             }
@@ -361,15 +367,21 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
             metadatas = results.get("metadatas") or []
             wins = 0
             fails = 0
+            pending = 0
+            settled = 0
             total_ret = 0.0
             regime_wins: dict[str, int] = {}
 
             for m in metadatas:
                 outcome = m.get("outcome")
-                ret = float(m.get("return_pct", 0.0) or 0.0)  # type: ignore[arg-type]  # chromadb metadata values are typed as a broad scalar union
                 regime = str(m.get("regime", "unknown"))
 
-                total_ret += ret
+                if outcome == "PENDING":
+                    pending += 1
+                    continue
+
+                settled += 1
+                total_ret += float(m.get("return_pct", 0.0) or 0.0)  # type: ignore[arg-type]  # chromadb metadata values are typed as a broad scalar union
                 if outcome == "SUCCESSFUL":
                     wins += 1
                     regime_wins[regime] = regime_wins.get(regime, 0) + 1
@@ -384,7 +396,8 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
                 "total_stored": count,
                 "successful_count": wins,
                 "failed_count": fails,
-                "avg_return_pct": total_ret / count if count > 0 else 0.0,
+                "pending_count": pending,
+                "avg_return_pct": total_ret / settled if settled > 0 else 0.0,
                 "best_regime_for_wins": best_regime,
             }
         except Exception as e:

--- a/argus/orchestration/collector.py
+++ b/argus/orchestration/collector.py
@@ -15,6 +15,9 @@ Responsibilities:
   - Invoke the caller-supplied compiled LangGraph DAG over whatever tickers
     the sweep actually populated
   - Append every resulting ARGUSDecision to a JSONL decision log
+    (append_decisions_jsonl is also called directly by api/main.py's
+    /analyze, the loop's other entry point into the graph, so the log
+    reflects both)
 
 Not responsible for:
   - Scheduling (see api/main.py's collector loop and scripts/collect_session.py)
@@ -55,8 +58,13 @@ class CollectionResult:
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
 
 
-def _append_decisions_jsonl(decisions: list[ARGUSDecision], path: str) -> int:
+def append_decisions_jsonl(decisions: list[ARGUSDecision], path: str) -> int:
     """Appends each decision to a JSONL log, one compact JSON object per line.
+
+    Shared by run_collection_cycle and api/main.py's /analyze — the two
+    entry points into the graph — so decisions.jsonl (the source
+    reconciliation reads, see orchestration/reconciliation.py) reflects
+    both instead of only the unattended collector's.
 
     Args:
         decisions: Decisions produced by this cycle's graph invocation.
@@ -191,7 +199,7 @@ async def run_collection_cycle(
         final_state = await asyncio.to_thread(compiled_graph.invoke, state, config)
 
     decisions: list[ARGUSDecision] = final_state.get("decisions") or []
-    logged = _append_decisions_jsonl(decisions, decisions_log_path)
+    logged = append_decisions_jsonl(decisions, decisions_log_path)
     errors = final_state.get("errors") or []
 
     macro_context = final_state.get("macro_context")

--- a/scripts/remediate_macro_regime_tags.py
+++ b/scripts/remediate_macro_regime_tags.py
@@ -46,13 +46,15 @@ def main() -> None:
     shutil.copy2(sqlite_path, backup_path)
     print(f"Backed up {sqlite_path} to {backup_path}")
 
-    import chromadb
+    from argus.memory.cultural import CulturalMemoryManager
 
-    client = chromadb.PersistentClient(
-        path=args.persist_dir,
-        settings=chromadb.config.Settings(anonymized_telemetry=False),
-    )
-    collection = client.get_or_create_collection(name="argus_wisdom")
+    # Opening the collection with its configured embedding_function (rather than
+    # bare chromadb.get_or_create_collection, which falls back to Chroma's default
+    # ONNX function) matters here: update() below re-embeds every document it
+    # touches (MEM-1) — the wrong function would silently corrupt the very rows
+    # this script means to fix.
+    manager = CulturalMemoryManager(persist_dir=args.persist_dir)
+    collection = manager.collection
 
     rows = collection.get(where={"regime": STALE_REGIME})
     ids = rows["ids"]

--- a/tests/test_api_concurrency.py
+++ b/tests/test_api_concurrency.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -27,6 +28,7 @@ from fastapi.testclient import TestClient
 import api.main as api_main
 import argus.risk.kill_switch as kill_switch_module
 from argus.risk.kill_switch import KillSwitch
+from argus.schemas.signals import ARGUSDecision
 
 _PAYLOAD = {"tickers": ["AAPL"], "total_wealth": 100_000, "invest_pct": 0.5}
 
@@ -164,3 +166,60 @@ async def test_mft_session_callback_evicts_untracked_tickers(monkeypatch):
 
     assert "MSFT" not in api_main._live_session_cache
     assert "AAPL" in api_main._live_session_cache
+
+
+# ---------------------------------------------------------------------------
+# RE-11: /analyze decisions reach decisions.jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_appends_decisions_to_decisions_jsonl(client, monkeypatch):
+    """A successful /analyze run appends its decisions to the log the collector also writes to.
+
+    Without this, decisions.jsonl — the only source reconcile_decisions
+    reads — never sees a decision made through /analyze, and an API-only
+    deployment reconciles nothing.
+    """
+    _ready(client, monkeypatch)
+    decision = ARGUSDecision(ticker="AAPL", session_timestamp=datetime.now())
+    allocation = mock.Mock(
+        session_id="sess-1", portfolio=[], cash_reserve_pct=0.5, expected_sharpe=1.0
+    )
+    fake_graph = mock.Mock()
+    fake_graph.invoke.return_value = {
+        "decisions": [decision],
+        "errors": [],
+        "portfolio_allocation": allocation,
+        "macro_context": None,
+    }
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 200
+    log_path = Path(api_main.settings.ARGUS_DATA_DIR) / "decisions.jsonl"
+    lines = log_path.read_text().splitlines()
+    assert len(lines) == 1
+    assert ARGUSDecision.model_validate_json(lines[0]).decision_id == decision.decision_id
+
+
+def test_analyze_writes_nothing_when_the_graph_produces_no_decisions(client, monkeypatch):
+    """A run with an empty decisions list leaves decisions.jsonl unwritten, not an empty file."""
+    _ready(client, monkeypatch)
+    allocation = mock.Mock(
+        session_id="sess-1", portfolio=[], cash_reserve_pct=0.5, expected_sharpe=1.0
+    )
+    fake_graph = mock.Mock()
+    fake_graph.invoke.return_value = {
+        "decisions": [],
+        "errors": [],
+        "portfolio_allocation": allocation,
+        "macro_context": None,
+    }
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 200
+    log_path = Path(api_main.settings.ARGUS_DATA_DIR) / "decisions.jsonl"
+    assert not log_path.exists()

--- a/tests/test_cultural.py
+++ b/tests/test_cultural.py
@@ -10,6 +10,8 @@ and query-shaping over already-stored metadata.
 from datetime import datetime
 from unittest import mock
 
+import pytest
+
 from argus.memory.cultural import CulturalMemoryManager, get_cultural_memory
 from argus.params import MEMORY, RECONCILIATION
 from argus.schemas.signals import (
@@ -222,6 +224,45 @@ def test_already_reconciled_empty_input_skips_the_query():
 
     assert manager.already_reconciled([]) == set()
     manager.collection.get.assert_not_called()
+
+
+def test_summary_stats_averages_return_over_settled_rows_only():
+    """avg_return_pct excludes PENDING rows from both the numerator and denominator.
+
+    Regression test for MEM-2: PENDING snapshots carry no return_pct, so
+    dividing by total_stored (which includes them) structurally biases the
+    average toward 0.0.
+    """
+    manager = _manager_with_metadatas(
+        [
+            {"outcome": "SUCCESSFUL", "return_pct": 0.10, "regime": "EXPANSION"},
+            {"outcome": "FAILED", "return_pct": -0.04, "regime": "EXPANSION"},
+            {"outcome": "PENDING", "regime": "EXPANSION"},
+            {"outcome": "PENDING", "regime": "EXPANSION"},
+        ]
+    )
+
+    stats = manager.summary_stats()
+
+    assert stats["total_stored"] == 4
+    assert stats["pending_count"] == 2
+    assert stats["successful_count"] == 1
+    assert stats["failed_count"] == 1
+    assert stats["avg_return_pct"] == pytest.approx((0.10 - 0.04) / 2)
+
+
+def test_summary_stats_all_pending_reports_zero_average_without_dividing_by_zero():
+    """An all-PENDING store reports avg_return_pct=0.0 rather than raising ZeroDivisionError."""
+    manager = _manager_with_metadatas(
+        [
+            {"outcome": "PENDING", "regime": "EXPANSION"},
+        ]
+    )
+
+    stats = manager.summary_stats()
+
+    assert stats["pending_count"] == 1
+    assert stats["avg_return_pct"] == 0.0
 
 
 def test_store_decision_snapshot_returns_true_on_success():


### PR DESCRIPTION
PR 5 of issue #49's release remediation. Fixes RE-11 (`/analyze`'s decisions never reached `decisions.jsonl`, the only source reconciliation reads, so an API-only deployment reconciled nothing — the dedup half of this finding, `already_reconciled`, already shipped) and MEM-2 (`summary_stats.avg_return_pct` divided by a row count that includes returnless `PENDING` snapshots, structurally biasing it toward 0.0; it now averages over settled rows and reports `pending_count` separately). Also fixes MEM-1: the regime-tag remediation script opened the Chroma collection without its configured embedding function, so `update()` silently re-embedded documents with the wrong model.

RE-12 is an acceptance gate, not a code change — it's the end-to-end collect → horizon wait → reconcile pass to run once PRs 1-5 are all live.

Refs #49.