### PR TITLE
PR 6: bound every growing store

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -20,7 +20,9 @@ Responsibilities:
     session state cache consumed by /analyze
   - Optionally run the unattended collector and daily reconciliation loops
     (ARGUS_COLLECTOR_ENABLED / ARGUS_RECONCILE_ENABLED) so the system keeps
-    accumulating decisions and outcomes without a human calling /analyze
+    accumulating decisions and outcomes without a human calling /analyze,
+    pruning every store the reconcile loop touches back to a bounded window
+    (PR 6) as part of the same daily pass
   - Serialize graph invocations across /analyze and the collector loop, and
     guard against a second process sharing this one's data directory
 
@@ -60,7 +62,12 @@ from argus.orchestration.collector import (
 )
 from argus.orchestration.governor import REGISTERED_MODELS, RateLimitExceeded, UnregisteredModel, governor
 from argus.orchestration.graph import build_graph
-from argus.orchestration.reconciliation import load_decisions_from_jsonl, reconcile_decisions
+from argus.orchestration.reconciliation import (
+    compact_decisions_jsonl,
+    load_decisions_from_jsonl,
+    prune_checkpoints,
+    reconcile_decisions,
+)
 from argus.orchestration.state import ARGUSState
 from argus.params import RECONCILIATION, SYSTEM
 from argus.risk import paper_book
@@ -196,8 +203,43 @@ async def _collector_loop(pipeline: MFTDataPipeline, compiled_graph) -> None:
         await asyncio.sleep(settings.ARGUS_COLLECTOR_INTERVAL_SECONDS)
 
 
+def _prune_growing_stores(decisions_log: str) -> None:
+    """Bounds the decision/checkpoint/PENDING-snapshot stores, all on one horizon-plus-margin cutoff (PR 6).
+
+    Runs after reconcile_decisions has already had its chance at every session
+    up to the same cutoff, so nothing pruned here was still reconcilable.
+    Failures are logged and swallowed independently per store — a checkpoint
+    DB VACUUM failing must not skip compacting decisions.jsonl, or vice versa.
+
+    Args:
+        decisions_log: Same decisions.jsonl path the caller just reconciled.
+    """
+    cutoff = datetime.now() - timedelta(
+        days=RECONCILIATION.horizon_days + RECONCILIATION.retention_margin_days
+    )
+
+    try:
+        kept = compact_decisions_jsonl(decisions_log, cutoff)
+        logger.info("[Reconcile] compacted decisions.jsonl to %d retained decision(s)", kept)
+    except Exception:
+        logger.exception("[Reconcile] decisions.jsonl compaction failed")
+
+    try:
+        checkpoint_db = f"{settings.ARGUS_DATA_DIR}/argus_graph.db"
+        pruned = prune_checkpoints(checkpoint_db, cutoff)
+        logger.info("[Reconcile] pruned %d stale checkpoint thread(s)", pruned)
+    except Exception:
+        logger.exception("[Reconcile] checkpoint pruning failed")
+
+    try:
+        expired = get_cultural_memory().expire_pending_snapshots(cutoff)
+        logger.info("[Reconcile] expired %d stale PENDING snapshot(s)", expired)
+    except Exception:
+        logger.exception("[Reconcile] PENDING snapshot expiry failed")
+
+
 def _reconcile_once() -> None:
-    """Runs one reconciliation pass: outcome backfill, paper-book update, kill-switch sync.
+    """Runs one reconciliation pass: outcome backfill, paper-book update, kill-switch sync, store pruning.
 
     Synchronous by design — `_reconcile_loop` runs this via `asyncio.to_thread`
     since it performs per-ticker yfinance fetches directly, which would
@@ -221,6 +263,10 @@ def _reconcile_once() -> None:
             decisions, market_data, RECONCILIATION.horizon_days
         ):
             book.apply_run(run_timestamp, run_return)
+        book.prune_runs_applied(
+            datetime.now()
+            - timedelta(days=RECONCILIATION.horizon_days + RECONCILIATION.retention_margin_days)
+        )
         paper_book.save(book, book_path)
 
         ks = get_kill_switch()
@@ -233,6 +279,8 @@ def _reconcile_once() -> None:
         )
     except Exception:
         logger.exception("[Reconcile] paper-book update failed")
+
+    _prune_growing_stores(decisions_log)
 
 
 async def _reconcile_loop() -> None:

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -59,6 +59,13 @@ _TRADING_MINUTES_PER_DAY = 390
 _FETCH_PERIOD_DAYS = SYSTEM.candle_buffer_days_retained
 _FETCH_PERIOD = f"{_FETCH_PERIOD_DAYS}d"
 
+# Once a ticker's buffer already holds an indicator-ready depth, a sweep only
+# needs to catch the candles written since the last one — "1d" (yfinance's
+# shortest supported intraday period) comfortably covers one _FETCH_INTERVAL
+# gap, and insert_candles' INSERT OR REPLACE makes the overlap with what's
+# already buffered a no-op rather than a duplicate (MFT-15)
+_STEADY_STATE_FETCH_PERIOD = "1d"
+
 # RSI/MACD/BB/ATR/ADX/VWAP/volume-ratio are computed on bars resampled to this
 # resolution regardless of the raw fetch interval — RSI-14 on 1m bars is a
 # 14-minute lookback, too twitchy for a decision cadence measured in tens of minutes
@@ -536,13 +543,23 @@ class MFTDataPipeline:
     def _fetch_and_insert(self, ticker: str) -> tuple[int, float]:
         """Synchronous fetch-and-bulk-insert for one ticker; run off the event loop.
 
+        Fetches the full `_FETCH_PERIOD` only while the ticker's buffer is
+        still cold (a new ticker, or the first sweep after a restart);
+        otherwise fetches just `_STEADY_STATE_FETCH_PERIOD`'s worth (MFT-15).
+        Re-downloading and re-upserting two full days of 1-minute candles
+        every `_FETCH_INTERVAL` regardless of how warm the buffer already is
+        multiplies out to ~15,600 row upserts per sweep at 20 tickers, almost
+        all of them re-writing rows already on disk unchanged.
+
         Args:
             ticker: Equity ticker symbol to fetch.
 
         Returns:
             Tuple of (candles inserted, latest close). (0, 0.0) on an empty fetch.
         """
-        df: pd.DataFrame = fetch_ohlcv_intraday(ticker, self.interval, _FETCH_PERIOD)
+        is_cold = self.buffer.row_counts().get(ticker, 0) < _required_raw_bars(self.interval_minutes)
+        period = _FETCH_PERIOD if is_cold else _STEADY_STATE_FETCH_PERIOD
+        df: pd.DataFrame = fetch_ohlcv_intraday(ticker, self.interval, period)
         if df is None or df.empty:
             return 0, 0.0
 

--- a/argus/memory/cultural.py
+++ b/argus/memory/cultural.py
@@ -10,6 +10,8 @@ Responsibilities:
   - Persist successful and failed trade outcomes as embedded documents
   - Retrieve semantically similar historical patterns for current macro and technical contexts
   - Expose agent-level accuracy statistics and regime diagnostics
+  - Expire PENDING decision snapshots that never settled (see
+    expire_pending_snapshots), so the collection stays bounded
 
 Not responsible for:
   - Real-time signal generation (see agents/)
@@ -460,6 +462,58 @@ Outcome: {actual_return_pct * 100:+.1f}% in {holding_days} days. Exit: {exit_rea
         except Exception as e:
             logger.warning("[Memory] Failed to snapshot decision for %s: %s", decision.ticker, e)
             return False
+
+    def expire_pending_snapshots(self, cutoff: datetime) -> int:
+        """Deletes PENDING decision snapshots older than cutoff (MEM-3).
+
+        A snapshot only leaves PENDING once store_trade_outcome settles it
+        (see its docstring); a decision that never took a position, or whose
+        reconciliation permanently fails (e.g. the ticker's price history is
+        never fetchable again), would otherwise sit PENDING indefinitely,
+        growing the collection and dragging summary_stats.pending_count up
+        forever. Called on the same reconciliation cadence as
+        orchestration.reconciliation.prune_checkpoints and
+        compact_decisions_jsonl, with the same horizon-plus-margin cutoff — a
+        snapshot that old has already had its chance to settle.
+
+        Args:
+            cutoff: Snapshots whose ``timestamp`` metadata is before this are
+                deleted. Should be tz-naive, matching the naive
+                session_timestamps snapshots are stored with.
+
+        Returns:
+            Count of snapshots deleted.
+        """
+        try:
+            results = self.collection.get(where={"outcome": "PENDING"})
+        except Exception as e:
+            logger.warning("[Memory] Failed to query PENDING snapshots for expiry: %s", e)
+            return 0
+
+        ids = results.get("ids") or []
+        metadatas = results.get("metadatas") or []
+        stale_ids = []
+        for doc_id, meta in zip(ids, metadatas):
+            timestamp_raw = meta.get("timestamp")
+            if not timestamp_raw:
+                continue
+            try:
+                if datetime.fromisoformat(str(timestamp_raw)) < cutoff:
+                    stale_ids.append(doc_id)
+            except ValueError:
+                continue
+
+        if not stale_ids:
+            return 0
+
+        try:
+            self.collection.delete(ids=stale_ids)
+        except Exception as e:
+            logger.warning("[Memory] Failed to delete stale PENDING snapshot(s): %s", e)
+            return 0
+
+        logger.info("[Memory] Expired %d stale PENDING snapshot(s)", len(stale_ids))
+        return len(stale_ids)
 
 
 _cultural_memory: Optional[CulturalMemoryManager] = None

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -203,7 +203,7 @@ def build_graph(
     fundamental_llm: Optional[LLMClient] = None,
     sentiment_llm: Optional[LLMClient] = None,
     portfolio_llm: Optional[LLMClient] = None,
-    checkpoint_db_path: str = "argus_graph.db",
+    checkpoint_db_path: Optional[str] = None,
 ):
     """Constructs and compiles the ARGUS decision graph.
 
@@ -220,14 +220,19 @@ def build_graph(
         checkpoint_db_path: SQLite file each invocation checkpoints ARGUSState
             to. Exposed (rather than hardcoded) so tests — and
             argus/orchestration/reconciliation.py's own tests — can point it
-            at a temp file instead of the real argus_graph.db production
-            callers use.
+            at a temp file instead of the real store production callers use.
+            None (default) resolves to ``<ARGUS_DATA_DIR>/argus_graph.db`` at
+            call time (X-5), so tests/conftest.py's per-test ARGUS_DATA_DIR
+            override also isolates a call site that omits this argument.
 
     Returns:
         A _CheckpointedGraph, ready for .invoke(). Recompiles with a fresh
         checkpointer connection on every call rather than baking one
         connection into a single compiled graph — see _CheckpointedGraph.
     """
+    if checkpoint_db_path is None:
+        checkpoint_db_path = str(Path(settings.ARGUS_DATA_DIR) / "argus_graph.db")
+
     market_data = market_data or LiveMarketDataProvider()
 
     macro_agent = MacroStatisticalAgent(market_data=market_data)

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -19,6 +19,8 @@ Responsibilities:
     argus_graph.db
   - load_decisions_from_jsonl: read ARGUSDecision objects back out of a
     decisions.jsonl log (the unattended collector's lighter-weight alternative)
+  - prune_checkpoints / compact_decisions_jsonl: bound the two decision
+    stores above so neither grows forever (PR 6)
 
 Not responsible for:
   - Deciding what a "good" outcome is, or evaluation metrics (see PR 10 /
@@ -413,3 +415,109 @@ def load_decisions_from_jsonl(path: str) -> list[ARGUSDecision]:
                     exc,
                 )
     return decisions
+
+
+def compact_decisions_jsonl(path: str, cutoff: datetime) -> int:
+    """Rewrites a decisions.jsonl log, dropping sessions older than cutoff (COL-1).
+
+    Meant to run right after a reconcile_decisions() pass over the same log
+    (see api/main.py's _reconcile_once and scripts/reconcile_outcomes.py) with
+    a cutoff at or before that pass's horizon: a decision that old has already
+    had its one chance at reconciliation, so dropping it here only stops the
+    log growing forever, it does not cost a delayed reconcile pass anything.
+
+    Args:
+        path: decisions.jsonl path.
+        cutoff: Decisions with session_timestamp before this are dropped. Should
+            be tz-naive, matching the naive timestamps this log stores.
+
+    Returns:
+        Count of decisions retained. 0 (and no file written) if the file
+        doesn't exist yet.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        return 0
+
+    decisions = load_decisions_from_jsonl(path)
+    cutoff_naive = _as_naive_timestamp(cutoff)
+    kept = [d for d in decisions if _as_naive_timestamp(d.session_timestamp) >= cutoff_naive]
+    if len(kept) == len(decisions):
+        return len(kept)
+
+    tmp_path = file_path.with_suffix(file_path.suffix + ".tmp")
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        for decision in kept:
+            f.write(decision.model_dump_json() + "\n")
+    tmp_path.replace(file_path)
+
+    logger.info(
+        "compact_decisions_jsonl: kept %d/%d decision(s) in %s (cutoff=%s)",
+        len(kept),
+        len(decisions),
+        path,
+        cutoff_naive.isoformat(),
+    )
+    return len(kept)
+
+
+def prune_checkpoints(db_path: str, cutoff: datetime) -> int:
+    """Deletes every checkpoint thread whose most recent checkpoint predates cutoff, then VACUUMs (RE-13).
+
+    Each build_graph() invocation checkpoints under a fresh, never-reused
+    thread_id (see build_graph()'s callers) and nothing resumes a thread by
+    id, so a thread's checkpoints exist only as load_decisions_from_checkpoints'
+    read path — a fallback now that RE-11 makes decisions.jsonl the durable
+    record both /analyze and the collector write to. Retention, not removal:
+    the checkpoint DB stays available as that fallback for anything within the
+    reconciliation window, it just no longer grows without bound.
+
+    Args:
+        db_path: Path to the SQLite file build_graph() checkpoints to.
+        cutoff: Threads whose newest checkpoint timestamp is before this are
+            deleted. Should be tz-naive, matching the naive timestamps
+            LangGraph checkpoint metadata is compared against here.
+
+    Returns:
+        Count of threads deleted. 0 if the database doesn't exist yet.
+    """
+    if not Path(db_path).exists():
+        return 0
+
+    cutoff_naive = _as_naive_timestamp(cutoff)
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    try:
+        saver = SqliteSaver(conn, serde=build_checkpoint_serde())
+        seen_threads: set[str] = set()
+        stale_threads: list[str] = []
+        for tup in saver.list(None):
+            thread_id = tup.config["configurable"]["thread_id"]
+            if thread_id in seen_threads:
+                continue
+            seen_threads.add(thread_id)
+            ts_raw = tup.checkpoint.get("ts")
+            if ts_raw is None:
+                continue
+            if _as_naive_timestamp(datetime.fromisoformat(ts_raw)) < cutoff_naive:
+                stale_threads.append(thread_id)
+
+        if not stale_threads:
+            return 0
+
+        cur = conn.cursor()
+        cur.executemany(
+            "DELETE FROM checkpoints WHERE thread_id = ?", [(t,) for t in stale_threads]
+        )
+        cur.executemany("DELETE FROM writes WHERE thread_id = ?", [(t,) for t in stale_threads])
+        conn.commit()
+        conn.execute("VACUUM")
+    finally:
+        conn.close()
+
+    logger.info(
+        "prune_checkpoints: deleted %d thread(s) from %s (cutoff=%s)",
+        len(stale_threads),
+        db_path,
+        cutoff_naive.isoformat(),
+    )
+    return len(stale_threads)

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 13
+PARAMS_VERSION = 14
 
 
 class Provenance(str, Enum):
@@ -346,6 +346,14 @@ class ReconciliationParams:
         Provenance.ARBITRARY,
         "matches cultural.store_trade_outcome's SUCCESSFUL/FAILED/FLAT |return| "
         "classification threshold; kept here so both live in one place",
+    )
+    retention_margin_days: int = p(
+        2,
+        Provenance.ARBITRARY,
+        "buffer beyond horizon_days before a decision, checkpoint, or PENDING "
+        "snapshot is pruned as growing-store cleanup (PR 6) — wide enough that "
+        "a delayed reconcile pass still finds it first, no basis for this "
+        "specific width",
     )
 
 

--- a/argus/risk/paper_book.py
+++ b/argus/risk/paper_book.py
@@ -19,8 +19,8 @@ Responsibilities:
     weight-average each non-overlapping run's matured outcomes into one
     compounding return
   - PaperBook: equity/high-water-mark/applied-runs state, with idempotent
-    run application and manual rebasing (see rebase(), used by
-    KillSwitch.reset())
+    run application, manual rebasing (see rebase(), used by
+    KillSwitch.reset()), and bounded runs_applied retention (prune_runs_applied)
   - load / save: JSON round trip at a caller-supplied path
 
 Not responsible for:
@@ -179,6 +179,30 @@ class PaperBook:
         self.equity = new_inception_value
         self.high_water_mark = new_inception_value
         self.rebased_at = rebased_at or datetime.now()
+
+    def prune_runs_applied(self, cutoff: datetime) -> int:
+        """Drops runs_applied entries older than cutoff, so the set doesn't grow forever (COL-1).
+
+        Safe to prune independently of equity/high_water_mark: runs_applied
+        exists only to make apply_run idempotent against re-processing a run
+        compute_run_returns has already returned once, and a run this old will
+        never be recomputed again — decisions that far back have either
+        already been compacted out of decisions.jsonl or fall outside every
+        horizon window compute_run_returns groups by.
+
+        Args:
+            cutoff: Runs applied before this timestamp are dropped from
+                tracking. Should be tz-naive, matching the naive
+                session_timestamps runs_applied entries are derived from.
+
+        Returns:
+            Count of entries dropped.
+        """
+        before = len(self.runs_applied)
+        self.runs_applied = {
+            key for key in self.runs_applied if datetime.fromisoformat(key) >= cutoff
+        }
+        return before - len(self.runs_applied)
 
 
 def load(path: str) -> PaperBook:

--- a/scripts/reconcile_outcomes.py
+++ b/scripts/reconcile_outcomes.py
@@ -8,7 +8,11 @@ RECONCILIATION.horizon_days against live market data, and reports how many
 outcomes were stored to cultural memory. Also applies matured runs onto the
 persisted paper equity curve (argus/risk/paper_book.py) so the scheduled
 GitHub Actions runner — which has no long-lived KillSwitch daemon to feed —
-still keeps that curve current for whichever process reads it next.
+still keeps that curve current for whichever process reads it next. Finally
+prunes decisions.jsonl, the checkpoint DB, PENDING snapshots, and
+runs_applied back to a bounded window (PR 6), the same cleanup api/main.py's
+_reconcile_once performs, since this script is the only reconcile pass a
+collector-only deployment (no long-lived API process) ever gets.
 
     .venv/bin/python scripts/reconcile_outcomes.py [--db PATH] [--horizon-days N]
     .venv/bin/python scripts/reconcile_outcomes.py --decisions-log PATH
@@ -22,12 +26,15 @@ from __future__ import annotations
 
 import argparse
 import logging
+from datetime import datetime, timedelta
 
 from argus.config import settings
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.reconciliation import (
+    compact_decisions_jsonl,
     load_decisions_from_checkpoints,
     load_decisions_from_jsonl,
+    prune_checkpoints,
     reconcile_decisions,
 )
 from argus.params import RECONCILIATION
@@ -42,7 +49,11 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--db", default="argus_graph.db", help="Path to the LangGraph checkpoint database")
+    parser.add_argument(
+        "--db",
+        default=f"{settings.ARGUS_DATA_DIR}/argus_graph.db",
+        help="Path to the LangGraph checkpoint database",
+    )
     parser.add_argument(
         "--decisions-log",
         default=None,
@@ -79,11 +90,26 @@ def main() -> None:
         decisions, market_data, args.horizon_days
     ):
         book.apply_run(run_timestamp, run_return)
+
+    cutoff = datetime.now() - timedelta(
+        days=args.horizon_days + RECONCILIATION.retention_margin_days
+    )
+    book.prune_runs_applied(cutoff)
     paper_book.save(book, book_path)
     print(
         f"Paper equity: ${book.equity:,.2f} "
         f"(drawdown={book.drawdown_from_peak():.1%} from peak ${book.high_water_mark:,.2f})"
     )
+
+    if args.decisions_log:
+        kept = compact_decisions_jsonl(args.decisions_log, cutoff)
+        print(f"Compacted {args.decisions_log}: {kept} decision(s) retained")
+
+    pruned = prune_checkpoints(args.db, cutoff)
+    print(f"Pruned {pruned} stale checkpoint thread(s) from {args.db}")
+
+    expired = get_cultural_memory().expire_pending_snapshots(cutoff)
+    print(f"Expired {expired} stale PENDING snapshot(s)")
 
 
 if __name__ == "__main__":

--- a/tests/test_cultural.py
+++ b/tests/test_cultural.py
@@ -265,6 +265,48 @@ def test_summary_stats_all_pending_reports_zero_average_without_dividing_by_zero
     assert stats["avg_return_pct"] == 0.0
 
 
+def _manager_with_pending(ids: list[str], timestamps: list[str]) -> CulturalMemoryManager:
+    manager = object.__new__(CulturalMemoryManager)
+    manager.collection = mock.Mock()
+    manager.collection.get.return_value = {
+        "ids": ids,
+        "metadatas": [{"outcome": "PENDING", "timestamp": ts} for ts in timestamps],
+    }
+    return manager
+
+
+def test_expire_pending_snapshots_deletes_only_entries_before_cutoff():
+    """MEM-3: a snapshot older than cutoff is deleted; one at or after it survives."""
+    manager = _manager_with_pending(
+        ids=["snapshot_old", "snapshot_new"],
+        timestamps=["2026-01-01T00:00:00", "2026-01-20T00:00:00"],
+    )
+
+    deleted = manager.expire_pending_snapshots(cutoff=datetime(2026, 1, 10))
+
+    assert deleted == 1
+    manager.collection.get.assert_called_once_with(where={"outcome": "PENDING"})
+    manager.collection.delete.assert_called_once_with(ids=["snapshot_old"])
+
+
+def test_expire_pending_snapshots_nothing_stale_does_not_call_delete():
+    """When every PENDING snapshot is at or after cutoff, delete() is never called."""
+    manager = _manager_with_pending(ids=["snapshot_new"], timestamps=["2026-01-20T00:00:00"])
+
+    deleted = manager.expire_pending_snapshots(cutoff=datetime(2026, 1, 1))
+
+    assert deleted == 0
+    manager.collection.delete.assert_not_called()
+
+
+def test_expire_pending_snapshots_empty_store_is_a_noop():
+    """No PENDING rows at all is a no-op, not an error."""
+    manager = _manager_with_pending(ids=[], timestamps=[])
+
+    assert manager.expire_pending_snapshots(cutoff=datetime(2026, 1, 1)) == 0
+    manager.collection.delete.assert_not_called()
+
+
 def test_store_decision_snapshot_returns_true_on_success():
     """A successful upsert reports success so callers can count real writes."""
     manager = _manager_with_metadatas([])

--- a/tests/test_golden_dag.py
+++ b/tests/test_golden_dag.py
@@ -100,11 +100,17 @@ def _strip_volatile(obj):
     return obj
 
 
-def _run_fixture_graph() -> dict:
+def _run_fixture_graph(tmp_path: Path) -> dict:
     """Invoke the fixture-backed DAG once, with cultural memory mocked out.
 
     The governor needs no patch: every LLM call here is fixture-backed, and
     FixtureLLMClient never reaches it (only GroqLLMClient does).
+
+    Args:
+        tmp_path: Per-test checkpoint directory (X-5) — keeps this run's
+            checkpoints out of the real argus_graph.db, not just the fixture
+            autouse `_isolated_data_dir` build_graph()'s default would also
+            resolve against.
 
     Returns:
         The final ARGUSState dict produced by the graph.
@@ -114,6 +120,7 @@ def _run_fixture_graph() -> dict:
         fundamental_llm=_per_ticker_llm("fundamental.json"),
         sentiment_llm=_per_ticker_llm("sentiment.json"),
         portfolio_llm=_portfolio_llm(),
+        checkpoint_db_path=str(tmp_path / "argus_graph_test.db"),
     )
     config = {"configurable": {"thread_id": str(uuid4())}}
 
@@ -142,7 +149,7 @@ class _NoneMacroMarketData(FixtureMarketDataProvider):
         return {"vix": None, "fed_funds": None, "t10y2y": None}
 
 
-def test_macro_context_none_still_produces_a_degraded_allocation():
+def test_macro_context_none_still_produces_a_degraded_allocation(tmp_path):
     """A None macro_context must not gate the three specialists or the allocator.
 
     Regression test for X1: no specialist agent consumes MacroContext, so a FRED
@@ -155,6 +162,7 @@ def test_macro_context_none_still_produces_a_degraded_allocation():
         fundamental_llm=_per_ticker_llm("fundamental.json"),
         sentiment_llm=_per_ticker_llm("sentiment.json"),
         portfolio_llm=_portfolio_llm(),
+        checkpoint_db_path=str(tmp_path / "argus_graph_test.db"),
     )
     config = {"configurable": {"thread_id": str(uuid4())}}
 
@@ -212,7 +220,7 @@ class _SpyCountingMarketData(FixtureMarketDataProvider):
         return result
 
 
-def test_spy_fetched_once_per_graph_run_not_once_per_risk_call():
+def test_spy_fetched_once_per_graph_run_not_once_per_risk_call(tmp_path):
     """RE-5 regression: SPY rides along with node_fetch_price_history's universe fetch.
 
     Before the fix, node_fetch_price_history never carried SPY in price_history, so
@@ -226,6 +234,7 @@ def test_spy_fetched_once_per_graph_run_not_once_per_risk_call():
         fundamental_llm=_per_ticker_llm("fundamental.json"),
         sentiment_llm=_per_ticker_llm("sentiment.json"),
         portfolio_llm=_portfolio_llm(),
+        checkpoint_db_path=str(tmp_path / "argus_graph_test.db"),
     )
     config = {"configurable": {"thread_id": str(uuid4())}}
 
@@ -254,7 +263,7 @@ class _CountingVixMarketData(_NoneMacroMarketData):
         return super().vix()
 
 
-def test_macro_context_none_still_reaches_a_real_vix_reading():
+def test_macro_context_none_still_reaches_a_real_vix_reading(tmp_path):
     """RE-6 regression: a FRED outage must not silently default the blackout gate to 20.0.
 
     _NoneMacroMarketData forces macro_bundle() (hence macro_context) to None but leaves
@@ -268,6 +277,7 @@ def test_macro_context_none_still_reaches_a_real_vix_reading():
         fundamental_llm=_per_ticker_llm("fundamental.json"),
         sentiment_llm=_per_ticker_llm("sentiment.json"),
         portfolio_llm=_portfolio_llm(),
+        checkpoint_db_path=str(tmp_path / "argus_graph_test.db"),
     )
     config = {"configurable": {"thread_id": str(uuid4())}}
 
@@ -284,9 +294,9 @@ def test_macro_context_none_still_reaches_a_real_vix_reading():
     assert provider.vix_calls == 1
 
 
-def test_golden_dag_runs_offline_and_produces_a_valid_allocation():
+def test_golden_dag_runs_offline_and_produces_a_valid_allocation(tmp_path):
     """The fixture-backed DAG runs end to end with zero network/LLM/torch dependencies."""
-    final_state = _run_fixture_graph()
+    final_state = _run_fixture_graph(tmp_path)
 
     assert final_state.get("macro_context") is not None
     assert final_state.get("technical_signals")
@@ -314,7 +324,7 @@ def test_golden_dag_runs_offline_and_produces_a_valid_allocation():
             assert pos.allocation_pct == 0.0
 
 
-def test_missing_indicator_is_reported_in_errors_not_silently_dropped():
+def test_missing_indicator_is_reported_in_errors_not_silently_dropped(tmp_path):
     """A ticker missing a required indicator is excluded from technical_signals
 
     and named in state["errors"], rather than vanishing with no trace.
@@ -331,6 +341,7 @@ def test_missing_indicator_is_reported_in_errors_not_silently_dropped():
         fundamental_llm=_per_ticker_llm("fundamental.json"),
         sentiment_llm=_per_ticker_llm("sentiment.json"),
         portfolio_llm=_portfolio_llm(),
+        checkpoint_db_path=str(tmp_path / "argus_graph_test.db"),
     )
     config = {"configurable": {"thread_id": str(uuid4())}}
 
@@ -347,7 +358,7 @@ def test_missing_indicator_is_reported_in_errors_not_silently_dropped():
     assert any("NVDA" in e for e in final_state["errors"])
 
 
-def test_missing_indicator_still_reaches_aggregation_with_evidence_surfaced():
+def test_missing_indicator_still_reaches_aggregation_with_evidence_surfaced(tmp_path):
     """A ticker missing one specialist still reaches aggregated_signals
 
     with the gap named in agents_present, and the allocator's prompt shows
@@ -377,6 +388,7 @@ def test_missing_indicator_still_reaches_aggregation_with_evidence_surfaced():
         fundamental_llm=_per_ticker_llm("fundamental.json"),
         sentiment_llm=_per_ticker_llm("sentiment.json"),
         portfolio_llm=portfolio_llm,
+        checkpoint_db_path=str(tmp_path / "argus_graph_test.db"),
     )
     config = {"configurable": {"thread_id": str(uuid4())}}
 
@@ -397,7 +409,7 @@ def test_missing_indicator_still_reaches_aggregation_with_evidence_surfaced():
     assert "Evidence=2/3" in captured_prompts[0]
 
 
-def test_cultural_memory_import_error_degrades_instead_of_crashing_the_run():
+def test_cultural_memory_import_error_degrades_instead_of_crashing_the_run(tmp_path):
     """A missing sentence-transformers/torch [models] extra must not abort the session.
 
     Regression test for C1: get_cultural_memory() raising ImportError must degrade
@@ -409,6 +421,7 @@ def test_cultural_memory_import_error_degrades_instead_of_crashing_the_run():
         fundamental_llm=_per_ticker_llm("fundamental.json"),
         sentiment_llm=_per_ticker_llm("sentiment.json"),
         portfolio_llm=_portfolio_llm(),
+        checkpoint_db_path=str(tmp_path / "argus_graph_test.db"),
     )
     config = {"configurable": {"thread_id": str(uuid4())}}
 
@@ -428,10 +441,10 @@ def test_cultural_memory_import_error_degrades_instead_of_crashing_the_run():
     assert all(agg.model_healthy is False for agg in aggs.values())
 
 
-def test_golden_dag_output_is_stable_across_runs():
+def test_golden_dag_output_is_stable_across_runs(tmp_path):
     """Two independent invocations of the same fixture-backed graph are byte-identical."""
-    first = _run_fixture_graph()
-    second = _run_fixture_graph()
+    first = _run_fixture_graph(tmp_path)
+    second = _run_fixture_graph(tmp_path)
 
     first_alloc = _strip_volatile(first["portfolio_allocation"].model_dump(mode="json"))
     second_alloc = _strip_volatile(second["portfolio_allocation"].model_dump(mode="json"))

--- a/tests/test_kill_switch.py
+++ b/tests/test_kill_switch.py
@@ -589,6 +589,35 @@ def test_paperbook_load_missing_file_starts_fresh_at_total_wealth(tmp_path):
     assert book.runs_applied == set()
 
 
+def test_paperbook_prune_runs_applied_drops_only_entries_older_than_cutoff():
+    """COL-1: entries before cutoff are dropped; entries at or after it survive."""
+    book = PaperBook(
+        equity=100_000.0,
+        high_water_mark=100_000.0,
+        runs_applied={
+            "2026-01-01T00:00:00",
+            "2026-01-10T00:00:00",
+            "2026-01-20T00:00:00",
+        },
+    )
+
+    dropped = book.prune_runs_applied(cutoff=datetime(2026, 1, 10))
+
+    assert dropped == 1
+    assert book.runs_applied == {"2026-01-10T00:00:00", "2026-01-20T00:00:00"}
+
+
+def test_paperbook_prune_runs_applied_leaves_equity_and_hwm_untouched():
+    """Pruning runs_applied is bookkeeping only — it must not touch the equity curve itself."""
+    book = PaperBook(equity=88_000.0, high_water_mark=100_000.0)
+    book.apply_run(datetime(2026, 1, 1), -0.12)
+
+    book.prune_runs_applied(cutoff=datetime(2026, 2, 1))
+
+    assert book.equity == pytest.approx(88_000.0 * 0.88)
+    assert book.runs_applied == set()
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle: stop() and idempotent start() (KS-10)
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -21,6 +21,8 @@ from argus.config import settings
 from argus.data.cache import OHLCVBuffer
 from argus.data.pipeline import (
     _FETCH_INTERVAL,
+    _FETCH_PERIOD,
+    _STEADY_STATE_FETCH_PERIOD,
     MFTDataPipeline,
     _bars_per_day,
     _derive_buffer_size,
@@ -679,3 +681,39 @@ def test_fetch_and_insert_returns_zero_on_an_empty_fetch(monkeypatch):
     n_candles, latest_close = pipeline._fetch_and_insert("AAPL")
 
     assert (n_candles, latest_close) == (0, 0.0)
+
+
+def test_fetch_and_insert_uses_the_full_period_for_a_cold_buffer(monkeypatch):
+    """A ticker with no buffered rows yet gets the full `_FETCH_PERIOD` fetch (MFT-15)."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    captured = {}
+
+    def fake_fetch(ticker, interval, period):
+        captured["period"] = period
+        return et_intraday_candles(5)
+
+    monkeypatch.setattr(pipeline_module, "fetch_ohlcv_intraday", fake_fetch)
+    monkeypatch.setattr(pipeline.buffer, "row_counts", lambda: {})
+
+    pipeline._fetch_and_insert("AAPL")
+
+    assert captured["period"] == _FETCH_PERIOD
+
+
+def test_fetch_and_insert_uses_the_steady_state_period_for_a_warm_buffer(monkeypatch):
+    """A ticker already holding an indicator-ready depth gets the short trailing fetch (MFT-15)."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    captured = {}
+
+    def fake_fetch(ticker, interval, period):
+        captured["period"] = period
+        return et_intraday_candles(5)
+
+    monkeypatch.setattr(pipeline_module, "fetch_ohlcv_intraday", fake_fetch)
+    monkeypatch.setattr(
+        pipeline.buffer, "row_counts", lambda: {"AAPL": _required_raw_bars(1)}
+    )
+
+    pipeline._fetch_and_insert("AAPL")
+
+    assert captured["period"] == _STEADY_STATE_FETCH_PERIOD

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -6,20 +6,25 @@ assignment, entry/exit price outcome computation, and reading decisions back
 out of the LangGraph checkpoint.
 """
 
-from datetime import datetime
+import sqlite3
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest import mock
 
 import pandas as pd
 import pytest
+from langgraph.checkpoint.sqlite import SqliteSaver
 
 from argus.memory.cultural import CulturalMemoryManager
 from argus.orchestration.aggregator import HybridSignalAggregator
-from argus.orchestration.graph import build_graph
+from argus.orchestration.graph import build_checkpoint_serde, build_graph
 from argus.orchestration.reconciliation import (
+    compact_decisions_jsonl,
     compute_realized_return,
     credit_primary_driver,
     load_decisions_from_checkpoints,
+    load_decisions_from_jsonl,
+    prune_checkpoints,
     reconcile_decision,
     reconcile_decisions,
 )
@@ -611,3 +616,101 @@ def test_load_decisions_from_checkpoints_round_trips_a_real_graph_run(tmp_path):
     assert decisions, "expected at least one decision to round-trip"
     assert all(isinstance(d, ARGUSDecision) for d in decisions)
     assert {d.ticker for d in decisions} <= set(universe)
+
+
+# ---------------------------------------------------------------------------
+# compact_decisions_jsonl (COL-1)
+# ---------------------------------------------------------------------------
+
+
+def test_compact_decisions_jsonl_drops_sessions_before_cutoff(tmp_path):
+    """Decisions older than cutoff are dropped; everything at or after it is kept."""
+    path = tmp_path / "decisions.jsonl"
+    old = ARGUSDecision(ticker="OLD", session_timestamp=datetime(2026, 1, 1))
+    kept_exact = ARGUSDecision(ticker="EXACT", session_timestamp=datetime(2026, 1, 10))
+    new = ARGUSDecision(ticker="NEW", session_timestamp=datetime(2026, 1, 20))
+    with open(path, "w", encoding="utf-8") as f:
+        for d in (old, kept_exact, new):
+            f.write(d.model_dump_json() + "\n")
+
+    retained = compact_decisions_jsonl(str(path), cutoff=datetime(2026, 1, 10))
+
+    assert retained == 2
+    tickers = {d.ticker for d in load_decisions_from_jsonl(str(path))}
+    assert tickers == {"EXACT", "NEW"}
+
+
+def test_compact_decisions_jsonl_missing_file_is_a_noop():
+    """A path that doesn't exist yet returns 0 and writes nothing."""
+    assert compact_decisions_jsonl("/nonexistent/decisions.jsonl", cutoff=datetime(2026, 1, 1)) == 0
+
+
+def test_compact_decisions_jsonl_nothing_to_drop_leaves_the_file_untouched(tmp_path):
+    """When every decision is at or after cutoff, the file is not rewritten."""
+    path = tmp_path / "decisions.jsonl"
+    decision = ARGUSDecision(ticker="NEW", session_timestamp=datetime(2026, 1, 20))
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(decision.model_dump_json() + "\n")
+    original_mtime = path.stat().st_mtime_ns
+
+    retained = compact_decisions_jsonl(str(path), cutoff=datetime(2026, 1, 1))
+
+    assert retained == 1
+    assert path.stat().st_mtime_ns == original_mtime
+
+
+# ---------------------------------------------------------------------------
+# prune_checkpoints (RE-13)
+# ---------------------------------------------------------------------------
+
+
+def _put_checkpoint(saver: SqliteSaver, thread_id: str, ts: datetime) -> None:
+    """Writes a minimal checkpoint for `thread_id` stamped with `ts`."""
+    config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    checkpoint = {
+        "v": 1,
+        "ts": ts.isoformat(),
+        "id": thread_id,
+        "channel_values": {},
+        "channel_versions": {},
+        "versions_seen": {},
+    }
+    saver.put(config, checkpoint, {"source": "input", "step": 1, "writes": {}}, {})
+
+
+def test_prune_checkpoints_deletes_only_threads_older_than_cutoff(tmp_path):
+    """A thread whose newest checkpoint predates cutoff is deleted; a newer one survives."""
+    db_path = str(tmp_path / "argus_graph.db")
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    saver = SqliteSaver(conn, serde=build_checkpoint_serde())
+    _put_checkpoint(saver, "stale-thread", datetime(2026, 1, 1))
+    _put_checkpoint(saver, "fresh-thread", datetime(2026, 1, 20))
+    conn.close()
+
+    deleted = prune_checkpoints(db_path, cutoff=datetime(2026, 1, 10))
+
+    assert deleted == 1
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    checkpoint_threads = {
+        row[0] for row in conn.execute("SELECT DISTINCT thread_id FROM checkpoints").fetchall()
+    }
+    conn.close()
+    assert checkpoint_threads == {"fresh-thread"}
+
+
+def test_prune_checkpoints_missing_db_is_a_noop():
+    """A checkpoint database that doesn't exist yet returns 0 rather than raising."""
+    assert prune_checkpoints("/nonexistent/argus_graph.db", cutoff=datetime(2026, 1, 1)) == 0
+
+
+def test_prune_checkpoints_nothing_stale_deletes_nothing(tmp_path):
+    """Every thread newer than cutoff survives untouched."""
+    db_path = str(tmp_path / "argus_graph.db")
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    saver = SqliteSaver(conn, serde=build_checkpoint_serde())
+    _put_checkpoint(saver, "fresh-thread", datetime.now())
+    conn.close()
+
+    deleted = prune_checkpoints(db_path, cutoff=datetime.now() - timedelta(days=30))
+
+    assert deleted == 0


### PR DESCRIPTION
PR 6 of issue #49's release remediation. Fixes RE-13 (the LangGraph checkpoint DB had no retention — 8,753 checkpoints, 565 MB locally — even though `decisions.jsonl` is now the durable record per RE-11; each daily reconcile pass deletes checkpoint threads past `horizon_days + retention_margin_days` and VACUUMs, keeping the DB as a fallback read path rather than removing checkpointing outright), COL-1 (`decisions.jsonl` and `PaperBook.runs_applied` grew forever; both are now compacted/pruned on the same cutoff), MEM-3 (PENDING decision snapshots that never settle now expire on that cutoff too), and MFT-15 (`_fetch_and_insert` re-pulled a full 2-day window every 5-minute sweep regardless of buffer warmth — it now fetches a short trailing window once a ticker's buffer already holds an indicator-ready depth, reserving the full fetch for a cold buffer).

Also fixes X-5: seven `tests/test_golden_dag.py` call sites omitted `checkpoint_db_path` and wrote into the literal `argus_graph.db` in the repo root. `build_graph()`'s default now derives from `settings.ARGUS_DATA_DIR` at call time (so the autouse per-test override covers any omitted call site), and the seven call sites now pass an explicit `tmp_path` too.

Refs #49.