### PR TITLE
PR 7: cost, quota, and request deadlines

### DIFF
--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -11,9 +11,11 @@ name: Unattended collector
 
 on:
   schedule:
-    # Every hour, 13:05-21:05 UTC covers 09:00-17:00 ET across both EST and
-    # EDT — wide enough that DST transitions don't need a second cron line
-    - cron: "5 13-21 * * 1-5"
+    # Every 2 hours, 13:05-21:05 UTC covers 09:00-17:00 ET across both EST
+    # and EDT — 5 ticks/weekday (GOV-14), matching NewsAPI's free-tier
+    # 100 request/day budget at 20 requests per 20-ticker sweep (see
+    # README.md's stated 5-run/day ceiling)
+    - cron: "5 13-21/2 * * 1-5"
   workflow_dispatch:
 
 concurrency:
@@ -40,6 +42,7 @@ jobs:
           mkdir -p data chroma_db
           [ -d state/chroma_db ] && cp -r state/chroma_db/. ./chroma_db/ || echo "no prior chroma_db"
           [ -f state/decisions.jsonl ] && cp state/decisions.jsonl data/decisions.jsonl || echo "no prior decisions.jsonl"
+          [ -f state/newsapi_budget.json ] && cp state/newsapi_budget.json data/newsapi_budget.json || echo "no prior newsapi_budget.json"
           # World-writable so the image's non-root `argus` user (uid 1000) can
           # write here regardless of the runner's own uid
           chmod -R a+rwX data chroma_db
@@ -73,6 +76,7 @@ jobs:
           else
             echo "::warning::decisions.jsonl absent after this cycle — nothing has ever been logged"
           fi
+          [ -f data/newsapi_budget.json ] && cp data/newsapi_budget.json publish/newsapi_budget.json || echo "no newsapi_budget.json to publish"
           # Merge rather than overwrite — reconcile.yml writes to the same
           # status.json on the same branch and its field must survive this
           ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/reconcile.yml
+++ b/.github/workflows/reconcile.yml
@@ -35,6 +35,7 @@ jobs:
           [ -d state/chroma_db ] && cp -r state/chroma_db/. ./chroma_db/ || echo "no prior chroma_db"
           [ -f state/decisions.jsonl ] && cp state/decisions.jsonl data/decisions.jsonl || echo "no prior decisions.jsonl"
           [ -f state/paper_equity.json ] && cp state/paper_equity.json data/paper_equity.json || echo "no prior paper_equity.json"
+          [ -f state/newsapi_budget.json ] && cp state/newsapi_budget.json data/newsapi_budget.json || echo "no prior newsapi_budget.json"
           chmod -R a+rwX data chroma_db
 
       - name: Log in to GHCR
@@ -58,6 +59,7 @@ jobs:
           cp -r chroma_db publish/chroma_db
           [ -f data/decisions.jsonl ] && cp data/decisions.jsonl publish/decisions.jsonl
           [ -f data/paper_equity.json ] && cp data/paper_equity.json publish/paper_equity.json
+          [ -f data/newsapi_budget.json ] && cp data/newsapi_budget.json publish/newsapi_budget.json
           # Merge rather than overwrite — collector.yml writes to the same
           # status.json on the same branch and its field must survive this
           ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ ARGUS needs to run continuously to be useful unattended — the MFT pipeline onl
 Three workflows under `.github/workflows/`:
 
 - **`image.yml`** — builds `Dockerfile.api` and pushes it to GHCR (`ghcr.io/<owner>/argus:latest`) on every push to `main`, plus a weekly rebuild for base-image security patches.
-- **`collector.yml`** — runs `argus-collect` (the `scripts/collect_session.py` entry point) hourly during US market hours against the published image.
+- **`collector.yml`** — runs `argus-collect` (the `scripts/collect_session.py` entry point) every 2 hours during US market hours against the published image — 5 ticks/weekday, matching NewsAPI's 5-run/day free-tier ceiling below.
 - **`reconcile.yml`** — runs `argus-reconcile` once daily, after market close.
 
 To enable: add `GROQ_API_KEY`, `FRED_API_KEY`, and `NEWSAPI_KEY` as repository secrets (**Settings → Secrets and variables → Actions**), then push to `main` so `image.yml` publishes the first image. Both scheduled workflows write their state — `chroma_db/`, `decisions.jsonl`, `status.json` — to an orphan `argus-data` branch, force-pushed as a single commit each run so the branch never grows unbounded. `collector.yml` and `reconcile.yml` share a concurrency group so they never race each other on that branch.

--- a/api/main.py
+++ b/api/main.py
@@ -868,7 +868,22 @@ async def analyze(req: AnalysisRequest):
 
     try:
         async with _analyze_semaphore:
-            final_state = await asyncio.to_thread(_graph.invoke, state, config)
+            final_state = await asyncio.wait_for(
+                asyncio.to_thread(_graph.invoke, state, config),
+                timeout=settings.ARGUS_ANALYZE_DEADLINE_SECONDS,
+            )
+    except asyncio.TimeoutError:
+        # The underlying thread can't be cancelled and keeps running (GOV-12
+        # notes async job submission as future work), but the server no longer
+        # holds the connection open past a proxy's own timeout with no signal.
+        logger.error(
+            "[API] Graph run exceeded the %ss deadline", settings.ARGUS_ANALYZE_DEADLINE_SECONDS
+        )
+        raise HTTPException(
+            504,
+            f"Analysis did not complete within {settings.ARGUS_ANALYZE_DEADLINE_SECONDS}s. "
+            "It may still be running and consuming governor quota in the background.",
+        )
     except RateLimitExceeded as e:
         logger.warning("[API] Governor rate limit exhausted: %s", e)
         raise HTTPException(429, f"Rate limit exhausted: {e}")

--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -54,6 +54,14 @@ _SECTOR_PE_MEDIANS: dict[str, float] = {
 }
 _DEFAULT_PE_MEDIAN = 20.0
 
+# Fraction of the configured per-minute request budget held back before a
+# ticker's fundamental analysis is even attempted, so the same-model portfolio
+# agent (GOV-13: ARGUS_PORTFOLIO_MODEL defaults to the same model as
+# ARGUS_FUNDAMENTAL_MODEL) still has room after a fundamental batch. Scaled
+# off ARGUS_GROQ_RPM rather than a fixed constant, so a low configured RPM
+# doesn't leave a reserve larger than the budget itself and skip every ticker.
+_CAPACITY_RESERVE_FRACTION = 0.1
+
 # Ratios fetched from market_data.fundamentals(ticker): measured data, never
 # LLM output. The LLM only ever supplies signal/conviction/moat_score/reasoning.
 _MEASURED_FUNDAMENTAL_FIELDS = (
@@ -355,7 +363,8 @@ class FundamentalAgent:
                 logger.debug("FundamentalAgent.analyze: Cache hit for %s", ticker)
                 return cached
 
-        if governor.get_remaining_capacity(settings.ARGUS_FUNDAMENTAL_MODEL) < 20:
+        capacity_reserve = max(1, int(settings.ARGUS_GROQ_RPM * _CAPACITY_RESERVE_FRACTION))
+        if governor.get_remaining_capacity(settings.ARGUS_FUNDAMENTAL_MODEL) < capacity_reserve:
             logger.warning(
                 "[Fundamental] Low capacity for %s, skipping %s", settings.ARGUS_FUNDAMENTAL_MODEL, ticker
             )

--- a/argus/config.py
+++ b/argus/config.py
@@ -167,6 +167,17 @@ class Settings(BaseSettings):
     ARGUS_GROQ_TPM: int = Field(
         default=6_000, gt=0, description="Bootstrap tokens-per-minute floor before headers are observed"
     )
+    ARGUS_ANALYZE_DEADLINE_SECONDS: int = Field(
+        default=360,
+        gt=0,
+        description=(
+            "Server-side deadline for a single /analyze graph run (GOV-12). At the "
+            "6,000 TPM bootstrap floor, a cold 20-ticker sweep spends ~256s in "
+            "governor sleeps plus ~50s of sentiment pacing; a proxy that times out "
+            "well before this would otherwise leave the server burning quota on a "
+            "request nothing is still waiting on."
+        ),
+    )
 
     # Model IDs for the three LLM-backed agents. Must each be a member of
     # argus.orchestration.governor.REGISTERED_MODELS — asserted at API startup

--- a/argus/data/fetchers.py
+++ b/argus/data/fetchers.py
@@ -27,6 +27,7 @@ Dependencies:
 
 from __future__ import annotations
 
+import json
 import logging
 import random
 import time
@@ -588,6 +589,11 @@ class _NewsApiBudget:
     A 20-ticker sweep spends 20 of the 100 — a 5-run/day ceiling, tighter than
     anything Groq imposes — so this is checked before every request rather
     than discovered from a 426/429 response.
+
+    Persisted under ARGUS_DATA_DIR (GOV-14): the Actions collector starts a
+    fresh container on every tick, so an in-memory-only counter always read
+    zero used and never actually enforced the daily ceiling in that
+    deployment.
     """
 
     def __init__(self, daily_limit: int = _NEWSAPI_DAILY_LIMIT) -> None:
@@ -600,6 +606,32 @@ class _NewsApiBudget:
         self._lock = Lock()
         self._requests_today = 0
         self._date = datetime.now(timezone.utc).date()
+        self._loaded_from_disk = False
+
+    def _persist_path(self) -> Path:
+        """Returns the counter's persistence path, read lazily so it honors
+        whatever ARGUS_DATA_DIR is current when first used rather than at
+        import time (matches _daily_bar_cache's convention above)."""
+        return Path(settings.ARGUS_DATA_DIR) / "newsapi_budget.json"
+
+    def _load_from_disk(self) -> None:
+        """Restores today's persisted request count, if any, once per process."""
+        try:
+            raw = json.loads(self._persist_path().read_text())
+            if date.fromisoformat(raw["date"]) == self._date:
+                self._requests_today = raw["requests_today"]
+        except (FileNotFoundError, KeyError, ValueError, json.JSONDecodeError):
+            pass
+
+    def _save_to_disk(self) -> None:
+        """Writes the current count to disk, tmp-file-then-replace for atomicity."""
+        path = self._persist_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps({"date": self._date.isoformat(), "requests_today": self._requests_today})
+        )
+        tmp_path.replace(path)
 
     def try_reserve(self) -> bool:
         """Reserves one request against today's budget if any remains.
@@ -608,6 +640,9 @@ class _NewsApiBudget:
             True if a request was reserved, False if today's budget is spent.
         """
         with self._lock:
+            if not self._loaded_from_disk:
+                self._load_from_disk()
+                self._loaded_from_disk = True
             today = datetime.now(timezone.utc).date()
             if today != self._date:
                 self._requests_today = 0
@@ -615,6 +650,7 @@ class _NewsApiBudget:
             if self._requests_today >= self._daily_limit:
                 return False
             self._requests_today += 1
+            self._save_to_disk()
             return True
 
 

--- a/tests/test_api_concurrency.py
+++ b/tests/test_api_concurrency.py
@@ -18,6 +18,7 @@ lifespan, so no MFT pipeline, collector, or reconcile loop needs to start.
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest import mock
@@ -105,6 +106,27 @@ def test_analyze_releases_the_semaphore_when_the_graph_raises(client, monkeypatc
     response = client.post("/analyze", json=_PAYLOAD)
 
     assert response.status_code == 500
+    assert not api_main._analyze_semaphore.locked()
+
+
+# ---------------------------------------------------------------------------
+# GOV-12: request deadline
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_returns_504_when_the_graph_exceeds_its_deadline(client, monkeypatch):
+    """A graph run that outlives ARGUS_ANALYZE_DEADLINE_SECONDS is bounded with a
+    504, not left open past whatever timeout the caller's own proxy already gave up at."""
+    _ready(client, monkeypatch)
+    monkeypatch.setattr(api_main.settings, "ARGUS_ANALYZE_DEADLINE_SECONDS", 0.05)
+
+    fake_graph = mock.Mock()
+    fake_graph.invoke.side_effect = lambda *a, **kw: time.sleep(0.5)
+    monkeypatch.setattr(api_main, "_graph", fake_graph)
+
+    response = client.post("/analyze", json=_PAYLOAD)
+
+    assert response.status_code == 504
     assert not api_main._analyze_semaphore.locked()
 
 

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -193,6 +193,30 @@ def test_newsapi_budget_resets_on_new_day():
     assert budget.try_reserve() is True
 
 
+def test_newsapi_budget_survives_a_fresh_process(monkeypatch):
+    """A second _NewsApiBudget instance under the same ARGUS_DATA_DIR resumes today's
+    count instead of restarting at zero — the Actions collector's cold-start case (GOV-14)."""
+    first = fetchers._NewsApiBudget(daily_limit=2)
+    assert first.try_reserve() is True
+
+    second = fetchers._NewsApiBudget(daily_limit=2)
+    assert second.try_reserve() is True
+    assert second.try_reserve() is False
+
+
+def test_newsapi_budget_ignores_a_stale_persisted_date(monkeypatch):
+    """A persisted count from a prior UTC day is not carried into a new process's day."""
+    stale = fetchers._NewsApiBudget(daily_limit=2)
+    assert stale.try_reserve() is True
+    stale._date = stale._date - timedelta(days=1)
+    stale._save_to_disk()
+
+    fresh = fetchers._NewsApiBudget(daily_limit=2)
+    assert fresh.try_reserve() is True
+    assert fresh.try_reserve() is True
+    assert fresh.try_reserve() is False
+
+
 def test_fetch_news_returns_none_without_api_key(monkeypatch):
     """No NEWSAPI_KEY means no request is even attempted."""
     monkeypatch.setattr(fetchers.settings, "newsapi_key", "")

--- a/tests/test_fundamental.py
+++ b/tests/test_fundamental.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime, timedelta
 
 
+import argus.agents.fundamental as fundamental_module
 from argus.agents.fundamental import (
     FundamentalAgent,
     FundamentalCache,
@@ -14,6 +15,7 @@ from argus.agents.fundamental import (
     anonymize_ticker,
     build_compact_prompt,
 )
+from argus.orchestration.governor import BOOTSTRAP_LIMITS, RateLimitGovernor
 from argus.schemas.signals import FundamentalSignal, Signal
 from argus.seams import FixtureLLMClient
 
@@ -220,3 +222,29 @@ def test_analyze_retries_with_the_prior_validation_error_in_the_prompt():
     assert signal is not None
     assert len(prompts) == 2
     assert "Your previous response was invalid" in prompts[1]
+
+
+def test_analyze_does_not_skip_every_ticker_at_a_low_configured_rpm(monkeypatch):
+    """A low ARGUS_GROQ_RPM must not make the pre-flight capacity reserve exceed
+    the budget itself (GOV-13) — an idle governor should still admit the call.
+
+    BOOTSTRAP_LIMITS is a dict computed once from settings at governor import
+    time, not re-read per call, so simulating ARGUS_GROQ_RPM=10 requires
+    patching it directly rather than just monkeypatching settings.
+    """
+    model = fundamental_module.settings.ARGUS_FUNDAMENTAL_MODEL
+    monkeypatch.setattr(fundamental_module.settings, "ARGUS_GROQ_RPM", 10)
+    monkeypatch.setitem(BOOTSTRAP_LIMITS[model], "requests_per_minute", 10)
+    monkeypatch.setattr(fundamental_module, "governor", RateLimitGovernor())
+
+    market_data = _StubMarketData({"sector": "Technology", "industry": "Consumer Electronics"})
+    llm = _RecordingLLMClient(
+        json.dumps({"signal": "NEUTRAL", "conviction": 0.5, "moat_score": 5, "reasoning": "r"})
+    )
+    agent = FundamentalAgent(llm_client=llm, market_data=market_data)
+
+    errors: list[str] = []
+    signal = agent.analyze("AAPL", errors=errors)
+
+    assert signal is not None
+    assert errors == []


### PR DESCRIPTION
PR 7 of issue #49's release remediation. Fixes GOV-12 (a cold `/analyze` graph run had no server-side deadline — a proxy timing out mid-run left the process still burning governor quota with nothing waiting on the result — so the graph invocation is now wrapped in `asyncio.wait_for` against a configurable `ARGUS_ANALYZE_DEADLINE_SECONDS`, returning 504 on expiry), GOV-13 (`FundamentalAgent.analyze` skipped every ticker whenever remaining governor capacity fell below a hardcoded 20, which silently disabled the whole agent at any configured RPM under 20; the reserve is now a fraction of `ARGUS_GROQ_RPM` so it never exceeds the configured budget itself), and GOV-14 (the Actions collector cold-starts a fresh container every tick, so the in-memory NewsAPI daily-budget counter always read zero used and never actually enforced the 100-request ceiling; it's now persisted to `ARGUS_DATA_DIR` and carried across runs on the `argus-data` branch, and the cron cadence drops from hourly to 5 ticks/weekday to match the budget it was already documented against).

Files: `api/main.py`, `argus/agents/fundamental.py`, `argus/config.py`, `argus/data/fetchers.py`, `.github/workflows/collector.yml`, `.github/workflows/reconcile.yml`, `README.md`.

Refs #49.