### PR TITLE
PR 9: documentation, dead code, and hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Multi-agent financial intelligence system orchestrating specialist LLMs and stat
 
 ![CI](https://github.com/nevilcp/argus/actions/workflows/ci.yml/badge.svg)
 ![Python Version](https://img.shields.io/badge/python-%E2%89%A53.11-blue)
-![Tests](https://img.shields.io/badge/tests-212_passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-437_passing-brightgreen)
 ![License](https://img.shields.io/badge/license-Proprietary-red)
 
 > **RESEARCH PROJECT ONLY — NOT FINANCIAL ADVICE.** ARGUS is not registered with the SEC or any regulatory body. All outputs are for educational and research purposes only. Do not make investment decisions based on this system's output.
@@ -146,15 +146,16 @@ ARGUS sits at the intersection of quantitative finance, statistical modeling, an
 
 | Field | Meaning | How to read it |
 |---|---|---|
-| `conviction` (per position) | Categorical strength of the agents' agreement on a position's direction (e.g. `STRONG_BUY` → `STRONG_SELL`) | Strength of agreement, not a probability of profit or an expected return. Its underlying aggregated score is scaled against the full three-agent vote mass, so it falls when specialists disagree or are absent rather than saturating near its cap whenever the agents who did vote agree |
-| `allocation_pct` | Fraction of the *invested* portion of `total_wealth` assigned to this ticker | Multiply by `total_wealth * (1 - cash_reserve_pct)` for a dollar figure — it is not a fraction of total wealth directly |
+| `composite_conviction` (per position) | Float `[0, 1]` — aggregated strength of the agents' agreement on a position's direction | Strength of agreement, not a probability of profit or an expected return. It is scaled against the full three-agent vote mass, so it falls when specialists disagree or are absent rather than saturating near its cap whenever the agents who did vote agree |
+| `allocation_pct` | Fraction of `total_wealth` (the request's `user_investable_capital`) assigned to this ticker, `[0, SYSTEM.max_single_position_pct]` | Multiply by `total_wealth` directly for a dollar figure — `allocation_usd` on the same position is that product, already computed |
 | `cash_reserve_pct` | Fraction of `total_wealth` held back from any position | Recomputed server-side from the risk engine's own figures rather than trusted verbatim from the LLM, so it always stays consistent with the position sizes actually returned |
 | `macro_regime` | The Gaussian HMM's current 3-state classification (e.g. `EXPANSION`, `CONTRACTION`) | Its multiplier is applied once, at signal-aggregation time, to each specialist's vote weight — never to a specialist's own analysis, which runs independently of macro classification. A `CONTRACTION` regime can still override an otherwise-bullish consensus after aggregation |
 | `vix_level` | The VIX close feeding the macro and risk engines this session | Above the configured blackout threshold (default 35), the safety layer blocks new positions before `/analyze` even runs — an elevated-but-sub-threshold value here signals wider risk-engine caution (VIX scaling), not a guarantee of safety |
+| `errors` | List of non-fatal gaps the graph hit this session (e.g. a macro data outage) | Empty on a clean run. A populated list doesn't mean the response is unusable — the specialists, aggregation, and portfolio allocation still ran on whatever evidence they had — but it says which inputs were degraded |
 
 ### Concepts Behind Each Agent
 
-- **Macro regime (Gaussian HMM)** — a Hidden Markov Model fit on FRED macro indicators (CPI, Fed Funds, unemployment, 10Y-2Y yield curve) plus VIX, classifying the current environment into one of three latent regimes rather than a hand-coded rule. It classifies from a trailing ~90-day feature window rather than a single observation, so the transition matrix — not one noisy print — drives the call. The fitted model ships as a committed artifact (`argus-train-macro` retrains it; see [Training the Macro Classifier](#training-the-macro-classifier)); if the artifact is missing or fails to load, the agent degrades to a static VIX/yield-curve rule rather than failing. See [`argus/agents/macro.py`](argus/agents/macro.py).
+- **Macro regime (Gaussian HMM)** — a Hidden Markov Model fit on FRED macro indicators (CPI, Fed Funds, unemployment, 10Y-2Y yield curve) plus VIX, classifying the current environment into one of three latent regimes rather than a hand-coded rule. It classifies from a trailing 36-month-end feature window rather than a single observation, so the transition matrix — not one noisy print — drives the call. The fitted model ships as a committed artifact (`argus-train-macro` retrains it; see [Training the Macro Classifier](#training-the-macro-classifier)); if the artifact is missing or fails to load, the agent degrades to a static VIX/yield-curve rule rather than failing. See [`argus/agents/macro.py`](argus/agents/macro.py).
 - **Technical indicators** — fetched as 1-minute intraday candles, resampled to 5-minute bars for indicator calculation, and compressed every 30 minutes. See [`argus/agents/technical.py`](argus/agents/technical.py) and [`argus/data/pipeline.py`](argus/data/pipeline.py).
   - *RSI* (Relative Strength Index): 0–100 momentum oscillator identifying overbought/oversold conditions.
   - *MACD*: trend-following momentum, read via the histogram (the gap between the MACD line and its signal line).
@@ -183,7 +184,7 @@ At small sample sizes — inherent to a system that has only recently started cl
 - **Historical covariance breaks down during shocks** (correlations tend toward 1); VaR/CVaR estimates during genuine crises should be treated as understated.
 - **Long-only** — no shorting, options, or hedging; a bearish `macro_regime` can only reduce exposure, not profit from it.
 - **LLM outputs are non-deterministic** — the fundamental, sentiment, and portfolio-synthesis agents can return slightly different conviction scores and notes between runs on identical inputs.
-- **A macro data outage doesn't blank the session** — if FRED/VIX data is unavailable, `macro_regime` comes back `"unknown"` and `vix_level` `0.0`, but the three specialist agents, aggregation, and portfolio allocation still run on whatever evidence they do have, rather than the whole session being scrapped. The graph's internal state records the specific gap (`state["errors"]`), though `/analyze`'s response schema doesn't currently surface that list to the caller — a `macro_regime` of `"unknown"` is presently the only client-visible signal that this happened.
+- **A macro data outage doesn't blank the session** — if FRED/VIX data is unavailable, `macro_regime` comes back `"unknown"` and `vix_level` `0.0`, but the three specialist agents, aggregation, and portfolio allocation still run on whatever evidence they do have, rather than the whole session being scrapped. The graph's internal state records the specific gap and `/analyze`'s response surfaces it in `errors` — a `macro_regime` of `"unknown"` is a secondary signal, not the only one.
 
 ## Prerequisites
 
@@ -312,13 +313,24 @@ curl -X POST http://localhost:8000/analyze \
 {
   "session_id": "a1b2c3d4-...",
   "portfolio": [
-    { "ticker": "AAPL", "allocation_pct": 0.32, "conviction": "MODERATE_BUY" }
+    {
+      "ticker": "AAPL",
+      "allocation_pct": 0.12,
+      "allocation_usd": 12000.0,
+      "stop_loss": 172.50,
+      "target_price": 210.0,
+      "thesis": "Momentum and margin trend both improving into earnings.",
+      "advisor_note": "...",
+      "composite_conviction": 0.71,
+      "time_horizon": "30 days"
+    }
   ],
   "cash_reserve_pct": 0.4,
   "macro_regime": "EXPANSION",
   "vix_level": 14.2,
   "governor_report": { "...": "per-model request/token usage" },
-  "timestamp": "2026-08-13T14:30:00"
+  "timestamp": "2026-08-13T14:30:00",
+  "errors": []
 }
 ```
 
@@ -439,7 +451,7 @@ pytest tests/ --cov=argus --cov-report=term-missing
 ```
 
 - **Categories**: Tests cover Pydantic validation boundaries, mathematical boundaries (e.g., Half-Kelly position sizing constraints), caching TTL expiration logic, and thread-safe rate limit assertions.
-- **Approximate Run Time**: ~140 seconds for 212 tests across 23 files, entirely offline by design — no live API calls, network access, or API keys required.
+- **Approximate Run Time**: ~155 seconds for 437 tests across 35 files, entirely offline by design — no live API calls, network access, or API keys required.
 - **CI gate**: `.github/workflows/ci.yml` additionally runs `ruff check .` and `mypy argus/` (pinned `ruff==0.16.2`, `mypy==2.3.0`) before the test step.
 
 ## Contributing

--- a/api/main.py
+++ b/api/main.py
@@ -120,7 +120,7 @@ async def _mft_session_callback(session_states: dict) -> None:
     Args:
         session_states: Mapping of ticker → technical feature dict from MFTDataPipeline.
     """
-    now = datetime.now()
+    now = datetime.now()  # noqa: DTZ005
     for ticker, state in session_states.items():
         _live_session_cache[ticker] = (state, now)
 
@@ -214,7 +214,7 @@ def _prune_growing_stores(decisions_log: str) -> None:
     Args:
         decisions_log: Same decisions.jsonl path the caller just reconciled.
     """
-    cutoff = datetime.now() - timedelta(
+    cutoff = datetime.now() - timedelta(  # noqa: DTZ005
         days=RECONCILIATION.horizon_days + RECONCILIATION.retention_margin_days
     )
 
@@ -264,7 +264,7 @@ def _reconcile_once() -> None:
         ):
             book.apply_run(run_timestamp, run_return)
         book.prune_runs_applied(
-            datetime.now()
+            datetime.now()  # noqa: DTZ005
             - timedelta(days=RECONCILIATION.horizon_days + RECONCILIATION.retention_margin_days)
         )
         paper_book.save(book, book_path)
@@ -363,20 +363,26 @@ def _assert_single_worker() -> None:
         if idx + 1 < len(argv) and argv[idx + 1] != "1":
             raise RuntimeError(
                 f"ARGUS must run with --workers 1 (in-process governor/kill-switch "
-                f"singletons); got --workers {argv[idx + 1]}"
+                f"singletons); got --workers {argv[idx + 1]}. This is only a pre-flight "
+                f"check of argv/env — it can't see a gunicorn config file or "
+                f"uvicorn.run(workers=N), and _acquire_process_lock's flock is the real guard."
             )
     for arg in argv:
         if arg.startswith("--workers=") and arg.removeprefix("--workers=") != "1":
             raise RuntimeError(
                 f"ARGUS must run with --workers 1 (in-process governor/kill-switch "
-                f"singletons); got {arg}"
+                f"singletons); got {arg}. This is only a pre-flight check of argv/env — it "
+                f"can't see a gunicorn config file or uvicorn.run(workers=N), and "
+                f"_acquire_process_lock's flock is the real guard."
             )
 
     web_concurrency = os.environ.get("WEB_CONCURRENCY")
     if web_concurrency is not None and web_concurrency != "1":
         raise RuntimeError(
             f"ARGUS must run with WEB_CONCURRENCY=1 (in-process governor/kill-switch "
-            f"singletons); got WEB_CONCURRENCY={web_concurrency}"
+            f"singletons); got WEB_CONCURRENCY={web_concurrency}. This is only a pre-flight "
+            f"check of argv/env — it can't see a gunicorn config file or "
+            f"uvicorn.run(workers=N), and _acquire_process_lock's flock is the real guard."
         )
 
 
@@ -536,7 +542,9 @@ async def lifespan(app: FastAPI):
         await asyncio.to_thread(_ks.stop, 5.0)
 
     if _mft_pipeline is not None:
-        _mft_pipeline.buffer.close()
+        # Pipeline-owned so it can wait out an orphaned buffer worker rather than
+        # racing it — cancelling the loops above can't stop one already mid-`to_thread` (MFT-16)
+        await _mft_pipeline.close_buffer()
 
     if _process_lock_file is not None:
         fcntl.flock(_process_lock_file, fcntl.LOCK_UN)
@@ -674,7 +682,7 @@ async def health():
 
     newest_cache_entry_age_seconds = None
     if _mft_pipeline is not None and _mft_pipeline.is_market_hours() and _live_session_cache:
-        now = datetime.now()
+        now = datetime.now()  # noqa: DTZ005
         newest_cache_entry_age_seconds = min(
             (now - updated_at).total_seconds() for _, updated_at in _live_session_cache.values()
         )
@@ -715,7 +723,7 @@ async def pipeline_status():
 
     buffer_depth = await asyncio.to_thread(_mft_pipeline.buffer.row_counts)
 
-    now = datetime.now()
+    now = datetime.now()  # noqa: DTZ005
     now_et = datetime.now(_ET)
     cache_age_seconds = {
         ticker: (now - updated_at).total_seconds()
@@ -813,7 +821,7 @@ async def analyze(req: AnalysisRequest):
             "The pipeline is warming up — retry after the next session cycle (~30 min after market open).",
         )
 
-    now = datetime.now()
+    now = datetime.now()  # noqa: DTZ005
     stalled = [
         t for t in req.tickers
         if (now - _live_session_cache[t][1]).total_seconds() > session_state_ttl_seconds()
@@ -943,7 +951,7 @@ async def analyze(req: AnalysisRequest):
         macro_regime=macro_regime,
         vix_level=vix_level,
         governor_report=governor.get_usage_report(),
-        timestamp=datetime.now().isoformat(),
+        timestamp=datetime.now().isoformat(),  # noqa: DTZ005
         errors=final_state.get("errors") or [],
     )
 

--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -105,7 +105,7 @@ def _session_seed_to_date(session_seed: int) -> date:
     Returns:
         The corresponding calendar date.
     """
-    return datetime.strptime(str(session_seed), "%Y%m%d").date()
+    return datetime.strptime(str(session_seed), "%Y%m%d").date()  # noqa: DTZ007
 
 
 def anonymize_ticker(ticker: str, session_seed: int) -> str:
@@ -273,7 +273,7 @@ class FundamentalCache:
         key = (ticker, session_seed)
         if key in self._cache:
             signal, cached_at = self._cache[key]
-            if (datetime.now() - cached_at).days < self._ttl_days:
+            if (datetime.now() - cached_at).days < self._ttl_days:  # noqa: DTZ005
                 return signal
         return None
 
@@ -285,7 +285,7 @@ class FundamentalCache:
             signal: Validated FundamentalSignal to cache.
             session_seed: Session scope to cache the signal under.
         """
-        self._cache[(ticker, session_seed)] = (signal, datetime.now())
+        self._cache[(ticker, session_seed)] = (signal, datetime.now())  # noqa: DTZ005
 
     def is_stale(self, ticker: str, session_seed: Optional[int] = None) -> bool:
         """Returns True if the (ticker, session_seed) has no valid cached signal.
@@ -380,7 +380,7 @@ class FundamentalAgent:
                 errors.append(f"fundamental_analysis[{ticker}]: failed to fetch fundamentals: {e}")
             return None
 
-        as_of_date = date.today()
+        as_of_date = date.today()  # noqa: DTZ011
         anon_id = None
         if _use_backtest_seed(backtest_mode, session_seed):
             assert session_seed is not None
@@ -419,7 +419,7 @@ class FundamentalAgent:
 
                 data["ticker"] = ticker
                 data["data_as_of_date"] = pit_data["as_of_date"]
-                data["timestamp"] = datetime.now().isoformat()
+                data["timestamp"] = datetime.now().isoformat()  # noqa: DTZ005
                 data["api_calls_used"] = 1
 
                 # All measured ratios come from the fetched payload, never the LLM

--- a/argus/agents/macro.py
+++ b/argus/agents/macro.py
@@ -744,7 +744,7 @@ class MacroStatisticalAgent:
         """
         if self._cache:
             ctx, cached_at = self._cache
-            if (datetime.now() - cached_at).total_seconds() < self._cache_ttl_hours * 3600:
+            if (datetime.now() - cached_at).total_seconds() < self._cache_ttl_hours * 3600:  # noqa: DTZ005
                 logger.debug("MacroStatisticalAgent.analyze: Cache hit.")
                 return ctx
 
@@ -773,7 +773,7 @@ class MacroStatisticalAgent:
         window_final: pd.Series | None = None
         try:
             history_start = (
-                datetime.now() - timedelta(days=365 * MACRO.inference_history_years)
+                datetime.now() - timedelta(days=365 * MACRO.inference_history_years)  # noqa: DTZ005
             ).strftime("%Y-%m-%d")
             frame = build_macro_feature_frame(self.market_data, start=history_start)
             window = frame.tail(MACRO.inference_window_months)
@@ -913,9 +913,9 @@ class MacroStatisticalAgent:
             sector_rotation_signal=sector_signal,
             agent_multipliers=multipliers,
             api_calls_used=0,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(),  # noqa: DTZ005
         )
 
-        self._cache = (ctx, datetime.now())
+        self._cache = (ctx, datetime.now())  # noqa: DTZ005
         logger.debug("analyze: new MacroContext generated (Regime: %s)", regime.value)
         return ctx

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -455,7 +455,7 @@ class PortfolioManagerAgent:
 
                 data["session_id"] = str(uuid4())
                 data["user_investable_capital"] = investable
-                data["timestamp"] = datetime.now().isoformat()
+                data["timestamp"] = datetime.now().isoformat()  # noqa: DTZ005
 
                 stage = "schema_validation"
                 allocation = PortfolioAllocation.model_validate(data)
@@ -500,5 +500,5 @@ class PortfolioManagerAgent:
             portfolio=[],
             cash_reserve_pct=1.0,
             rebalance_trigger="MONTHLY",
-            timestamp=datetime.now(),
+            timestamp=datetime.now(),  # noqa: DTZ005
         )

--- a/argus/agents/risk.py
+++ b/argus/agents/risk.py
@@ -59,17 +59,17 @@ def get_sector(ticker: str) -> str:
     """
     if ticker in _SECTOR_CACHE:
         sector, cached_at = _SECTOR_CACHE[ticker]
-        if (datetime.now() - cached_at).total_seconds() < _SECTOR_CACHE_TTL_SECONDS:
+        if (datetime.now() - cached_at).total_seconds() < _SECTOR_CACHE_TTL_SECONDS:  # noqa: DTZ005
             return sector
 
     try:
         info = fetchers.fetch_ticker_info(ticker)
         sector = info.get("sector", "Unknown")
-        _SECTOR_CACHE[ticker] = (sector, datetime.now())
+        _SECTOR_CACHE[ticker] = (sector, datetime.now())  # noqa: DTZ005
         return sector
     except Exception:
         logger.warning(f"Failed to fetch sector for {ticker}, defaulting to 'Unknown'")
-        _SECTOR_CACHE[ticker] = ("Unknown", datetime.now())
+        _SECTOR_CACHE[ticker] = ("Unknown", datetime.now())  # noqa: DTZ005
         return "Unknown"
 
 
@@ -394,7 +394,7 @@ class RiskStatisticalEngine:
                 avg_correlation=None,
                 stop_loss=0.0,
                 api_calls_used=0,
-                timestamp=datetime.now(),
+                timestamp=datetime.now(),  # noqa: DTZ005
             )
 
         sector_weights: dict[str, float] = {}
@@ -534,7 +534,7 @@ class RiskStatisticalEngine:
                 avg_correlation=corr,
                 stop_loss=0.0,
                 api_calls_used=0,
-                timestamp=datetime.now(),
+                timestamp=datetime.now(),  # noqa: DTZ005
             )
 
         stops = atr_stop_losses(proposed_positions, price_history)
@@ -559,5 +559,5 @@ class RiskStatisticalEngine:
             avg_correlation=corr,
             stop_loss=stop_val,
             api_calls_used=0,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(),  # noqa: DTZ005
         )

--- a/argus/agents/sentiment.py
+++ b/argus/agents/sentiment.py
@@ -209,7 +209,7 @@ class SentimentDailyCache:
         """
         if ticker in self._cache:
             signal, cached_at = self._cache[ticker]
-            if (datetime.now() - cached_at).total_seconds() < self._ttl_days * 86400:
+            if (datetime.now() - cached_at).total_seconds() < self._ttl_days * 86400:  # noqa: DTZ005
                 return signal
         return None
 
@@ -220,7 +220,7 @@ class SentimentDailyCache:
             ticker: Equity ticker symbol.
             signal: Validated SentimentSignal to cache.
         """
-        self._cache[ticker] = (signal, datetime.now())
+        self._cache[ticker] = (signal, datetime.now())  # noqa: DTZ005
 
     def is_stale(self, ticker: str) -> bool:
         """Returns True if the ticker has no valid cached signal.
@@ -254,11 +254,11 @@ def _check_earnings_calendar(ticker: str) -> bool:
             earnings_dates = cal.loc["Earnings Date"]
             if not earnings_dates.empty:
                 dt = pd.to_datetime(earnings_dates.iloc[0])
-                if 0 <= (dt.tz_localize(None) - datetime.now()).days <= 14:
+                if 0 <= (dt.tz_localize(None) - datetime.now()).days <= 14:  # noqa: DTZ005
                     return True
         elif isinstance(cal, dict) and "Earnings Date" in cal:
             dt = pd.to_datetime(cal["Earnings Date"][0])
-            if 0 <= (dt.tz_localize(None) - datetime.now()).days <= 14:
+            if 0 <= (dt.tz_localize(None) - datetime.now()).days <= 14:  # noqa: DTZ005
                 return True
     except Exception as e:
         logger.debug("[EarningsCalendar] %s check failed: %s", ticker, e)
@@ -496,7 +496,7 @@ class SentimentAgent:
                     conviction=float(data["conviction"]),
                     sentiment_decay_risk=data.get("sentiment_decay_risk", "MEDIUM"),
                     reasoning=data.get("reasoning", "")[:400],
-                    timestamp=datetime.now(),
+                    timestamp=datetime.now(),  # noqa: DTZ005
                     api_calls_used=1,
                 )
                 self.cache.set(ticker, signal)

--- a/argus/agents/technical.py
+++ b/argus/agents/technical.py
@@ -335,7 +335,7 @@ class TechnicalStatisticalAgent:
             conviction=conviction,
             net_score=net_score,
             api_calls_used=0,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(),  # noqa: DTZ005
         )
 
     def batch_analyze(

--- a/argus/backtesting/__init__.py
+++ b/argus/backtesting/__init__.py
@@ -1,6 +1,9 @@
 """Backtesting sub-package for ARGUS.
 
-metrics.py: pure return-series statistics (Sharpe, Sortino, max drawdown, IC).
+metrics.py: pure return-series and trade-level statistics (Sharpe, Sortino,
+max drawdown, win rate, profit factor); its trade-level block is wired into
+evaluation.py, its return-series block has no caller yet (see metrics.py).
+evaluation.py: pre-registered rank IC / hit-rate / trade-level evaluation.
 replay.py: replays recorded fixture sessions through the real graph; there is
 no multi-year walk-forward engine here.
 """

--- a/argus/backtesting/evaluation.py
+++ b/argus/backtesting/evaluation.py
@@ -11,6 +11,8 @@ Responsibilities:
   - System-behavior metrics (schema validity, constraint enforcement,
     API calls/decision, replay determinism), reported separately and never
     blended into the predictive metrics above
+  - Trade-level win/loss statistics over the same paired outcomes (see
+    backtesting/metrics.py), reported separately from the metrics above
 
 Not responsible for:
   - Running the replay itself (see backtesting/replay.py)
@@ -18,7 +20,9 @@ Not responsible for:
     and read from argus/params.py, not re-derived here)
 
 Dependencies:
-  - numpy, scipy (statistics)
+  - numpy, pandas, scipy (statistics)
+  - argus.backtesting.metrics (compute_all_metrics, reused for its
+    trade-level block rather than duplicated)
   - argus.orchestration.reconciliation (compute_realized_return, reused
     rather than duplicated — this is the same function that feeds
     cultural.store_trade_outcome in production)
@@ -33,8 +37,10 @@ from pathlib import Path
 from typing import Callable, Optional, Sequence
 
 import numpy as np
+import pandas as pd
 from scipy import stats
 
+from argus.backtesting.metrics import compute_all_metrics
 from argus.backtesting.replay import SessionResult, replay_session
 from argus.orchestration.reconciliation import compute_realized_return
 from argus.schemas.signals import ARGUSDecision, RiskVerdict, Signal
@@ -252,6 +258,43 @@ def evaluate_decisions(
         hit_rate_ci=hit_ci,
         pairs=pairs,
     )
+
+
+_TRADE_LEVEL_KEYS = (
+    "win_rate",
+    "avg_win_pct",
+    "avg_loss_pct",
+    "win_loss_ratio",
+    "profit_factor",
+    "total_trades",
+    "avg_holding_days",
+)
+
+
+def trade_level_win_loss_stats(pairs: Sequence[PairedOutcome]) -> dict:
+    """Win/loss/profit-factor statistics over a set of paired outcomes.
+
+    Reuses backtesting.metrics.compute_all_metrics' trade-level block rather
+    than duplicating it, keying it on each pair's forward_return/holding_days.
+    compute_all_metrics also returns return-series metrics (annualized_return,
+    sharpe_ratio, max_drawdown, alpha/beta, VaR/CVaR, ...) that assume a daily
+    equity curve; this replay only has discrete per-decision horizon returns,
+    not one, so those keys are intentionally dropped rather than reported
+    under a false premise.
+
+    Args:
+        pairs: Paired outcomes, e.g. from EvaluationResult.pairs.
+
+    Returns:
+        Empty dict if pairs is empty; otherwise the trade-level subset of
+        compute_all_metrics' output.
+    """
+    if not pairs:
+        return {}
+    strategy_returns = pd.Series([p.forward_return for p in pairs])
+    trade_log = [{"return_pct": p.forward_return, "holding_days": p.holding_days} for p in pairs]
+    all_metrics = compute_all_metrics(strategy_returns, pd.Series(dtype=float), trade_log=trade_log)
+    return {key: all_metrics[key] for key in _TRADE_LEVEL_KEYS}
 
 
 @dataclass(frozen=True)

--- a/argus/backtesting/metrics.py
+++ b/argus/backtesting/metrics.py
@@ -1,9 +1,11 @@
 """
 argus/backtesting/metrics.py
 
-Pure return-series risk and performance metrics, reused by PR 10's
-pre-registered evaluation (rank IC, hit-rate-with-dead-band, Sharpe,
-Sortino, max drawdown).
+Pure return-series risk and performance metrics. Its trade-level block
+(win rate, profit factor, avg win/loss) is reused by
+backtesting/evaluation.py's trade_level_win_loss_stats; the return-series
+block (Sharpe, Sortino, max drawdown, alpha/beta, VaR/CVaR) has no caller
+yet — nothing in this repo produces a daily equity curve for it to score.
 
 Responsibilities:
   - Compute return, drawdown, benchmark-adjusted, tail-risk, and trade-level statistics

--- a/argus/data/fetchers.py
+++ b/argus/data/fetchers.py
@@ -430,7 +430,7 @@ def fetch_fundamentals(ticker: str) -> dict:
         "industry": info.get("industry"),
         "marketCap": mktcap,
         "p_fcf": p_fcf,
-        "as_of_date": date.today().isoformat(),
+        "as_of_date": date.today().isoformat(),  # noqa: DTZ011
     }
     logger.info(
         "fetch_fundamentals: %s → %d keys populated",
@@ -725,7 +725,7 @@ def fetch_news(
         from newsapi import NewsApiClient  # Lazy import; only loaded when NewsAPI is used
 
         client = NewsApiClient(api_key=settings.newsapi_key)
-        from_date = (datetime.utcnow() - timedelta(days=days_back)).strftime("%Y-%m-%d")
+        from_date = (datetime.now(timezone.utc) - timedelta(days=days_back)).strftime("%Y-%m-%d")
         query = f"{ticker} OR {company_name}"
 
         result = _fetch_news_page(client, query, from_date)

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -28,6 +28,7 @@ import importlib.metadata  # noqa: F401 — pandas_ta.maps uses this without imp
 import logging
 import math
 import re
+import threading
 import time
 from collections.abc import Callable
 from datetime import datetime, time as dtime, timedelta
@@ -290,6 +291,10 @@ class MFTDataPipeline:
         self.buffer = OHLCVBuffer(db_path=db_path, buffer_size=buffer_size, interval=self.interval)
         self.running = False
         self._stop_event = asyncio.Event()
+        # Held for the full body of every to_thread-run, buffer-touching worker
+        # (_fetch_and_insert, compress_all) so close_buffer can wait out one that's
+        # still running after its owning task was cancelled rather than joined (MFT-16)
+        self._buffer_op_lock = threading.Lock()
         # Routed through register_tickers rather than a bare assignment, so the
         # ticker-shape and universe-cap invariants apply uniformly here, to
         # run_collection_cycle, and to collect_session.py's --universe CLI arg
@@ -410,6 +415,26 @@ class MFTDataPipeline:
         self.running = False
         self._stop_event.set()
         logger.info("MFTDataPipeline.stop: shutdown requested")
+
+    async def close_buffer(self) -> None:
+        """Closes the candle buffer, waiting out any still-running buffer worker first (MFT-16).
+
+        Cancelling the fetch/collector loops' asyncio tasks unwinds their
+        coroutines but can't interrupt a `to_thread` call already executing on
+        a worker thread — that worker runs `_fetch_and_insert`/`compress_all`
+        to completion regardless of the task's cancellation. Both methods hold
+        `_buffer_op_lock` for their entire body, so blocking here until it's
+        acquired guarantees any such orphaned worker has actually finished
+        touching the buffer before its connection is closed. Callers must
+        await both loops' tasks to completion first — with `self.running`
+        already False by then, neither loop can start a *new* worker after
+        this returns.
+        """
+        await asyncio.to_thread(self._buffer_op_lock.acquire)
+        try:
+            self.buffer.close()
+        finally:
+            self._buffer_op_lock.release()
 
     async def run_once(self) -> dict[str, dict]:
         """Runs a single fetch-and-compress cycle without the background loops.
@@ -557,26 +582,29 @@ class MFTDataPipeline:
         Returns:
             Tuple of (candles inserted, latest close). (0, 0.0) on an empty fetch.
         """
-        is_cold = self.buffer.row_counts().get(ticker, 0) < _required_raw_bars(self.interval_minutes)
-        period = _FETCH_PERIOD if is_cold else _STEADY_STATE_FETCH_PERIOD
-        df: pd.DataFrame = fetch_ohlcv_intraday(ticker, self.interval, period)
-        if df is None or df.empty:
-            return 0, 0.0
+        with self._buffer_op_lock:
+            is_cold = (
+                self.buffer.row_counts().get(ticker, 0) < _required_raw_bars(self.interval_minutes)
+            )
+            period = _FETCH_PERIOD if is_cold else _STEADY_STATE_FETCH_PERIOD
+            df: pd.DataFrame = fetch_ohlcv_intraday(ticker, self.interval, period)
+            if df is None or df.empty:
+                return 0, 0.0
 
-        candles = [
-            {
-                "timestamp": idx.isoformat(),
-                "open": float(row["open"]) if "open" in row.index else None,
-                "high": float(row["high"]) if "high" in row.index else None,
-                "low": float(row["low"]) if "low" in row.index else None,
-                "close": float(row["close"]) if "close" in row.index else None,
-                "volume": float(row["volume"]) if "volume" in row.index else None,
-            }
-            for idx, row in df.iterrows()
-        ]
-        self.buffer.insert_candles(ticker, candles)
-        latest_close = float(df["close"].iloc[-1]) if "close" in df.columns else 0.0
-        return len(df), latest_close
+            candles = [
+                {
+                    "timestamp": idx.isoformat(),
+                    "open": float(row["open"]) if "open" in row.index else None,
+                    "high": float(row["high"]) if "high" in row.index else None,
+                    "low": float(row["low"]) if "low" in row.index else None,
+                    "close": float(row["close"]) if "close" in row.index else None,
+                    "volume": float(row["volume"]) if "volume" in row.index else None,
+                }
+                for idx, row in df.iterrows()
+            ]
+            self.buffer.insert_candles(ticker, candles)
+            latest_close = float(df["close"].iloc[-1]) if "close" in df.columns else 0.0
+            return len(df), latest_close
 
     def compress_all(self) -> dict[str, dict]:
         """Compresses cached candle metrics across all universe symbols into a feature dictionary.
@@ -601,32 +629,33 @@ class MFTDataPipeline:
         """
         states: dict[str, dict] = {}
         required_raw = _required_raw_bars(self.interval_minutes)
-        tracked = set(self.tickers)
-        for ticker in tracked & set(self.buffer.get_all_tickers()):
-            try:
-                df = self.buffer.get_candles(ticker)
-                if df is None or len(df) < required_raw:
-                    continue
-                state = self._compress_candles(df)
-                if state is None:
-                    continue
-                missing = missing_session_state_keys(state)
-                if missing:
+        with self._buffer_op_lock:
+            tracked = set(self.tickers)
+            for ticker in tracked & set(self.buffer.get_all_tickers()):
+                try:
+                    df = self.buffer.get_candles(ticker)
+                    if df is None or len(df) < required_raw:
+                        continue
+                    state = self._compress_candles(df)
+                    if state is None:
+                        continue
+                    missing = missing_session_state_keys(state)
+                    if missing:
+                        logger.warning(
+                            "compress_all: %s missing/non-finite required keys %s — omitting",
+                            ticker,
+                            missing,
+                        )
+                        continue
+                    states[ticker] = state
+                except Exception as exc:
                     logger.warning(
-                        "compress_all: %s missing/non-finite required keys %s — omitting",
+                        "compress_all: %s compression failed — %s: %s",
                         ticker,
-                        missing,
+                        type(exc).__name__,
+                        exc,
                     )
-                    continue
-                states[ticker] = state
-            except Exception as exc:
-                logger.warning(
-                    "compress_all: %s compression failed — %s: %s",
-                    ticker,
-                    type(exc).__name__,
-                    exc,
-                )
-        self.buffer.prune_untracked(tracked)
+            self.buffer.prune_untracked(tracked)
         logger.info("compress_all: %d tickers compressed", len(states))
         return states
 

--- a/argus/orchestration/collector.py
+++ b/argus/orchestration/collector.py
@@ -55,7 +55,7 @@ class CollectionResult:
     decisions_logged: int = 0
     macro_regime: str | None = None
     errors: list[str] = field(default_factory=list)
-    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())  # noqa: DTZ005
 
 
 def append_decisions_jsonl(decisions: list[ARGUSDecision], path: str) -> int:
@@ -181,7 +181,8 @@ async def run_collection_cycle(
         logger.info("run_collection_cycle: skipping graph invocation — %s", reason)
         return CollectionResult(ran=False, reason=reason)
 
-    config = {"configurable": {"thread_id": f"collector-{datetime.now().strftime('%Y%m%d%H%M%S')}"}}
+    thread_id = f"collector-{datetime.now().strftime('%Y%m%d%H%M%S')}"  # noqa: DTZ005
+    config = {"configurable": {"thread_id": thread_id}}
 
     logger.info(
         "run_collection_cycle: invoking graph for %d/%d ticker(s) with session data",

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -640,7 +640,7 @@ def build_graph(
         positions = {pos.ticker: pos for pos in allocation.portfolio}
         # A replayed session's as_of is the fixture's own capture date; falling back
         # to wall-clock only applies to genuinely live sessions
-        now = state.get("as_of") or datetime.now()
+        now = state.get("as_of") or datetime.now()  # noqa: DTZ005
         decisions: list[ARGUSDecision] = []
         errors: list[str] = []
 

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -23,8 +23,8 @@ Responsibilities:
     stores above so neither grows forever (PR 6)
 
 Not responsible for:
-  - Deciding what a "good" outcome is, or evaluation metrics (see PR 10 /
-    backtesting/metrics.py)
+  - Deciding what a "good" outcome is, or evaluation metrics (see
+    backtesting/evaluation.py and backtesting/metrics.py)
   - Scheduling reconciliation runs (see scripts/reconcile_outcomes.py)
 
 Dependencies:

--- a/argus/risk/kill_switch.py
+++ b/argus/risk/kill_switch.py
@@ -262,7 +262,7 @@ class KillSwitch:
 
         if drawdown >= threshold and not self._halted.is_set():
             reason = f"Drawdown {drawdown:.1%} >= {threshold:.0%} limit ({self.risk_tolerance})"
-            halt_time = datetime.now()
+            halt_time = datetime.now()  # noqa: DTZ005
             with self._state_lock:
                 self._halt_reason = reason
                 self._halt_time = halt_time
@@ -353,7 +353,8 @@ class KillSwitch:
 
         reason = dump.get("reason") or f"Restored from {path.name}"
         halt_time_raw = dump.get("halt_time")
-        halt_time = datetime.fromisoformat(halt_time_raw) if halt_time_raw else datetime.now()
+        # Naive local if no persisted halt_time — matches fromisoformat's naive parse of halt_time_raw
+        halt_time = datetime.fromisoformat(halt_time_raw) if halt_time_raw else datetime.now()  # noqa: DTZ005
         with self._state_lock:
             self._halt_reason = reason
             self._halt_time = halt_time
@@ -429,7 +430,8 @@ def _list_halt_dumps(runs_dir: Optional[str] = None) -> list[Path]:
                 return datetime.fromisoformat(raw)
         except Exception:
             pass
-        return datetime.fromtimestamp(path.stat().st_mtime)
+        # Naive local, matching the fromisoformat fallback above — must not mix aware/naive in the sort key
+        return datetime.fromtimestamp(path.stat().st_mtime)  # noqa: DTZ006
 
     return sorted(directory.glob("argus_halt_*.json"), key=_halt_time)
 

--- a/argus/risk/paper_book.py
+++ b/argus/risk/paper_book.py
@@ -178,7 +178,7 @@ class PaperBook:
         """
         self.equity = new_inception_value
         self.high_water_mark = new_inception_value
-        self.rebased_at = rebased_at or datetime.now()
+        self.rebased_at = rebased_at or datetime.now()  # noqa: DTZ005
 
     def prune_runs_applied(self, cutoff: datetime) -> int:
         """Drops runs_applied entries older than cutoff, so the set doesn't grow forever (COL-1).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,13 +107,19 @@ target-version = "py311"
 [tool.ruff.lint]
 # Stated explicitly rather than inherited from whatever the installed ruff
 # version defaults to. This is the set that was actually enforced across the
-# rebuild (ruff 0.15's defaults): pyflakes plus the pycodestyle error subset.
-# Ruff 0.16 would additionally flag ~230 findings, mostly DTZ (naive
-# `datetime.now()`) and UP (PEP 604/585 annotations). Those are real and worth
-# fixing — DTZ especially, in a system whose outcome resolution is date-keyed —
-# but adopting them is a code change, not a CI fix, so it is tracked separately
-# rather than smuggled in here.
-select = ["E4", "E7", "E9", "F"]
+# rebuild (ruff 0.15's defaults): pyflakes plus the pycodestyle error subset,
+# plus DTZ (naive datetime construction) — real in a system whose outcome
+# resolution is date-keyed (DEP-10). UP (PEP 604/585 annotations) is still
+# deferred; it's a style change, not a correctness one.
+select = ["E4", "E7", "E9", "F", "DTZ"]
+
+[tool.ruff.lint.per-file-ignores]
+# Test fixtures deliberately construct the same naive local timestamps production
+# code does (every session_timestamp/timestamp field is documented in
+# argus/schemas/signals.py as "naive local"); flagging each one individually
+# would be noise, not signal, unlike the reviewed per-call-site DTZ suppressions
+# production code carries
+"tests/*" = ["DTZ"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/scripts/reconcile_outcomes.py
+++ b/scripts/reconcile_outcomes.py
@@ -91,7 +91,7 @@ def main() -> None:
     ):
         book.apply_run(run_timestamp, run_return)
 
-    cutoff = datetime.now() - timedelta(
+    cutoff = datetime.now() - timedelta(  # noqa: DTZ005
         days=args.horizon_days + RECONCILIATION.retention_margin_days
     )
     book.prune_runs_applied(cutoff)

--- a/scripts/run_evaluation.py
+++ b/scripts/run_evaluation.py
@@ -26,6 +26,7 @@ from argus.backtesting.evaluation import (
     check_replay_determinism,
     evaluate_decisions,
     system_behavior_report,
+    trade_level_win_loss_stats,
 )
 from argus.backtesting.replay import replay_session
 from argus.params import RECONCILIATION
@@ -51,6 +52,15 @@ def _print_evaluation(label: str, result: EvaluationResult) -> None:
         print(f"  hit-rate:       {result.hit_rate:.4f} (n={result.hit_rate_n}), 95% CI {ci}")
     else:
         print("  hit-rate:       undefined (every decision fell inside the dead band)")
+
+    trade_stats = trade_level_win_loss_stats(result.pairs)
+    if trade_stats:
+        print(f"  win rate:       {trade_stats['win_rate']:.4f} "
+              f"({trade_stats['total_trades']} decisions)")
+        print(f"  profit factor:  {trade_stats['profit_factor']}")
+        print(f"  avg win/loss:   {trade_stats['avg_win_pct']:+.4f} / "
+              f"{trade_stats['avg_loss_pct']:+.4f} pct, "
+              f"avg holding {trade_stats['avg_holding_days']:.1f}d")
 
 
 def main() -> None:

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -25,6 +25,7 @@ from argus.backtesting.evaluation import (
     rank_information_coefficient,
     signed_conviction,
     system_behavior_report,
+    trade_level_win_loss_stats,
 )
 from argus.backtesting.replay import SessionResult, replay_session
 from argus.schemas.signals import ARGUSDecision, Signal
@@ -141,6 +142,27 @@ def test_hit_rate_excludes_returns_inside_deadband():
     hit_rate, n_scored = hit_rate_with_deadband(pairs, deadband=0.01)
     assert n_scored == 0
     assert hit_rate is None
+
+
+# ---------------------------------------------------------------------------
+# trade_level_win_loss_stats
+# ---------------------------------------------------------------------------
+
+
+def test_trade_level_win_loss_stats_empty_for_no_pairs():
+    """Trade-level stats are an empty dict when there are no paired outcomes."""
+    assert trade_level_win_loss_stats([]) == {}
+
+
+def test_trade_level_win_loss_stats_computes_win_rate_and_profit_factor():
+    """Trade-level stats key on forward_return sign, independent of conviction."""
+    pairs = _pairs(convictions=[0.5, -0.5, 0.5], returns=[0.05, -0.02, -0.01])
+    stats = trade_level_win_loss_stats(pairs)
+    assert stats["total_trades"] == 3
+    assert stats["win_rate"] == pytest.approx(1 / 3, abs=1e-4)
+    assert stats["avg_win_pct"] == pytest.approx(0.05)
+    assert stats["avg_loss_pct"] == pytest.approx(-0.015)
+    assert stats["avg_holding_days"] == pytest.approx(5.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -646,6 +646,20 @@ async def test_stop_ends_the_loop_promptly(monkeypatch):
     await asyncio.wait_for(task, timeout=2.0)
 
 
+@pytest.mark.asyncio
+async def test_close_buffer_waits_out_an_in_flight_buffer_worker():
+    """close_buffer blocks until a worker holding _buffer_op_lock releases it (MFT-16)."""
+    pipeline = MFTDataPipeline([], interval="1m")
+    pipeline._buffer_op_lock.acquire()
+
+    close_task = asyncio.create_task(pipeline.close_buffer())
+    await asyncio.sleep(0.05)
+    assert not close_task.done(), "close_buffer must not close the buffer while the lock is held"
+
+    pipeline._buffer_op_lock.release()
+    await asyncio.wait_for(close_task, timeout=2.0)
+
+
 def test_fetch_and_insert_bulk_inserts_in_one_call(monkeypatch):
     """`_fetch_and_insert` hands the whole fetched frame to insert_candles in one call, not per-row."""
     pipeline = MFTDataPipeline([], interval="1m")


### PR DESCRIPTION
## Summary
- DOC-1: regenerates the README's `/analyze` response table and example from the actual Pydantic models (composite_conviction is a float not a categorical label, allocation_pct is a fraction of total_wealth not the invested portion, errors is surfaced, macro window is 36 month-end observations not ~90 days); updates the stale test-count badge.
- DOC-2: softens `_assert_single_worker`'s error messages to name what the pre-flight check can't see and point at the flock as the real guard.
- DOC-3: wires `argus/backtesting/metrics.py`'s trade-level block into `scripts/run_evaluation.py` via a new `trade_level_win_loss_stats` helper, rather than leaving it referenced by a PR 10 that was never part of this plan.
- MFT-16: gives `MFTDataPipeline` a `close_buffer()` that waits out any buffer-touching worker still running on an orphaned thread before closing the sqlite connection — cancelling the fetch/collector loops' asyncio tasks can't stop a `to_thread` call already executing.
- DEP-9: replaces the last `datetime.utcnow()` call.
- DEP-10: enables ruff's DTZ rule, with reviewed per-call-site suppressions for this system's deliberately naive local timestamps (documented throughout `argus/schemas/signals.py`) and a `tests/*` per-file ignore for fixtures mirroring the same convention.
- Deletes local gitignored clutter (`argus_graph.db`, `daily_bars_cache.db`, a stale chroma backup).

## Test plan
- [x] `.venv/bin/python -m pytest -q` — 437 passed
- [x] `ruff check .` — clean
- [x] `mypy argus/` — clean