### PR TITLE
Deepen the LLM seam: one structured-output call owns parse, validate, and retry

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,76 @@
+# ARGUS Glossary
+
+Vocabulary this project's design documents and code assume you already know. Where a
+term is also a class or module, the reference is included so this file can be checked
+against the code rather than trusted blindly.
+
+## Verdict, signal, proposal
+
+These three are the vocabulary introduced by the LLM seam work (issue #67) and are
+easy to conflate because the codebase already overloads two of the words elsewhere —
+see the notes under each entry.
+
+- **Verdict** — what an LLM actually returns from a structured-output call. Narrower
+  than a signal: it carries only the model's own judgement (direction, conviction, and
+  the fields that support that judgement — moat score, decay risk, reasoning), never
+  measured data the model was shown but does not own. *Not* `RiskVerdict`
+  (`argus/schemas/signals.py`), which is the risk engine's deterministic
+  APPROVE/VETO/REDUCE disposition and carries no model judgement at all.
+
+- **Signal** — the domain object an agent produces by combining a verdict with
+  measured data the agent itself owns. `FundamentalSignal` merges the fundamental
+  verdict with ratios fetched from the market-data provider; `SentimentSignal` merges
+  the sentiment verdict with FinBERT metrics computed locally. Neither is ever taken
+  from the model's echo of data it was shown. Distinct from the `Signal` enum
+  (`argus/schemas/signals.py`), which is just the BULLISH/BEARISH/NEUTRAL directional
+  label carried inside one of these objects, not the object itself.
+
+- **Proposal** — the portfolio agent's equivalent of a verdict: an advisory allocation
+  the risk engine has not yet enforced against. A proposal becomes an allocation only
+  after risk caps have been applied in code.
+
+## Domain nouns
+
+- **Session** — one invocation of the LangGraph DAG — a live `/analyze` request, an
+  unattended collector cycle, or a replay run. Every decision the run produces shares
+  one `session_timestamp` (`ARGUSDecision`, `argus/schemas/signals.py`), which is what
+  later lets `paper_book.py` group them back into a single notional rebalance.
+
+- **Universe** — the full set of tickers eligible for analysis in a session
+  (`ARGUSState.universe`, `argus/orchestration/state.py`). Tracked by the MFT pipeline
+  subject to a 100-ticker cap and 24h TTL eviction for non-seed tickers.
+
+- **Session state** — the compressed technical-indicator dict for one ticker (RSI,
+  MACD histogram, VWAP distance, etc. — see `SESSION_STATE_REQUIRED_KEYS`,
+  `argus/schemas/signals.py`) that the MFT pipeline produces and the technical agent
+  consumes. Not the same thing as a session: a session has many tickers, each with its
+  own session state.
+
+- **Sweep** — one pass of the MFT pipeline (`_sweep_once`, `argus/data/pipeline.py`)
+  fetching the latest intraday candles for every tracked ticker in the universe. Its
+  callers compress the buffer into session states afterward, via `compress_all`.
+
+- **Decision** — an `ARGUSDecision` (`argus/schemas/signals.py`): a per-ticker snapshot
+  of every agent's output plus the resulting allocation, logged once per session.
+
+- **Allocation** — a `PositionAllocation` or `PortfolioAllocation`
+  (`argus/schemas/signals.py`): the risk-enforced target weight(s) a session
+  ultimately recommends. What a proposal becomes once risk caps have been applied.
+
+- **Governor** — the per-process `RateLimitGovernor`
+  (`argus/orchestration/governor.py`) that enforces Groq's per-model rate-limit quotas
+  and provides cooperative back-pressure ahead of every LLM call.
+
+- **Kill switch** — the background daemon (`argus/risk/kill_switch.py`) with two
+  independent gates: it halts all activity on excessive portfolio drawdown, and
+  separately blocks *new* positions during extreme VIX. It runs independently of the
+  LangGraph DAG and knows nothing about it.
+
+- **Cultural memory** — the ChromaDB-backed long-term memory
+  (`argus/memory/cultural.py`) that stores trade outcomes and decision snapshots, and
+  retrieves regime-scoped historical wisdom and warnings for the portfolio agent.
+
+- **Reconciliation** — the slow-clock pass (`argus/orchestration/reconciliation.py`)
+  that closes the decision-to-outcome loop: computing realized returns, assigning
+  per-agent credit via leave-one-out ablation, and persisting trade outcomes into
+  cultural memory.

--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -22,9 +22,7 @@ Dependencies:
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
-import time
 from datetime import date, datetime
 from typing import Any, Optional
 
@@ -32,8 +30,9 @@ from pydantic import ValidationError
 
 from argus.config import settings
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel, governor
-from argus.schemas.signals import FundamentalSignal
+from argus.schemas.signals import FundamentalSignal, FundamentalVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
+from argus.structured_output import StructuredOutputError, decode
 
 logger = logging.getLogger("argus.fundamental")
 
@@ -53,6 +52,17 @@ _SECTOR_PE_MEDIANS: dict[str, float] = {
     "Basic Materials": 16.0,
 }
 _DEFAULT_PE_MEDIAN = 20.0
+
+# Field descriptions for the prompt's "Fields required" line, keyed by the
+# same names as FundamentalVerdict's schema — a drift test (test_fundamental.py)
+# asserts the two stay equal, so a schema change that isn't mirrored here fails
+# loudly instead of leaving the prompt asking for fields the model can't supply.
+_VERDICT_FIELD_DESCRIPTIONS: dict[str, str] = {
+    "signal": "signal (string)",
+    "conviction": "conviction (float 0.0–1.0)",
+    "moat_score": "moat_score (int 1–10)",
+    "reasoning": "reasoning (string ≤80 words, no markdown)",
+}
 
 # Fraction of the configured per-minute request budget held back before a
 # ticker's fundamental analysis is even attempted, so the same-model portfolio
@@ -197,10 +207,7 @@ def build_compact_prompt(ticker: str, pit_data: dict, anon_id: Optional[str] = N
         "(3) null fields do not drive the primary signal.\n"
         "\n"
         "Output ONLY a valid JSON object — no markdown, no preamble, no trailing text.\n"
-        "Fields required: signal (string), conviction (float 0.0–1.0), pe_ttm (float|null), "
-        "revenue_growth_yoy (float|null), operating_margin (float|null), fcf_yield (float|null), "
-        "debt_to_equity (float|null), roic (float|null), moat_score (int 1–10), "
-        "reasoning (string ≤80 words, no markdown)."
+        "Fields required: " + ", ".join(_VERDICT_FIELD_DESCRIPTIONS.values()) + "."
     )
     return prompt.strip()
 
@@ -302,8 +309,8 @@ class FundamentalAgent:
 
     Uses an injected LLMClient (Groq by default) to construct structured
     investment theses from ratio payloads fetched via an injected
-    MarketDataProvider, applying local caches, governor rate limits, and
-    exponential back-off on transient failures.
+    MarketDataProvider, applying local caches, governor rate limits, and the
+    shared structured-output decoder's parse/validate/retry (with repair).
     """
 
     def __init__(
@@ -347,7 +354,8 @@ class FundamentalAgent:
         """Audits fundamentals for a single ticker and returns a validated Pydantic signal.
 
         Checks the local cache first, enforces governor capacity, fetches current
-        financial ratios, and invokes the LLM with up to 3 retry attempts.
+        financial ratios, and decodes a FundamentalVerdict from the LLM via
+        argus.structured_output.decode (with repair enabled).
 
         Args:
             ticker: Equity ticker symbol.
@@ -359,7 +367,7 @@ class FundamentalAgent:
                 only logging it.
 
         Returns:
-            A validated FundamentalSignal, or None if all attempts fail.
+            A validated FundamentalSignal, or None if decoding ultimately fails.
         """
         if not self.cache.is_stale(ticker, session_seed):
             cached = self.cache.get(ticker, session_seed)
@@ -397,87 +405,59 @@ class FundamentalAgent:
         }
         prompt = build_compact_prompt(ticker, pit_data, anon_id)
 
-        last_error: Optional[str] = None
-        for attempt in range(3):
-            try:
-                user_prompt = prompt
-                if last_error is not None:
-                    user_prompt = (
-                        f"{prompt}\n\n"
-                        f"Your previous response was invalid: {last_error}\n"
-                        "Return a corrected JSON object satisfying the schema above."
-                    )
-                raw = self.llm_client.complete(SYSTEM_PROMPT, user_prompt).strip()
+        try:
+            verdict = decode(self.llm_client, SYSTEM_PROMPT, prompt, FundamentalVerdict, repair=True)
+        except StructuredOutputError as e:
+            logger.warning("[Fundamental] Decode failed for %s: %s", ticker, e)
+            if errors is not None:
+                errors.append(f"fundamental_analysis[{ticker}]: {e}")
+            return None
+        except (RateLimitExceeded, UnregisteredModel) as e:
+            # The governor already exhausted its own bounded wait before raising
+            # either of these — degrade this ticker immediately rather than
+            # retrying into the same wall.
+            logger.warning("[Fundamental] Governor rejected call for %s: %s", ticker, e)
+            if errors is not None:
+                errors.append(f"fundamental_analysis[{ticker}]: rate limited: {e}")
+            return None
+        except Exception as e:
+            logger.error("[Fundamental] API error for %s: %s", ticker, e)
+            if errors is not None:
+                errors.append(f"fundamental_analysis[{ticker}]: API error: {e}")
+            return None
 
-                if raw.startswith("```"):
-                    parts = raw.split("```")
-                    if len(parts) >= 3:
-                        raw = parts[1]
-                    else:
-                        raw = parts[-1]
-                    raw = raw.strip()
-                    if raw.startswith("json"):
-                        raw = raw[4:].strip()
+        data: dict[str, Any] = verdict.model_dump()
+        data["ticker"] = ticker
+        data["data_as_of_date"] = pit_data["as_of_date"]
+        data["timestamp"] = datetime.now().isoformat()  # noqa: DTZ005
+        data["api_calls_used"] = 1
 
-                data = json.loads(raw)
+        # All measured ratios come from the fetched payload, never the LLM
+        # echo — the LLM only supplies signal/conviction/moat_score/reasoning.
+        f = pit_data.get("fundamentals", {})
+        for key in _MEASURED_FUNDAMENTAL_FIELDS:
+            data[key] = f.get(key)
+        data["sector"] = data["sector"] or "Unknown"
+        data["industry"] = data["industry"] or "Unknown"
 
-                data["ticker"] = ticker
-                data["data_as_of_date"] = pit_data["as_of_date"]
-                data["timestamp"] = datetime.now().isoformat()  # noqa: DTZ005
-                data["api_calls_used"] = 1
+        data["reasoning"] = data["reasoning"][:400]
 
-                # All measured ratios come from the fetched payload, never the LLM
-                # echo — the LLM only supplies signal/conviction/moat_score/reasoning.
-                f = pit_data.get("fundamentals", {})
-                for key in _MEASURED_FUNDAMENTAL_FIELDS:
-                    data[key] = f.get(key)
-                data["sector"] = data["sector"] or "Unknown"
-                data["industry"] = data["industry"] or "Unknown"
+        try:
+            signal = FundamentalSignal.model_validate(data)
+        except ValidationError as e:
+            # Merged-in measured data (e.g. a negative debt_to_equity) can violate
+            # the signal schema even though the verdict itself decoded cleanly —
+            # degrade this ticker rather than let it crash the batch.
+            logger.warning("[Fundamental] Measured data failed signal validation for %s: %s", ticker, e)
+            if errors is not None:
+                errors.append(f"fundamental_analysis[{ticker}]: measured data failed validation: {e}")
+            return None
 
-                if "reasoning" in data and isinstance(data["reasoning"], str):
-                    data["reasoning"] = data["reasoning"][:400]
-
-                signal = FundamentalSignal.model_validate(data)
-                self.cache.set(ticker, signal, session_seed)
-                logger.debug(
-                    "[Fundamental] Analysis complete for %s -> %s", ticker, signal.signal.value
-                )
-                return signal
-
-            except (json.JSONDecodeError, ValidationError) as e:
-                logger.warning(
-                    "[Fundamental] Attempt %d parse error for %s: %s", attempt + 1, ticker, e
-                )
-                last_error = str(e)
-                if attempt == 2:
-                    if errors is not None:
-                        errors.append(
-                            f"fundamental_analysis[{ticker}]: parse error after 3 attempts: {e}"
-                        )
-                    return None
-                time.sleep(2**attempt)
-            except (RateLimitExceeded, UnregisteredModel) as e:
-                # The governor already exhausted its own bounded wait before raising
-                # either of these — retrying here would just re-run into the same
-                # wall, not recover from it. Degrade this ticker immediately instead
-                # of burning three more rounds of governor waits.
-                logger.warning("[Fundamental] Governor rejected call for %s: %s", ticker, e)
-                if errors is not None:
-                    errors.append(f"fundamental_analysis[{ticker}]: rate limited: {e}")
-                return None
-            except Exception as e:
-                logger.error(
-                    "[Fundamental] Attempt %d API error for %s: %s", attempt + 1, ticker, e
-                )
-                if attempt == 2:
-                    if errors is not None:
-                        errors.append(
-                            f"fundamental_analysis[{ticker}]: API error after 3 attempts: {e}"
-                        )
-                    return None
-                time.sleep(2**attempt)
-
-        return None
+        self.cache.set(ticker, signal, session_seed)
+        logger.debug(
+            "[Fundamental] Analysis complete for %s -> %s", ticker, signal.signal.value
+        )
+        return signal
 
     def batch_analyze(
         self, tickers: list[str], backtest_mode: bool = False, session_seed: Optional[int] = None

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -21,9 +21,7 @@ Dependencies:
 
 from __future__ import annotations
 
-import json
 import logging
-import time
 from datetime import datetime
 from typing import Optional, TypeGuard
 from uuid import uuid4
@@ -33,8 +31,16 @@ import numpy as np
 from argus.config import settings
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
 from argus.params import PORTFOLIO
-from argus.schemas.signals import MacroContext, PortfolioAllocation, RiskAssessment, RiskVerdict, Signal
+from argus.schemas.signals import (
+    MacroContext,
+    PortfolioAllocation,
+    PortfolioProposal,
+    RiskAssessment,
+    RiskVerdict,
+    Signal,
+)
 from argus.seams import GroqLLMClient, LLMClient
+from argus.structured_output import StructuredOutputError, decode
 
 logger = logging.getLogger("argus.portfolio")
 
@@ -137,6 +143,35 @@ def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContex
     return "\n".join(lines)
 
 
+# Field descriptions for the prompt's declared output schema, keyed by the same
+# names as ProposedPosition's and PortfolioProposal's schemas — a drift test
+# (test_portfolio_enforcement.py) asserts the two stay equal, so a schema change
+# that isn't mirrored here fails loudly instead of leaving the prompt asking for
+# fields the model can't supply.
+_POSITION_FIELD_DESCRIPTIONS: dict[str, str] = {
+    "ticker": '""',
+    "allocation_pct": "0.0",
+    "stop_loss": "0.0",
+    "target_price": "null",
+    "thesis": '"<≤20 words>"',
+    "advisor_note": '"2–4 professional sentences: rationale, key risks, what to monitor"',
+    "composite_conviction": "0.0",
+    "time_horizon": '"3-6 months"',
+}
+_PROPOSAL_FIELD_DESCRIPTIONS: dict[str, str] = {
+    "cash_reserve_pct": "0.0",
+    "rebalance_trigger": '"MONTHLY"',
+}
+_POSITION_SCHEMA_JSON = (
+    "{" + ",".join(f'"{k}":{v}' for k, v in _POSITION_FIELD_DESCRIPTIONS.items()) + "}"
+)
+_PROPOSAL_SCHEMA_JSON = (
+    '{"portfolio":[' + _POSITION_SCHEMA_JSON + "],"
+    + ",".join(f'"{k}":{v}' for k, v in _PROPOSAL_FIELD_DESCRIPTIONS.items())
+    + "}"
+)
+
+
 SYSTEM_PROMPT = (
     "You are a systematic portfolio construction specialist at a quantitative investment fund. "
     "You receive pre-computed, risk-approved signals from four independent analytical agents. "
@@ -184,8 +219,11 @@ class PortfolioManagerAgent:
     """Agent coordinating LLM-driven portfolio optimization and cash allocation.
 
     Synthesizes risk verdicts, specialist convictions, Half-Kelly size suggestions,
-    and cultural memory wisdom into a structured PortfolioAllocation. Falls back to
-    all-cash on API failures or when no tickers are risk-approved.
+    and cultural memory wisdom into a structured PortfolioAllocation. Obtains its
+    proposal via the shared structured-output decoder with repair disabled — the
+    prompt already carries the signal table, sizing anchors, and cultural memory,
+    so a repair round-trip would be a large charge against the governor. Falls
+    back to all-cash on API failures or when no tickers are risk-approved.
     """
 
     def __init__(self, llm_client: Optional[LLMClient] = None) -> None:
@@ -222,10 +260,10 @@ class PortfolioManagerAgent:
         """Aggregates all specialist agent verdicts to construct a consolidated PortfolioAllocation.
 
         Computes Half-Kelly size suggestions as a mathematical anchor, constructs a
-        fully contextualized state prompt, and invokes the LLM to produce the final
-        allocation with advisor notes. Returns None on LLM API or parse failure so
-        the orchestrator can exit gracefully rather than masking the failure with a
-        fabricated all-cash response.
+        fully contextualized state prompt, and decodes a PortfolioProposal from the
+        LLM via argus.structured_output.decode. Returns None on decode failure or a
+        response-enforcement error so the orchestrator can exit gracefully rather
+        than masking the failure with a fabricated all-cash response.
 
         Args:
             user_profile: Dict with keys ``total_wealth``, ``invest_pct``, ``risk_tolerance``.
@@ -238,14 +276,15 @@ class PortfolioManagerAgent:
             adjustments: Optional list that receives one human-readable entry per
                 clamped, zeroed, or dropped position — the caller's record of
                 where the LLM's proposal disagreed with risk enforcement. Also
-                receives one entry naming which of the three retry-loop stages
-                (``llm_call``, ``json_parse``, ``response_enforcement``, or
-                ``schema_validation``) was failing when all 3 attempts were
-                exhausted, if that happens.
+                receives one entry naming which stage failed if allocation
+                ultimately fails: the decoder's ``json_parse``/``schema_validation``
+                stage when the proposal itself never decoded, or the agent's own
+                ``response_enforcement``/``schema_validation`` stage when risk
+                enforcement or the final PortfolioAllocation build failed.
 
         Returns:
             A validated PortfolioAllocation, all-cash if no tickers are approved, or None
-            if all 3 LLM retry attempts fail.
+            if decoding the proposal or enforcing it against risk data ultimately fails.
 
         Raises:
             RateLimitExceeded: If the governor's rate budget is exhausted for this
@@ -367,123 +406,114 @@ class PortfolioManagerAgent:
             "(3) every approved ticker appears in portfolio.\n"
             "\n"
             "Output JSON schema exactly:\n"
-            '{"portfolio":[{"ticker":"","allocation_pct":0.0,"allocation_usd":0.0,"stop_loss":0.0,'
-            '"target_price":null,"thesis":"<≤20 words>",'
-            '"advisor_note":"2–4 professional sentences: rationale, key risks, what to monitor",'
-            '"composite_conviction":0.0,"time_horizon":"3-6 months"}],'
-            '"cash_reserve_pct":0.0,"rebalance_trigger":"MONTHLY"}'
+            f"{_PROPOSAL_SCHEMA_JSON}"
         )
-        for attempt in range(3):
-            stage = "llm_call"
-            try:
-                raw = self.llm_client.complete(SYSTEM_PROMPT, prompt).strip()
-                if raw.startswith("```"):
-                    parts = raw.split("```")
-                    if len(parts) >= 3:
-                        raw = parts[1]
-                    else:
-                        raw = parts[-1]
-                    raw = raw.strip()
-                    if raw.startswith("json"):
-                        raw = raw[4:].strip()
 
-                stage = "json_parse"
-                data = json.loads(raw)
+        try:
+            proposal = decode(self.llm_client, SYSTEM_PROMPT, prompt, PortfolioProposal, repair=False)
+        except StructuredOutputError as e:
+            msg = f"portfolio_allocation: {e}"
+            logger.error("[Portfolio] %s", msg)
+            if adjustments is not None:
+                adjustments.append(msg)
+            return None
+        except (RateLimitExceeded, UnregisteredModel):
+            # There is no per-ticker fallback here the way fundamental/sentiment
+            # have one — a single allocate() call either produces the whole
+            # portfolio or nothing does. The governor has already exhausted its
+            # own bounded wait before raising either of these, so propagate
+            # immediately and let the caller (node_portfolio_allocation -> the
+            # API layer) surface it as a 429/503 instead of a generic 500.
+            raise
+        except Exception as e:
+            msg = f"portfolio_allocation: PortfolioManagerAgent API error: {e}"
+            logger.error("[Portfolio] %s", msg)
+            if adjustments is not None:
+                adjustments.append(msg)
+            return None
 
-                stage = "response_enforcement"
-                # Enforce risk verdicts in code: the LLM's proposal is advisory input,
-                # not a binding allocation, so it cannot be trusted to respect caps it
-                # was merely shown in the prompt.
-                enforced_portfolio = []
-                for pos in data.get("portfolio", []):
-                    ticker = pos["ticker"]
-                    if ticker not in all_signals:
+        stage = "response_enforcement"
+        try:
+            # Enforce risk verdicts in code: the LLM's proposal is advisory input,
+            # not a binding allocation, so it cannot be trusted to respect caps it
+            # was merely shown in the prompt.
+            enforced_portfolio = []
+            for pos in proposal.portfolio:
+                ticker = pos.ticker
+                if ticker not in all_signals:
+                    msg = (
+                        f"portfolio_allocation: dropped {ticker} "
+                        "(not in this session's signal universe)"
+                    )
+                    logger.warning(msg)
+                    if adjustments is not None:
+                        adjustments.append(msg)
+                    continue
+
+                risk = all_signals[ticker].get("risk")
+                proposed_pct = pos.allocation_pct
+                pos_data = pos.model_dump()
+                if not _is_risk_approved(risk):
+                    if proposed_pct:
+                        verdict = risk.verdict.value if risk else "MISSING"
                         msg = (
-                            f"portfolio_allocation: dropped {ticker} "
-                            "(not in this session's signal universe)"
+                            f"portfolio_allocation: zeroed {ticker} allocation "
+                            f"(risk verdict {verdict})"
                         )
                         logger.warning(msg)
                         if adjustments is not None:
                             adjustments.append(msg)
-                        continue
+                    pos_data["allocation_pct"] = 0.0
+                else:
+                    cap = risk.approved_weight
+                    if proposed_pct > cap + 1e-9:
+                        msg = (
+                            f"portfolio_allocation: clamped {ticker} allocation from "
+                            f"{proposed_pct:.4f} to risk cap {cap:.4f}"
+                        )
+                        logger.warning(msg)
+                        if adjustments is not None:
+                            adjustments.append(msg)
+                        pos_data["allocation_pct"] = cap
 
-                    risk = all_signals[ticker].get("risk")
-                    proposed_pct = pos.get("allocation_pct", 0.0)
-                    if not _is_risk_approved(risk):
-                        if proposed_pct:
-                            verdict = risk.verdict.value if risk else "MISSING"
-                            msg = (
-                                f"portfolio_allocation: zeroed {ticker} allocation "
-                                f"(risk verdict {verdict})"
-                            )
-                            logger.warning(msg)
-                            if adjustments is not None:
-                                adjustments.append(msg)
-                        pos["allocation_pct"] = 0.0
-                    else:
-                        cap = risk.approved_weight
-                        if proposed_pct > cap + 1e-9:
-                            msg = (
-                                f"portfolio_allocation: clamped {ticker} allocation from "
-                                f"{proposed_pct:.4f} to risk cap {cap:.4f}"
-                            )
-                            logger.warning(msg)
-                            if adjustments is not None:
-                                adjustments.append(msg)
-                            pos["allocation_pct"] = cap
+                pos_data["allocation_usd"] = round(investable * pos_data["allocation_pct"], 2)
+                pos_data["thesis"] = pos_data["thesis"][:PORTFOLIO.thesis_char_limit]
+                if pos_data["advisor_note"] is not None:
+                    pos_data["advisor_note"] = pos_data["advisor_note"][:PORTFOLIO.advisor_note_char_limit]
+                if risk is not None and risk.stop_loss is not None:
+                    pos_data["stop_loss"] = float(risk.stop_loss)
 
-                    pos["allocation_usd"] = round(investable * pos["allocation_pct"], 2)
-                    if "thesis" in pos and isinstance(pos["thesis"], str):
-                        pos["thesis"] = pos["thesis"][:PORTFOLIO.thesis_char_limit]
-                    if "advisor_note" in pos and isinstance(pos["advisor_note"], str):
-                        pos["advisor_note"] = pos["advisor_note"][:PORTFOLIO.advisor_note_char_limit]
-                    if risk is not None and risk.stop_loss is not None:
-                        pos["stop_loss"] = float(risk.stop_loss)
+                enforced_portfolio.append(pos_data)
 
-                    enforced_portfolio.append(pos)
+            # Force residual exact; LLM may set cash_reserve_pct independently, not as 1-equity.
+            # Clamped to the schema floor (PA-4) rather than left to fail model_validate on a
+            # near-fully-deployed session (e.g. invest_pct=0.95), which surfaced as a 500
+            # instead of the achievable allocation this session actually produced
+            total_equity = sum(p["allocation_pct"] for p in enforced_portfolio)
+            cash_reserve_pct = round(
+                max(PORTFOLIO.cash_reserve_floor_pct, 1.0 - total_equity), 6
+            )
 
-                data["portfolio"] = enforced_portfolio
+            data = {
+                "session_id": str(uuid4()),
+                "user_investable_capital": investable,
+                "portfolio": enforced_portfolio,
+                "cash_reserve_pct": cash_reserve_pct,
+                "rebalance_trigger": proposal.rebalance_trigger,
+                "timestamp": datetime.now().isoformat(),  # noqa: DTZ005
+            }
 
-                # Force residual exact; LLM may set cash_reserve_pct independently, not as 1-equity.
-                # Clamped to the schema floor (PA-4) rather than left to fail model_validate on a
-                # near-fully-deployed session (e.g. invest_pct=0.95), which surfaced as a 500
-                # instead of the achievable allocation this session actually produced
-                total_equity = sum(p["allocation_pct"] for p in data["portfolio"])
-                data["cash_reserve_pct"] = round(
-                    max(PORTFOLIO.cash_reserve_floor_pct, 1.0 - total_equity), 6
-                )
+            stage = "schema_validation"
+            allocation = PortfolioAllocation.model_validate(data)
+        except Exception as e:
+            msg = f"portfolio_allocation: PortfolioManagerAgent failed at {stage}: {e}"
+            logger.error("[Portfolio] %s", msg)
+            if adjustments is not None:
+                adjustments.append(msg)
+            return None
 
-                data["session_id"] = str(uuid4())
-                data["user_investable_capital"] = investable
-                data["timestamp"] = datetime.now().isoformat()  # noqa: DTZ005
-
-                stage = "schema_validation"
-                allocation = PortfolioAllocation.model_validate(data)
-                self._session_count += 1
-                return allocation
-
-            except (RateLimitExceeded, UnregisteredModel):
-                # There is no per-ticker fallback here the way fundamental/sentiment
-                # have one — a single allocate() call either produces the whole
-                # portfolio or nothing does. Retrying would just re-run into the
-                # governor's already-exhausted wait, so propagate immediately and
-                # let the caller (node_portfolio_allocation -> the API layer)
-                # surface it as a 429/503 instead of a generic 500.
-                raise
-            except Exception as e:
-                logger.warning("[Portfolio] Attempt %d failed (%s): %s", attempt + 1, stage, e)
-                if attempt == 2:
-                    msg = (
-                        f"portfolio_allocation: PortfolioManagerAgent failed after 3 attempts "
-                        f"at {stage}: {e}"
-                    )
-                    logger.error("[Portfolio] %s", msg)
-                    if adjustments is not None:
-                        adjustments.append(msg)
-                    return None
-                time.sleep(2**attempt)
-
-        return None
+        self._session_count += 1
+        return allocation
 
     def _all_cash_allocation(self, investable: float) -> PortfolioAllocation:
         """Returns a defensive all-cash portfolio structure during risk vetoes or API failures.

--- a/argus/agents/sentiment.py
+++ b/argus/agents/sentiment.py
@@ -22,20 +22,19 @@ Dependencies:
 
 from __future__ import annotations
 
-import json
 import logging
 import time
 from datetime import datetime
 from typing import Optional
 
 import numpy as np
-from pydantic import ValidationError
 
 from argus.config import settings
 from argus.data import fetchers
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
-from argus.schemas.signals import SentimentSignal
+from argus.schemas.signals import SentimentSignal, SentimentVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
+from argus.structured_output import StructuredOutputError, decode
 
 logger = logging.getLogger("argus.sentiment")
 
@@ -284,6 +283,23 @@ _SENTIMENT_METRIC_LABELS: dict[str, str] = {
 }
 
 
+# Field descriptions for the prompt's declared output schema, keyed by the same
+# names as SentimentVerdict's schema — a drift test (test_sentiment.py) asserts
+# the two stay equal, so a schema change that isn't mirrored here fails loudly
+# instead of leaving the prompt asking for fields the model can't supply. Shared
+# between _build_synthesis_prompt and SYSTEM_PROMPT so their two schema restatements
+# can't drift apart from each other either.
+_VERDICT_FIELD_DESCRIPTIONS: dict[str, str] = {
+    "signal": '"BULLISH|BEARISH|NEUTRAL"',
+    "conviction": "<float 0.0–1.0>",
+    "sentiment_decay_risk": '"LOW|MEDIUM|HIGH"',
+    "reasoning": '"<≤60 words citing the primary driver>"',
+}
+_VERDICT_SCHEMA_JSON = (
+    "{" + ", ".join(f'"{k}": {v}' for k, v in _VERDICT_FIELD_DESCRIPTIONS.items()) + "}"
+)
+
+
 def _build_synthesis_prompt(ticker: str, metrics: dict) -> str:
     """Constructs the human-turn message for LLM sentiment synthesis.
 
@@ -319,8 +335,7 @@ def _build_synthesis_prompt(ticker: str, metrics: dict) -> str:
         "Step 4 — Set sentiment_decay_risk (LOW | MEDIUM | HIGH) and state the mechanism.\n"
         "\n"
         "Output ONLY valid JSON matching this exact schema — no preamble, no trailing text:\n"
-        '{"signal": "<BULLISH|BEARISH|NEUTRAL>", "conviction": <float 0.0–1.0>, '
-        '"sentiment_decay_risk": "<LOW|MEDIUM|HIGH>", "reasoning": "<≤60 words citing key driver>"}'
+        f"{_VERDICT_SCHEMA_JSON}"
     )
     return prompt.strip()
 
@@ -355,8 +370,7 @@ SYSTEM_PROMPT = (
     "  4. upcoming_catalyst=True → sentiment_decay_risk must be MEDIUM or HIGH.\n"
     "\n"
     "OUTPUT: Return ONLY a valid JSON object — no markdown, no preamble, no trailing text.\n"
-    'Schema: {"signal": "BULLISH|BEARISH|NEUTRAL", "conviction": <float 0.0–1.0>, '
-    '"sentiment_decay_risk": "LOW|MEDIUM|HIGH", "reasoning": "<≤60 words citing the primary driver>"}'
+    "Schema: " + _VERDICT_SCHEMA_JSON
 )
 
 
@@ -365,8 +379,8 @@ class SentimentAgent:
     LLM synthesis.
 
     Uses a daily cache to prevent redundant inference for the same ticker within a
-    trading session. Retries the LLM call up to 3 times with exponential back-off
-    on parse or validation failures.
+    trading session. Obtains its verdict via the shared structured-output decoder
+    with repair disabled — see analyze()'s docstring for why.
     """
 
     def __init__(
@@ -415,8 +429,15 @@ class SentimentAgent:
                 returns None, so callers can surface the failure instead of
                 only logging it.
 
+        Decodes a SentimentVerdict from the LLM via argus.structured_output.decode
+        with repair disabled: a failed decode degrades this ticker rather than
+        re-prompting with the failure appended, since repair would roughly double
+        token spend for a ticker whose measured completion peak already sits close
+        to its budget, against a governor that is the binding constraint on the
+        whole system (see #71).
+
         Returns:
-            A validated SentimentSignal, or None if all retry attempts fail.
+            A validated SentimentSignal, or None if decoding ultimately fails.
         """
         if not self.cache.is_stale(ticker):
             cached = self.cache.get(ticker)
@@ -452,69 +473,47 @@ class SentimentAgent:
 
         prompt = _build_synthesis_prompt(ticker, metrics)
 
-        for attempt in range(3):
-            try:
-                raw = self.llm_client.complete(SYSTEM_PROMPT, prompt).strip()
-                if raw.startswith("```"):
-                    parts = raw.split("```")
-                    if len(parts) >= 3:
-                        raw = parts[1]
-                    else:
-                        raw = parts[-1]
-                    raw = raw.strip()
-                    if raw.startswith("json"):
-                        raw = raw[4:].strip()
+        try:
+            verdict = decode(self.llm_client, SYSTEM_PROMPT, prompt, SentimentVerdict, repair=False)
+        except StructuredOutputError as e:
+            logger.warning("[Sentiment] Decode failed for %s: %s", ticker, e)
+            if errors is not None:
+                errors.append(f"sentiment_analysis[{ticker}]: {e}")
+            return None
+        except (RateLimitExceeded, UnregisteredModel) as e:
+            # The governor already exhausted its own bounded wait before raising
+            # either of these — degrade this ticker immediately rather than
+            # retrying into the same wall.
+            logger.warning("[Sentiment] Governor rejected call for %s: %s", ticker, e)
+            if errors is not None:
+                errors.append(f"sentiment_analysis[{ticker}]: rate limited: {e}")
+            return None
+        except Exception as e:
+            logger.error("[Sentiment] API error for %s: %s", ticker, e)
+            if errors is not None:
+                errors.append(f"sentiment_analysis[{ticker}]: API error: {e}")
+            return None
 
-                data = json.loads(raw)
-
-                signal = SentimentSignal(
-                    ticker=ticker,
-                    # A failed fetch's 0.0 is indistinguishable from a real neutral
-                    # read; persist None rather than fabricate a measured score
-                    finbert_net_score=metrics["net_finbert_score"] if news_available else None,
-                    pct_positive=metrics["pct_positive"],
-                    pct_negative=metrics["pct_negative"],
-                    news_volume_7d=metrics["news_volume_7d"],
-                    news_scored_count=metrics["news_scored_count"],
-                    news_data_available=metrics["news_data_available"],
-                    upcoming_catalyst=metrics["upcoming_catalyst"],
-                    signal=data["signal"],
-                    conviction=float(data["conviction"]),
-                    sentiment_decay_risk=data.get("sentiment_decay_risk", "MEDIUM"),
-                    reasoning=data.get("reasoning", "")[:400],
-                    timestamp=datetime.now(),  # noqa: DTZ005
-                    api_calls_used=1,
-                )
-                self.cache.set(ticker, signal)
-                return signal
-
-            except (json.JSONDecodeError, ValidationError) as e:
-                logger.warning("[Sentiment] Attempt %d parse error: %s", attempt + 1, e)
-                if attempt == 2:
-                    if errors is not None:
-                        errors.append(
-                            f"sentiment_analysis[{ticker}]: parse error after 3 attempts: {e}"
-                        )
-                    return None
-                time.sleep(2**attempt)
-            except (RateLimitExceeded, UnregisteredModel) as e:
-                # The governor already exhausted its own bounded wait before raising
-                # either of these — retrying here would just re-run into the same
-                # wall, not recover from it. Degrade this ticker immediately instead
-                # of burning three more rounds of governor waits.
-                logger.warning("[Sentiment] Governor rejected call for %s: %s", ticker, e)
-                if errors is not None:
-                    errors.append(f"sentiment_analysis[{ticker}]: rate limited: {e}")
-                return None
-            except Exception as e:
-                logger.warning("[Sentiment] Attempt %d failed: %s", attempt + 1, e)
-                if attempt == 2:
-                    if errors is not None:
-                        errors.append(f"sentiment_analysis[{ticker}]: failed after 3 attempts: {e}")
-                    return None
-                time.sleep(2**attempt)
-
-        return None
+        signal = SentimentSignal(
+            ticker=ticker,
+            # A failed fetch's 0.0 is indistinguishable from a real neutral
+            # read; persist None rather than fabricate a measured score
+            finbert_net_score=metrics["net_finbert_score"] if news_available else None,
+            pct_positive=metrics["pct_positive"],
+            pct_negative=metrics["pct_negative"],
+            news_volume_7d=metrics["news_volume_7d"],
+            news_scored_count=metrics["news_scored_count"],
+            news_data_available=metrics["news_data_available"],
+            upcoming_catalyst=metrics["upcoming_catalyst"],
+            signal=verdict.signal,
+            conviction=verdict.conviction,
+            sentiment_decay_risk=verdict.sentiment_decay_risk,
+            reasoning=verdict.reasoning[:400],
+            timestamp=datetime.now(),  # noqa: DTZ005
+            api_calls_used=1,
+        )
+        self.cache.set(ticker, signal)
+        return signal
 
     def batch_analyze(self, tickers: list[str]) -> tuple[dict[str, SentimentSignal], list[str]]:
         """Generates SentimentSignals sequentially for a list of tickers.

--- a/argus/params.py
+++ b/argus/params.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field, fields
 from enum import Enum
 from typing import Any
 
-PARAMS_VERSION = 15
+PARAMS_VERSION = 16
 
 
 class Provenance(str, Enum):
@@ -370,6 +370,38 @@ class MemoryParams:
     )
 
 
+@dataclass(frozen=True)
+class StructuredOutputParams:
+    """Retry/back-off controls for the structured-output decoder (structured_output.py).
+
+    One attempt budget replacing the three per-agent copies of ``range(3)`` +
+    ``time.sleep(2**attempt)`` this decoder consolidates (fundamental.py,
+    sentiment.py, portfolio.py) — none of those three had any basis beyond
+    "seemed reasonable" either, so the value carries forward unchanged rather
+    than being re-guessed.
+    """
+
+    max_attempts: int = p(
+        3,
+        Provenance.ARBITRARY,
+        "matches the per-agent retry loops this decoder replaces; not evaluated "
+        "against alternatives",
+    )
+    backoff_base_seconds: float = p(
+        1.0,
+        Provenance.ARBITRARY,
+        "matches the per-agent time.sleep(2**attempt) back-off this decoder "
+        "replaces; not evaluated against alternatives",
+    )
+    backoff_max_seconds: float = p(
+        30.0,
+        Provenance.ARBITRARY,
+        "ceiling on the exponential back-off; the per-agent loops this decoder "
+        "replaces had no cap since 3 attempts alone tops out at 4s, kept here as "
+        "a defensive bound if max_attempts is ever raised",
+    )
+
+
 SYSTEM = SystemParams()
 KILL_SWITCH = KillSwitchParams()
 TECHNICAL_INDICATOR_WEIGHTS = TechnicalIndicatorWeights()
@@ -380,6 +412,7 @@ RISK = RiskParams()
 MACRO = MacroParams()
 RECONCILIATION = ReconciliationParams()
 MEMORY = MemoryParams()
+STRUCTURED_OUTPUT = StructuredOutputParams()
 
 _ALL_GROUPS: dict[str, Any] = {
     "SYSTEM": SYSTEM,
@@ -392,6 +425,7 @@ _ALL_GROUPS: dict[str, Any] = {
     "MACRO": MACRO,
     "RECONCILIATION": RECONCILIATION,
     "MEMORY": MEMORY,
+    "STRUCTURED_OUTPUT": STRUCTURED_OUTPUT,
 }
 
 

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -537,6 +537,43 @@ class AggregatedSignal(BaseModel):
     )
 
 
+class ProposedPosition(BaseModel):
+    """A single position as the LLM itself proposes it — advisory, not yet risk-enforced.
+
+    Never carries allocation_usd or a risk-approved stop_loss: the agent computes
+    the former from allocation_pct and overrides the latter with the risk engine's
+    own figure when one exists. See GLOSSARY.md's Proposal entry.
+    """
+
+    ticker: str = Field(..., description="Equity ticker symbol")
+    allocation_pct: float = Field(0.0, description="Proposed target portfolio weight")
+    stop_loss: float | None = Field(None, description="Model's own stop-loss estimate")
+    target_price: float | None = Field(None, description="12-month price target (optional)")
+    thesis: str = Field(..., description="One-sentence position thesis")
+    advisor_note: str | None = Field(
+        None, description="Professional multi-sentence advisory rationale (optional)"
+    )
+    composite_conviction: float = Field(
+        ..., ge=0.0, le=1.0, description="Aggregated conviction across all agents"
+    )
+    time_horizon: str = Field(..., description="Expected holding period, e.g. '30 days'")
+
+
+class PortfolioProposal(BaseModel):
+    """What the LLM itself returns for portfolio allocation — judgement only.
+
+    Advisory until the risk engine has enforced against it: caps, vetoes, and the
+    cash residual are all applied by the agent afterwards, never trusted from this
+    object directly. See GLOSSARY.md's Proposal entry.
+    """
+
+    portfolio: list[ProposedPosition] = Field(default_factory=list)
+    cash_reserve_pct: float = Field(..., description="Model's own residual estimate")
+    rebalance_trigger: str = Field(
+        ..., description="Condition that will next trigger rebalancing, e.g. 'VIX > 35'"
+    )
+
+
 class PositionAllocation(BaseModel):
     """Target allocation weight, pricing levels, and thesis for a single asset."""
 
@@ -684,6 +721,8 @@ __all__ = [
     "SentimentSignal",
     "RiskAssessment",
     "AggregatedSignal",
+    "ProposedPosition",
+    "PortfolioProposal",
     "PositionAllocation",
     "PortfolioAllocation",
     "ARGUSDecision",

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -274,6 +274,28 @@ class TechnicalSignal(BaseModel):
         return _clamp_conviction(v)
 
 
+class FundamentalVerdict(BaseModel):
+    """What the LLM itself returns for a fundamental analysis — judgement only.
+
+    Never carries measured ratios: those come from the market-data provider
+    and are merged in by the agent to build a FundamentalSignal. See
+    GLOSSARY.md's Verdict entry.
+    """
+
+    signal: Signal = Field(..., description="Directional label")
+    conviction: float = Field(..., ge=0.0, le=_CONVICTION_MAX)
+    moat_score: float = Field(
+        ..., ge=0.0, le=10.0, description="Qualitative competitive moat [0, 10]"
+    )
+    reasoning: str = Field(..., description="LLM-generated investment thesis")
+
+    @field_validator("conviction", mode="before")
+    @classmethod
+    def cap_conviction(cls, v: float) -> float:
+        """Silently clamps conviction to the 0.95 maximum."""
+        return _clamp_conviction(v)
+
+
 class FundamentalSignal(BaseModel):
     """Corporate fundamental metrics and qualitative moat ratings for a target asset."""
 
@@ -635,6 +657,7 @@ __all__ = [
     "missing_session_state_keys",
     "MacroContext",
     "TechnicalSignal",
+    "FundamentalVerdict",
     "FundamentalSignal",
     "SentimentSignal",
     "RiskAssessment",

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -335,6 +335,27 @@ class FundamentalSignal(BaseModel):
         return _clamp_conviction(v)
 
 
+class SentimentVerdict(BaseModel):
+    """What the LLM itself returns for a sentiment synthesis — judgement only.
+
+    Never carries the FinBERT metrics: those are computed locally and merged
+    in by the agent to build a SentimentSignal. See GLOSSARY.md's Verdict entry.
+    """
+
+    signal: Signal = Field(..., description="Directional label")
+    conviction: float = Field(..., ge=0.0, le=_CONVICTION_MAX)
+    sentiment_decay_risk: Literal["LOW", "MEDIUM", "HIGH"] = Field(
+        ..., description="Estimated speed at which the sentiment signal will decay"
+    )
+    reasoning: str = Field(..., description="LLM rationale for the signal")
+
+    @field_validator("conviction", mode="before")
+    @classmethod
+    def cap_conviction(cls, v: float) -> float:
+        """Silently clamps conviction to the 0.95 maximum."""
+        return _clamp_conviction(v)
+
+
 class SentimentSignal(BaseModel):
     """News sentiment features with associated signal conviction scores."""
 
@@ -659,6 +680,7 @@ __all__ = [
     "TechnicalSignal",
     "FundamentalVerdict",
     "FundamentalSignal",
+    "SentimentVerdict",
     "SentimentSignal",
     "RiskAssessment",
     "AggregatedSignal",

--- a/argus/seams.py
+++ b/argus/seams.py
@@ -11,8 +11,10 @@ Each boundary gets one Protocol and two implementations:
     argus/data/fetchers.py, unchanged behavior) / `FixtureMarketDataProvider`
     (serves pre-captured JSON from tests/fixtures/market_data/).
   - `LLMClient` / `GroqLLMClient` (wraps ChatGroq construction + invocation,
-    and is the sole choke point for governor rate-limiting, header-driven
-    limit observation, and retry/back-off — see its own docstring)
+    and is the sole choke point for governor rate-limiting and header-driven
+    limit observation; classifies which failures are worth retrying and
+    raises RetryableTransportError for those, but the retry loop itself
+    lives in argus/structured_output.py's decode() — see its own docstring)
     / `FixtureLLMClient` (serves pre-captured response text from
     tests/fixtures/llm_responses/, never touches the governor or the network).
 
@@ -25,8 +27,6 @@ from __future__ import annotations
 
 import json
 import logging
-import random
-import time
 from pathlib import Path
 from typing import Any, Optional, Protocol
 
@@ -188,11 +188,41 @@ class LLMClient(Protocol):
     Callers keep owning response parsing (JSON extraction, markdown-fence
     stripping, schema validation) — this seam only replaces "how do I get an
     LLM to answer this prompt," not "what does the answer mean."
+
+    An implementation makes exactly one invocation per call — it does not
+    loop. A transient failure worth a caller-side retry (see
+    argus/structured_output.py's decode()) must be raised as
+    RetryableTransportError; anything else propagates as-is and is treated
+    as terminal.
     """
 
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         """Sends a system + user prompt to the LLM and returns the raw response text."""
         ...
+
+
+class RetryableTransportError(Exception):
+    """Signals that an LLMClient.complete() attempt failed transiently and is worth retrying.
+
+    Raised by an LLMClient implementation, not by callers. A caller with its
+    own attempt budget (argus/structured_output.py's decode()) catches this
+    to retry the call, without needing to know which provider-specific
+    exceptions are retryable — that classification stays with the adapter
+    that raises this.
+
+    Args:
+        cause: The underlying transport exception.
+        retry_after: Seconds the provider explicitly said to wait before
+            retrying (e.g. a 429's Retry-After header), or None if the
+            provider gave no hint and the caller should decide its own
+            back-off.
+    """
+
+    def __init__(self, cause: Exception, retry_after: Optional[float] = None) -> None:
+        """Wraps the underlying transport exception with an optional retry hint."""
+        self.cause = cause
+        self.retry_after = retry_after
+        super().__init__(str(cause))
 
 
 # Retryable: transient conditions where a second attempt might succeed.
@@ -210,42 +240,37 @@ _TERMINAL_GROQ_ERRORS = (
     groq.NotFoundError,
 )
 
-_MAX_COMPLETE_ATTEMPTS = 3
-_BASE_BACKOFF_SECONDS = 1.0
-_MAX_BACKOFF_SECONDS = 30.0
 
+def _groq_retry_delay(exc: Exception) -> Optional[float]:
+    """Reads the provider's own retry hint off a retryable Groq error, if it gave one.
 
-def _groq_retry_delay(exc: Exception, attempt: int) -> float:
-    """Computes the delay before retrying a failed Groq call.
-
-    A RateLimitError's Retry-After header is honored verbatim when present —
-    Groq is telling us exactly how long its own limit takes to clear. Anything
-    else backs off exponentially with full jitter, capped at 30s.
+    Only a RateLimitError carries an explicit hint (its Retry-After header,
+    honored verbatim since Groq is telling us exactly how long its own limit
+    takes to clear). Every other retryable error has no such hint, so the
+    caller decides its own back-off. Header extraction itself is shared with
+    argus/data/fetchers.py's retry loop rather than reimplemented here.
 
     Args:
         exc: The exception the failed attempt raised.
-        attempt: Zero-based attempt number that just failed.
 
     Returns:
-        Seconds to sleep before the next attempt.
+        Seconds to wait before retrying per the provider's hint, or None.
     """
     if isinstance(exc, groq.RateLimitError):
-        retry_after = exc.response.headers.get("retry-after")
-        if retry_after is not None:
-            try:
-                return float(retry_after)
-            except ValueError:
-                pass
-    return random.uniform(0.0, min(_MAX_BACKOFF_SECONDS, _BASE_BACKOFF_SECONDS * 2**attempt))
+        return fetchers._retry_after_seconds(exc)
+    return None
 
 
 class GroqLLMClient:
     """Wraps a ChatGroq model+params combination. One instance per (model, temperature, max_tokens).
 
     The sole choke point for governance: token estimation, the governor's pre-flight
-    wait, rate-limit-header observation, and retry/back-off all live here rather than
-    duplicated across the three agents that construct this client, so none of them can
-    bypass it by accident.
+    wait, and rate-limit-header observation all live here rather than duplicated
+    across the three agents that construct this client, so none of them can bypass
+    it by accident. It also classifies which Groq failures are worth retrying and
+    supplies the provider's own retry hint, but performs no retry loop itself — see
+    RetryableTransportError and argus/structured_output.py's decode(), which owns
+    the retry loop this client's failures feed into.
     """
 
     def __init__(self, model: str, temperature: float, max_tokens: int, api_key: str) -> None:
@@ -291,77 +316,60 @@ class GroqLLMClient:
         governor.observe_headers(self._model, response.headers)
 
     def complete(self, system_prompt: str, user_prompt: str) -> str:
-        """Invokes the Groq model and returns its response as plain text.
+        """Invokes the Groq model once and returns its response as plain text.
 
-        Waits for governor capacity, then retries transient failures with
-        back-off, honoring Retry-After on 429s. Terminal errors (bad key, bad
-        request) propagate immediately without retrying. Any failure that
-        escapes this method — terminal or retries-exhausted — releases the
-        governor's pre-flight reservation first, since no tokens were ever
-        actually spent (see RateLimitGovernor.release_reservation).
+        Waits for governor capacity, then makes a single invocation — a
+        caller with its own attempt budget (argus/structured_output.py's
+        decode()) is responsible for retrying. A retryable failure (per
+        _RETRYABLE_GROQ_ERRORS) is wrapped in RetryableTransportError,
+        carrying the provider's retry hint if it gave one; a terminal
+        failure (bad key, bad request) propagates as-is. Either way the
+        governor's pre-flight reservation is released first, since no
+        tokens were ever actually spent (see
+        RateLimitGovernor.release_reservation).
 
         Returns:
             The response text, flattened from a content-block list if needed.
 
         Raises:
-            The underlying groq/langchain exception if every attempt fails, or
-            immediately for a terminal (non-retryable) error.
+            RetryableTransportError: If the call fails with a transient error.
+            The underlying groq/langchain exception: For a terminal error.
         """
         estimated_tokens = estimate_tokens(system_prompt, user_prompt, self._max_tokens)
         governor.wait_if_needed(self._model, estimated_tokens)
 
         try:
-            return self._complete_with_retries(system_prompt, user_prompt, estimated_tokens)
+            response = self._llm.invoke(
+                [SystemMessage(content=system_prompt), HumanMessage(content=user_prompt)]
+            )
+        except _TERMINAL_GROQ_ERRORS:
+            governor.release_reservation(self._model, estimated_tokens)
+            raise
+        except _RETRYABLE_GROQ_ERRORS as e:
+            governor.release_reservation(self._model, estimated_tokens)
+            raise RetryableTransportError(e, retry_after=_groq_retry_delay(e)) from e
         except Exception:
             governor.release_reservation(self._model, estimated_tokens)
             raise
 
-    def _complete_with_retries(
-        self, system_prompt: str, user_prompt: str, estimated_tokens: int
-    ) -> str:
-        """Runs the invoke/retry loop assuming the governor has already granted capacity.
+        token_usage = response.response_metadata.get("token_usage") or {}
+        governor.record_usage(
+            self._model,
+            estimated_tokens,
+            token_usage.get("prompt_tokens", 0),
+            token_usage.get("completion_tokens", 0),
+        )
 
-        Args:
-            system_prompt: The system message text.
-            user_prompt: The user message text.
-            estimated_tokens: The pre-flight estimate already reserved with the governor.
-
-        Returns:
-            The response text, flattened from a content-block list if needed.
-        """
-        for attempt in range(_MAX_COMPLETE_ATTEMPTS):
-            try:
-                response = self._llm.invoke(
-                    [SystemMessage(content=system_prompt), HumanMessage(content=user_prompt)]
-                )
-            except _TERMINAL_GROQ_ERRORS:
-                raise
-            except _RETRYABLE_GROQ_ERRORS as e:
-                if attempt == _MAX_COMPLETE_ATTEMPTS - 1:
-                    raise
-                time.sleep(_groq_retry_delay(e, attempt))
-                continue
-
-            token_usage = response.response_metadata.get("token_usage") or {}
-            governor.record_usage(
-                self._model,
-                estimated_tokens,
-                token_usage.get("prompt_tokens", 0),
-                token_usage.get("completion_tokens", 0),
+        raw = response.content
+        if isinstance(raw, list):
+            raw = "".join(
+                item.get("text", "")
+                for item in raw
+                if isinstance(item, dict) and item.get("type") == "text"
             )
-
-            raw = response.content
-            if isinstance(raw, list):
-                raw = "".join(
-                    item.get("text", "")
-                    for item in raw
-                    if isinstance(item, dict) and item.get("type") == "text"
-                )
-            elif not isinstance(raw, str):
-                raw = str(raw)
-            return raw
-
-        raise AssertionError("unreachable: loop always returns or raises")
+        elif not isinstance(raw, str):
+            raw = str(raw)
+        return raw
 
 
 class FixtureLLMClient:

--- a/argus/structured_output.py
+++ b/argus/structured_output.py
@@ -5,8 +5,8 @@ The expand half of the LLM seam refactor (issue #67): one structured-output
 call replacing the three near-identical fence-strip/parse/validate/retry
 blocks in agents/fundamental.py, agents/sentiment.py, and agents/portfolio.py.
 Composed over the existing LLMClient transport port rather than widening it —
-see argus/seams.py's LLMClient docstring. Used by agents/fundamental.py;
-sentiment.py and portfolio.py still carry their own copies pending #71/#72.
+see argus/seams.py's LLMClient docstring. Used by agents/fundamental.py and
+agents/sentiment.py; portfolio.py still carries its own copy pending #72.
 
 Responsibilities:
   - Strip a markdown code fence from a raw LLM response, in any of its four

--- a/argus/structured_output.py
+++ b/argus/structured_output.py
@@ -5,7 +5,8 @@ The expand half of the LLM seam refactor (issue #67): one structured-output
 call replacing the three near-identical fence-strip/parse/validate/retry
 blocks in agents/fundamental.py, agents/sentiment.py, and agents/portfolio.py.
 Composed over the existing LLMClient transport port rather than widening it —
-see argus/seams.py's LLMClient docstring. Not yet used by any agent.
+see argus/seams.py's LLMClient docstring. Used by agents/fundamental.py;
+sentiment.py and portfolio.py still carry their own copies pending #71/#72.
 
 Responsibilities:
   - Strip a markdown code fence from a raw LLM response, in any of its four

--- a/argus/structured_output.py
+++ b/argus/structured_output.py
@@ -1,0 +1,188 @@
+"""
+argus/structured_output.py
+
+The expand half of the LLM seam refactor (issue #67): one structured-output
+call replacing the three near-identical fence-strip/parse/validate/retry
+blocks in agents/fundamental.py, agents/sentiment.py, and agents/portfolio.py.
+Composed over the existing LLMClient transport port rather than widening it —
+see argus/seams.py's LLMClient docstring. Not yet used by any agent.
+
+Responsibilities:
+  - Strip a markdown code fence from a raw LLM response, in any of its four
+    observed shapes (unfenced, fenced, json-tagged, unterminated)
+  - Parse the fence-stripped text as JSON and validate it against a
+    caller-supplied Pydantic schema
+  - Retry invalid-JSON and schema-violating responses up to a declared
+    attempt cap, with exponential back-off between attempts
+  - Optionally re-prompt with the prior failure appended (repair), so the
+    model can correct itself
+  - Raise a typed, stage-tagged error when every attempt is exhausted
+
+Not responsible for:
+  - Sending the request or governing rate limits (argus/seams.py's
+    LLMClient / GroqLLMClient owns transport, and already retries transient
+    network/API errors beneath this call)
+  - Defining what a valid response looks like for any particular agent —
+    callers supply the target schema
+  - Deciding what to do when decoding ultimately fails — callers catch
+    StructuredOutputError and degrade however fits their context
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Optional, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from argus.params import STRUCTURED_OUTPUT
+from argus.seams import LLMClient
+
+logger = logging.getLogger("argus.structured_output")
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class StructuredOutputError(Exception):
+    """Raised when every decode attempt is exhausted, naming which stage kept failing.
+
+    Args:
+        stage: "json_parse" if the response was never valid JSON, or
+            "schema_validation" if it parsed but never matched the target schema.
+        attempts: Number of attempts made before giving up.
+        cause: The last attempt's underlying exception.
+    """
+
+    def __init__(self, stage: str, attempts: int, cause: Exception) -> None:
+        """Builds the error message from stage, attempt count, and underlying cause."""
+        self.stage = stage
+        self.attempts = attempts
+        self.cause = cause
+        super().__init__(f"{stage} failed after {attempts} attempt(s): {cause}")
+
+
+def _strip_markdown_fence(raw: str) -> str:
+    """Strips a markdown code fence from a raw LLM response, if present.
+
+    Handles four shapes: unfenced text (returned unchanged), a closed fence
+    (```...```), a json-tagged fence (```json...```), and an unterminated
+    fence (a single opening marker with no closing one, which truncated
+    generations have produced in practice). Only the leading and trailing
+    fence markers are stripped, not every ``` occurrence in the text — a
+    JSON string value that itself quotes a fenced snippet (e.g. a
+    "reasoning" field citing code) must survive intact.
+
+    Args:
+        raw: The LLM's raw response text.
+
+    Returns:
+        The response text with any surrounding fence markers removed.
+    """
+    raw = raw.strip()
+    if not raw.startswith("```"):
+        return raw
+    raw = raw[3:]
+    if raw.startswith("json"):
+        raw = raw[4:]
+    raw = raw.strip()
+    if raw.endswith("```"):
+        raw = raw[:-3]
+    return raw.strip()
+
+
+def _repair_prompt(user_prompt: str, last_error: str) -> str:
+    """Appends the prior attempt's failure to a prompt so the model can correct itself.
+
+    Args:
+        user_prompt: The original user prompt.
+        last_error: ``str(exception)`` from the previous attempt's failure.
+
+    Returns:
+        The user prompt with a correction request appended.
+    """
+    return (
+        f"{user_prompt}\n\n"
+        f"Your previous response was invalid: {last_error}\n"
+        "Return a corrected response satisfying the schema above."
+    )
+
+
+def decode(
+    llm_client: LLMClient,
+    system_prompt: str,
+    user_prompt: str,
+    schema: type[T],
+    *,
+    repair: bool,
+) -> T:
+    """Sends a prompt and decodes the response into a validated instance of ``schema``.
+
+    Owns everything between "send the prompt" and "hand back a usable
+    object": strips a markdown fence, parses JSON, and validates against
+    ``schema``. Invalid JSON and schema-violating JSON are each retried up
+    to ``STRUCTURED_OUTPUT.max_attempts``, backing off exponentially between
+    attempts. With ``repair=True``, a failed attempt's error is appended to
+    the next attempt's prompt; with ``repair=False``, the same prompt is
+    re-sent unchanged.
+
+    ``llm_client.complete()`` may itself raise — a transport-level error
+    (GroqLLMClient already retries transient ones beneath this call) or the
+    governor's RateLimitExceeded/UnregisteredModel. None of those are caught
+    here, so they propagate on the first occurrence: the governor has
+    already exhausted its own bounded wait before raising either of its
+    exceptions, and a second retry loop above it would only re-run into the
+    same wall.
+
+    Args:
+        llm_client: Transport to send the prompt over.
+        system_prompt: The system message text.
+        user_prompt: The user message text.
+        schema: Pydantic model class the decoded response must validate against.
+        repair: Whether to append the prior failure to the next attempt's prompt.
+
+    Returns:
+        A validated instance of ``schema``.
+
+    Raises:
+        StructuredOutputError: If every attempt fails to produce valid JSON
+            (stage="json_parse") or schema-valid data (stage="schema_validation").
+    """
+    last_error: Optional[Exception] = None
+    stage = "json_parse"
+
+    for attempt in range(STRUCTURED_OUTPUT.max_attempts):
+        prompt = user_prompt
+        if repair and last_error is not None:
+            prompt = _repair_prompt(user_prompt, str(last_error))
+
+        raw = llm_client.complete(system_prompt, prompt)
+        stripped = _strip_markdown_fence(raw)
+
+        try:
+            data = json.loads(stripped)
+        except json.JSONDecodeError as e:
+            last_error = e
+            stage = "json_parse"
+        else:
+            try:
+                return schema.model_validate(data)
+            except ValidationError as e:
+                last_error = e
+                stage = "schema_validation"
+
+        if attempt == STRUCTURED_OUTPUT.max_attempts - 1:
+            assert last_error is not None
+            raise StructuredOutputError(stage, attempt + 1, last_error)
+
+        delay = min(
+            STRUCTURED_OUTPUT.backoff_max_seconds,
+            STRUCTURED_OUTPUT.backoff_base_seconds * 2**attempt,
+        )
+        logger.warning(
+            "[StructuredOutput] Attempt %d %s failed: %s", attempt + 1, stage, last_error
+        )
+        time.sleep(delay)
+
+    raise AssertionError("unreachable: loop always returns or raises")

--- a/argus/structured_output.py
+++ b/argus/structured_output.py
@@ -5,8 +5,8 @@ The expand half of the LLM seam refactor (issue #67): one structured-output
 call replacing the three near-identical fence-strip/parse/validate/retry
 blocks in agents/fundamental.py, agents/sentiment.py, and agents/portfolio.py.
 Composed over the existing LLMClient transport port rather than widening it —
-see argus/seams.py's LLMClient docstring. Used by agents/fundamental.py and
-agents/sentiment.py; portfolio.py still carries its own copy pending #72.
+see argus/seams.py's LLMClient docstring. Used by agents/fundamental.py,
+agents/sentiment.py, and agents/portfolio.py.
 
 Responsibilities:
   - Strip a markdown code fence from a raw LLM response, in any of its four

--- a/argus/structured_output.py
+++ b/argus/structured_output.py
@@ -15,14 +15,20 @@ Responsibilities:
     caller-supplied Pydantic schema
   - Retry invalid-JSON and schema-violating responses up to a declared
     attempt cap, with exponential back-off between attempts
+  - Retry a transport-level RetryableTransportError from the same attempt
+    budget, honoring the provider's own retry hint when the adapter
+    supplies one
   - Optionally re-prompt with the prior failure appended (repair), so the
     model can correct itself
   - Raise a typed, stage-tagged error when every attempt is exhausted
 
 Not responsible for:
   - Sending the request or governing rate limits (argus/seams.py's
-    LLMClient / GroqLLMClient owns transport, and already retries transient
-    network/API errors beneath this call)
+    LLMClient owns transport). An adapter makes one invocation per call and
+    performs no retry loop of its own — this module is the only place that
+    loops
+  - Classifying which transport failures are worth retrying versus terminal
+    — that stays with the LLMClient implementation (e.g. GroqLLMClient)
   - Defining what a valid response looks like for any particular agent —
     callers supply the target schema
   - Deciding what to do when decoding ultimately fails — callers catch
@@ -33,13 +39,14 @@ from __future__ import annotations
 
 import json
 import logging
+import random
 import time
 from typing import Optional, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
 from argus.params import STRUCTURED_OUTPUT
-from argus.seams import LLMClient
+from argus.seams import LLMClient, RetryableTransportError
 
 logger = logging.getLogger("argus.structured_output")
 
@@ -50,8 +57,10 @@ class StructuredOutputError(Exception):
     """Raised when every decode attempt is exhausted, naming which stage kept failing.
 
     Args:
-        stage: "json_parse" if the response was never valid JSON, or
-            "schema_validation" if it parsed but never matched the target schema.
+        stage: "json_parse" if the response was never valid JSON,
+            "schema_validation" if it parsed but never matched the target
+            schema, or "transport" if the LLMClient call itself kept failing
+            transiently.
         attempts: Number of attempts made before giving up.
         cause: The last attempt's underlying exception.
     """
@@ -122,19 +131,26 @@ def decode(
 
     Owns everything between "send the prompt" and "hand back a usable
     object": strips a markdown fence, parses JSON, and validates against
-    ``schema``. Invalid JSON and schema-violating JSON are each retried up
-    to ``STRUCTURED_OUTPUT.max_attempts``, backing off exponentially between
-    attempts. With ``repair=True``, a failed attempt's error is appended to
-    the next attempt's prompt; with ``repair=False``, the same prompt is
-    re-sent unchanged.
+    ``schema``. Invalid JSON, schema-violating JSON, and a retryable
+    transport failure are each retried up to ``STRUCTURED_OUTPUT.max_attempts``,
+    backing off exponentially between attempts (full-jitter for an unhinted
+    transport retry, to avoid the parallel agents thundering-herding a
+    shared provider outage; deterministic otherwise). With ``repair=True``,
+    the most recent json_parse/schema_validation failure's error is kept
+    appended to the prompt across attempts, including one interrupted by a
+    transport retry in between — a transport hiccup carries no content
+    feedback of its own, so it must not discard repair context that was
+    about to be sent.
 
-    ``llm_client.complete()`` may itself raise — a transport-level error
-    (GroqLLMClient already retries transient ones beneath this call) or the
-    governor's RateLimitExceeded/UnregisteredModel. None of those are caught
-    here, so they propagate on the first occurrence: the governor has
-    already exhausted its own bounded wait before raising either of its
-    exceptions, and a second retry loop above it would only re-run into the
-    same wall.
+    ``llm_client.complete()`` may itself raise. A RetryableTransportError is
+    retried from this same attempt budget — honoring its ``retry_after``
+    hint when the adapter supplied one, else the same exponential back-off
+    used for invalid-JSON/schema-violation retries. Anything else (a
+    terminal transport error, or the governor's
+    RateLimitExceeded/UnregisteredModel) propagates immediately: the
+    governor has already exhausted its own bounded wait before raising
+    either of its exceptions, and a terminal transport error would only
+    fail identically on a second attempt.
 
     Args:
         llm_client: Transport to send the prompt over.
@@ -148,39 +164,61 @@ def decode(
 
     Raises:
         StructuredOutputError: If every attempt fails to produce valid JSON
-            (stage="json_parse") or schema-valid data (stage="schema_validation").
+            (stage="json_parse"), schema-valid data (stage="schema_validation"),
+            or a successful transport call (stage="transport").
     """
     last_error: Optional[Exception] = None
+    last_content_error: Optional[Exception] = None
     stage = "json_parse"
+    retry_after: Optional[float] = None
 
     for attempt in range(STRUCTURED_OUTPUT.max_attempts):
         prompt = user_prompt
-        if repair and last_error is not None:
-            prompt = _repair_prompt(user_prompt, str(last_error))
-
-        raw = llm_client.complete(system_prompt, prompt)
-        stripped = _strip_markdown_fence(raw)
+        if repair and last_content_error is not None:
+            prompt = _repair_prompt(user_prompt, str(last_content_error))
 
         try:
-            data = json.loads(stripped)
-        except json.JSONDecodeError as e:
+            raw = llm_client.complete(system_prompt, prompt)
+        except RetryableTransportError as e:
             last_error = e
-            stage = "json_parse"
+            stage = "transport"
+            retry_after = e.retry_after
         else:
+            retry_after = None
+            stripped = _strip_markdown_fence(raw)
             try:
-                return schema.model_validate(data)
-            except ValidationError as e:
+                data = json.loads(stripped)
+            except json.JSONDecodeError as e:
                 last_error = e
-                stage = "schema_validation"
+                last_content_error = e
+                stage = "json_parse"
+            else:
+                try:
+                    return schema.model_validate(data)
+                except ValidationError as e:
+                    last_error = e
+                    last_content_error = e
+                    stage = "schema_validation"
 
         if attempt == STRUCTURED_OUTPUT.max_attempts - 1:
             assert last_error is not None
             raise StructuredOutputError(stage, attempt + 1, last_error)
 
-        delay = min(
-            STRUCTURED_OUTPUT.backoff_max_seconds,
-            STRUCTURED_OUTPUT.backoff_base_seconds * 2**attempt,
-        )
+        if retry_after is not None:
+            delay = retry_after
+        elif stage == "transport":
+            delay = random.uniform(
+                0.0,
+                min(
+                    STRUCTURED_OUTPUT.backoff_max_seconds,
+                    STRUCTURED_OUTPUT.backoff_base_seconds * 2**attempt,
+                ),
+            )
+        else:
+            delay = min(
+                STRUCTURED_OUTPUT.backoff_max_seconds,
+                STRUCTURED_OUTPUT.backoff_base_seconds * 2**attempt,
+            )
         logger.warning(
             "[StructuredOutput] Attempt %d %s failed: %s", attempt + 1, stage, last_error
         )

--- a/tests/fixtures/llm_responses/portfolio.json
+++ b/tests/fixtures/llm_responses/portfolio.json
@@ -44,6 +44,5 @@
     }
   ],
   "cash_reserve_pct": 0.575,
-  "expected_sharpe": null,
   "rebalance_trigger": "MONTHLY"
 }

--- a/tests/test_fundamental.py
+++ b/tests/test_fundamental.py
@@ -16,7 +16,7 @@ from argus.agents.fundamental import (
     build_compact_prompt,
 )
 from argus.orchestration.governor import BOOTSTRAP_LIMITS, RateLimitGovernor
-from argus.schemas.signals import FundamentalSignal, Signal
+from argus.schemas.signals import FundamentalSignal, FundamentalVerdict, Signal
 from argus.seams import FixtureLLMClient
 
 
@@ -40,6 +40,15 @@ class _RecordingLLMClient:
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         self.last_user_prompt = user_prompt
         return self._response_text
+
+def test_prompt_declared_fields_match_the_verdict_schema():
+    """The prompt's declared output fields and FundamentalVerdict's fields must never drift apart.
+
+    The prompt used to also declare six measured ratios the agent unconditionally
+    overwrote after parsing; this asserts none of those field names sneak back in.
+    """
+    assert set(fundamental_module._VERDICT_FIELD_DESCRIPTIONS) == set(FundamentalVerdict.model_fields)
+
 
 def test_anonymize_ticker():
     """Anonymized IDs are deterministic per (ticker, seed) and vary if either input changes."""
@@ -222,6 +231,52 @@ def test_analyze_retries_with_the_prior_validation_error_in_the_prompt():
     assert signal is not None
     assert len(prompts) == 2
     assert "Your previous response was invalid" in prompts[1]
+
+
+def test_analyze_degrades_the_ticker_on_governor_exhaustion_without_retrying():
+    """A RateLimitExceeded from the LLM client fails that ticker immediately, once, into errors."""
+    market_data = _StubMarketData({"sector": "Technology", "industry": "Consumer Electronics"})
+
+    class _RateLimitedLLMClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete(self, system_prompt: str, user_prompt: str) -> str:
+            self.calls += 1
+            raise fundamental_module.RateLimitExceeded("gpt-oss-120b quota exhausted")
+
+    llm = _RateLimitedLLMClient()
+    agent = FundamentalAgent(llm_client=llm, market_data=market_data)
+
+    errors: list[str] = []
+    signal = agent.analyze("AAPL", errors=errors)
+
+    assert signal is None
+    assert llm.calls == 1
+    assert len(errors) == 1
+    assert "rate limited" in errors[0]
+
+
+def test_analyze_degrades_the_ticker_when_measured_data_fails_signal_validation():
+    """A schema violation in the merged-in measured data (not the verdict) must not crash the batch."""
+    market_data = _StubMarketData(
+        {
+            "sector": "Technology",
+            "industry": "Consumer Electronics",
+            "debt_to_equity": -1.5,  # FundamentalSignal requires ge=0.0
+        }
+    )
+    llm = _RecordingLLMClient(
+        json.dumps({"signal": "NEUTRAL", "conviction": 0.5, "moat_score": 5, "reasoning": "r"})
+    )
+    agent = FundamentalAgent(llm_client=llm, market_data=market_data)
+
+    errors: list[str] = []
+    signal = agent.analyze("AAPL", errors=errors)
+
+    assert signal is None
+    assert len(errors) == 1
+    assert "failed validation" in errors[0]
 
 
 def test_analyze_does_not_skip_every_ticker_at_a_low_configured_rpm(monkeypatch):

--- a/tests/test_portfolio_enforcement.py
+++ b/tests/test_portfolio_enforcement.py
@@ -6,17 +6,28 @@ verdicts and caps in code, not merely display them in the prompt. Reproduces
 the audit's finding that an over-cap allocation, a VETO'd ticker, and a
 fabricated ticker all validated cleanly.
 
-Also covers PA-6: when all 3 retry attempts fail, allocate() must say which
-of its three stages (LLM call, JSON parse, schema validation) was failing,
+Also covers PA-6: when the structured-output decoder exhausts its retries,
+allocate() must say which stage was failing (JSON parse or schema validation),
 not a single generic message regardless of cause.
 """
 
 import json
 from datetime import datetime
 
+import pytest
+
+import argus.agents.portfolio as portfolio_module
 from argus.agents.portfolio import PortfolioManagerAgent
+from argus.orchestration.governor import RateLimitExceeded
 from argus.params import PORTFOLIO, SYSTEM
-from argus.schemas.signals import PortfolioAllocation, PositionAllocation, RiskAssessment, RiskVerdict
+from argus.schemas.signals import (
+    PortfolioAllocation,
+    PortfolioProposal,
+    PositionAllocation,
+    ProposedPosition,
+    RiskAssessment,
+    RiskVerdict,
+)
 from argus.seams import FixtureLLMClient
 
 TIMESTAMP = datetime(2026, 1, 1)
@@ -36,6 +47,59 @@ class _CapturingLLMClient:
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         self.last_prompt = user_prompt
         return json.dumps(self._response_json)
+
+
+def test_prompt_declared_fields_match_the_proposal_schema():
+    """The prompt's declared output fields and the proposal schemas' fields must never drift apart."""
+    assert set(portfolio_module._POSITION_FIELD_DESCRIPTIONS) == set(ProposedPosition.model_fields)
+    assert set(portfolio_module._PROPOSAL_FIELD_DESCRIPTIONS) == (
+        set(PortfolioProposal.model_fields) - {"portfolio"}
+    )
+
+
+def test_allocate_reraises_on_governor_exhaustion_without_retrying():
+    """A RateLimitExceeded from the LLM client propagates immediately, unlike fundamental/sentiment.
+
+    There is no per-ticker fallback for a whole-portfolio call: a session either
+    produces the entire allocation or none of it, so the caller needs the
+    rate-limit signal itself rather than a swallowed None.
+    """
+
+    class _RateLimitedLLMClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete(self, system_prompt: str, user_prompt: str) -> str:
+            self.calls += 1
+            raise RateLimitExceeded("gpt-oss-120b quota exhausted")
+
+    llm = _RateLimitedLLMClient()
+    agent = PortfolioManagerAgent(llm_client=llm)
+
+    with pytest.raises(RateLimitExceeded):
+        agent.allocate(
+            user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
+            all_signals={"AAPL": {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)}},
+            macro=None,
+        )
+
+    assert llm.calls == 1
+
+
+def test_allocate_does_not_repair_a_bad_response(monkeypatch):
+    """Repair stays disabled: an invalid response is not re-prompted with the failure appended."""
+    monkeypatch.setattr("argus.structured_output.time.sleep", lambda *_: None)
+    llm_client = _CapturingLLMClient({"cash_reserve_pct": 0.5})
+
+    agent = PortfolioManagerAgent(llm_client=llm_client)
+    alloc = agent.allocate(
+        user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
+        all_signals={"AAPL": {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)}},
+        macro=None,
+    )
+
+    assert alloc is None
+    assert "Your previous response was invalid" not in llm_client.last_prompt
 
 
 def _risk(verdict: RiskVerdict, approved_weight: float, proposed_weight: float) -> RiskAssessment:
@@ -123,7 +187,7 @@ def test_allocate_enforces_caps_vetoes_and_fabrications_in_code():
 
 def test_allocate_names_the_json_parse_stage_on_exhausted_retries(monkeypatch):
     """A response that never parses as JSON is reported as a json_parse failure, not a generic one."""
-    monkeypatch.setattr("argus.agents.portfolio.time.sleep", lambda *_: None)
+    monkeypatch.setattr("argus.structured_output.time.sleep", lambda *_: None)
     llm_client = FixtureLLMClient({"only": "not valid json"}, key_fn=lambda _prompt: "only")
 
     agent = PortfolioManagerAgent(llm_client=llm_client)
@@ -140,9 +204,9 @@ def test_allocate_names_the_json_parse_stage_on_exhausted_retries(monkeypatch):
 
 
 def test_allocate_names_the_schema_validation_stage_on_exhausted_retries(monkeypatch):
-    """Valid JSON that fails PortfolioAllocation's schema is reported as schema_validation, not json_parse."""
-    monkeypatch.setattr("argus.agents.portfolio.time.sleep", lambda *_: None)
-    # Missing the required "portfolio" list entirely -> model_validate raises, json.loads does not
+    """Valid JSON that fails PortfolioProposal's schema is reported as schema_validation, not json_parse."""
+    monkeypatch.setattr("argus.structured_output.time.sleep", lambda *_: None)
+    # Missing the required "rebalance_trigger" field -> model_validate raises, json.loads does not
     llm_client = FixtureLLMClient(
         {"only": json.dumps({"cash_reserve_pct": "not_a_number"})}, key_fn=lambda _prompt: "only"
     )

--- a/tests/test_seams.py
+++ b/tests/test_seams.py
@@ -17,7 +17,13 @@ import pytest
 from argus.agents.fundamental import FundamentalAgent
 from argus.agents.sentiment import SentimentAgent
 from argus.schemas.signals import FundamentalSignal, SentimentSignal
-from argus.seams import FixtureLLMClient, FixtureMarketDataProvider, GroqLLMClient, _groq_retry_delay
+from argus.seams import (
+    FixtureLLMClient,
+    FixtureMarketDataProvider,
+    GroqLLMClient,
+    RetryableTransportError,
+    _groq_retry_delay,
+)
 
 FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 
@@ -105,17 +111,22 @@ def _synthetic_rate_limit_error(retry_after: str | None) -> groq.RateLimitError:
 
 
 def test_groq_retry_delay_honors_retry_after():
-    """A RateLimitError's Retry-After header is honored verbatim, not re-jittered."""
+    """A RateLimitError's Retry-After header is honored verbatim."""
     exc = _synthetic_rate_limit_error(retry_after="12.5")
-    assert _groq_retry_delay(exc, attempt=0) == 12.5
+    assert _groq_retry_delay(exc) == 12.5
 
 
-def test_groq_retry_delay_falls_back_to_jittered_backoff_without_header():
-    """Without a Retry-After header, delay is jittered exponential back-off capped at 30s."""
+def test_groq_retry_delay_returns_none_without_header():
+    """Without a Retry-After header, the adapter gives no hint — the caller decides its own back-off."""
     exc = _synthetic_rate_limit_error(retry_after=None)
-    for attempt in range(6):
-        delay = _groq_retry_delay(exc, attempt)
-        assert 0.0 <= delay <= 30.0
+    assert _groq_retry_delay(exc) is None
+
+
+def test_groq_retry_delay_returns_none_for_non_rate_limit_errors():
+    """A retryable error other than RateLimitError carries no provider retry hint."""
+    request = httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions")
+    exc = groq.APIConnectionError(request=request)
+    assert _groq_retry_delay(exc) is None
 
 
 def _fake_success_response(prompt_tokens: int = 10, completion_tokens: int = 5):
@@ -162,20 +173,29 @@ def test_groq_llm_client_sets_reasoning_effort_low():
     assert client._llm.reasoning_effort == "low"
 
 
-def test_groq_llm_client_retries_retryable_error_then_succeeds():
-    """A transient APIConnectionError is retried and the eventual success is returned."""
+def test_groq_llm_client_retryable_error_raises_retryable_transport_error():
+    """A transient APIConnectionError becomes RetryableTransportError after a single invocation."""
     client = _client_with_mocked_llm()
     request = httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions")
-    client._llm.invoke.side_effect = [
-        groq.APIConnectionError(request=request),
-        _fake_success_response(),
-    ]
+    exc = groq.APIConnectionError(request=request)
+    client._llm.invoke.side_effect = exc
 
-    with mock.patch("argus.seams.time.sleep"):
-        result = client.complete("system", "user")
+    with pytest.raises(RetryableTransportError) as exc_info:
+        client.complete("system", "user")
 
-    assert result == "synthetic response"
-    assert client._llm.invoke.call_count == 2
+    assert exc_info.value.cause is exc
+    assert client._llm.invoke.call_count == 1
+
+
+def test_groq_llm_client_retryable_error_carries_retry_after_hint():
+    """A RateLimitError's Retry-After header rides along on the RetryableTransportError."""
+    client = _client_with_mocked_llm()
+    client._llm.invoke.side_effect = _synthetic_rate_limit_error(retry_after="12.5")
+
+    with pytest.raises(RetryableTransportError) as exc_info:
+        client.complete("system", "user")
+
+    assert exc_info.value.retry_after == 12.5
 
 
 def test_groq_llm_client_terminal_error_raises_without_retry():
@@ -187,27 +207,10 @@ def test_groq_llm_client_terminal_error_raises_without_retry():
         "bad key", response=response, body=None
     )
 
-    with mock.patch("argus.seams.time.sleep") as mock_sleep:
-        with pytest.raises(groq.AuthenticationError):
-            client.complete("system", "user")
+    with pytest.raises(groq.AuthenticationError):
+        client.complete("system", "user")
 
     assert client._llm.invoke.call_count == 1
-    assert mock_sleep.call_count == 0
-
-
-def test_groq_llm_client_exhausts_retries_and_raises():
-    """A persistently retryable error is retried up to the attempt cap, then propagates."""
-    client = _client_with_mocked_llm()
-    request = httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions")
-    client._llm.invoke.side_effect = groq.APIConnectionError(request=request)
-
-    with mock.patch("argus.seams.time.sleep"):
-        with pytest.raises(groq.APIConnectionError):
-            client.complete("system", "user")
-
-    from argus.seams import _MAX_COMPLETE_ATTEMPTS
-
-    assert client._llm.invoke.call_count == _MAX_COMPLETE_ATTEMPTS
 
 
 def test_groq_llm_client_releases_reservation_on_terminal_error():
@@ -219,9 +222,7 @@ def test_groq_llm_client_releases_reservation_on_terminal_error():
         "bad key", response=response, body=None
     )
 
-    with mock.patch("argus.seams.time.sleep"), mock.patch(
-        "argus.seams.governor.release_reservation"
-    ) as mock_release:
+    with mock.patch("argus.seams.governor.release_reservation") as mock_release:
         with pytest.raises(groq.AuthenticationError):
             client.complete("system", "user")
 
@@ -229,19 +230,18 @@ def test_groq_llm_client_releases_reservation_on_terminal_error():
     assert mock_release.call_args.args[0] == client._model
 
 
-def test_groq_llm_client_releases_reservation_after_exhausting_retries():
-    """Retries-exhausted also releases the reservation instead of leaking it (GOV-1)."""
+def test_groq_llm_client_releases_reservation_on_retryable_error():
+    """A retryable error also releases the reservation instead of leaking it (GOV-1)."""
     client = _client_with_mocked_llm()
     request = httpx.Request("POST", "https://api.groq.com/openai/v1/chat/completions")
     client._llm.invoke.side_effect = groq.APIConnectionError(request=request)
 
-    with mock.patch("argus.seams.time.sleep"), mock.patch(
-        "argus.seams.governor.release_reservation"
-    ) as mock_release:
-        with pytest.raises(groq.APIConnectionError):
+    with mock.patch("argus.seams.governor.release_reservation") as mock_release:
+        with pytest.raises(RetryableTransportError):
             client.complete("system", "user")
 
     mock_release.assert_called_once()
+    assert mock_release.call_args.args[0] == client._model
 
 
 def test_groq_llm_client_success_does_not_release_reservation():

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -5,13 +5,15 @@ Tests for the Sentiment Agent and its pure-Python helpers.
 from datetime import datetime, timedelta
 
 
+import argus.agents.sentiment as sentiment_module
 from argus.agents.sentiment import (
     SentimentAgent,
     aggregate_finbert_scores,
     SentimentDailyCache,
     _check_earnings_calendar,
 )
-from argus.schemas.signals import SentimentSignal, Signal
+from argus.orchestration.governor import RateLimitExceeded
+from argus.schemas.signals import SentimentSignal, SentimentVerdict, Signal
 
 def test_aggregate_finbert_scores_empty():
     """An empty article list returns the neutral, low-confidence default."""
@@ -110,6 +112,54 @@ class _RecordingLLMClient:
     def complete(self, system_prompt, user_prompt):
         self.last_user_prompt = user_prompt
         return self._response_text
+
+
+def test_prompt_declared_fields_match_the_verdict_schema():
+    """The prompt's declared output fields and SentimentVerdict's fields must never drift apart."""
+    assert set(sentiment_module._VERDICT_FIELD_DESCRIPTIONS) == set(SentimentVerdict.model_fields)
+
+
+def test_analyze_degrades_the_ticker_on_governor_exhaustion_without_retrying(monkeypatch):
+    """A RateLimitExceeded from the LLM client fails that ticker immediately, once, into errors."""
+    monkeypatch.setattr("argus.agents.sentiment._check_earnings_calendar", lambda ticker: False)
+
+    market_data = _StubMarketData(news=[])
+
+    class _RateLimitedLLMClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete(self, system_prompt: str, user_prompt: str) -> str:
+            self.calls += 1
+            raise RateLimitExceeded("gpt-oss-20b quota exhausted")
+
+    llm = _RateLimitedLLMClient()
+    agent = SentimentAgent(llm_client=llm, market_data=market_data)
+
+    errors: list[str] = []
+    signal = agent.analyze("AAPL", errors=errors)
+
+    assert signal is None
+    assert llm.calls == 1
+    assert len(errors) == 1
+    assert "rate limited" in errors[0]
+
+
+def test_analyze_degrades_the_ticker_without_repairing_a_bad_response(monkeypatch):
+    """Repair stays disabled: an invalid response is not re-prompted with the failure appended."""
+    monkeypatch.setattr("argus.agents.sentiment._check_earnings_calendar", lambda ticker: False)
+    monkeypatch.setattr("argus.structured_output.time.sleep", lambda s: None)
+
+    market_data = _StubMarketData(news=[])
+    llm = _RecordingLLMClient("not json")
+    agent = SentimentAgent(llm_client=llm, market_data=market_data)
+
+    errors: list[str] = []
+    signal = agent.analyze("AAPL", errors=errors)
+
+    assert signal is None
+    assert len(errors) == 1
+    assert "Your previous response was invalid" not in llm.last_user_prompt
 
 
 def test_analyze_flags_unavailable_news_in_the_llm_prompt(monkeypatch):

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -1,0 +1,251 @@
+"""
+Tests for argus/structured_output.py's decode() — fence-stripping, the
+retry/repair loop, and typed-error reporting. No agent is migrated onto
+this decoder yet (issue #69 is expand-only), so these tests exercise it
+directly against a mocked LLMClient rather than through any agent.
+"""
+
+from unittest import mock
+
+import pytest
+from pydantic import BaseModel
+
+from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
+from argus.params import STRUCTURED_OUTPUT
+from argus.structured_output import StructuredOutputError, _strip_markdown_fence, decode
+
+
+class _Verdict(BaseModel):
+    """Minimal schema for exercising decode() without depending on any agent's schema."""
+
+    signal: str
+    conviction: float
+
+
+def _mock_llm(*raw_responses: str) -> mock.Mock:
+    """Builds a Mock LLMClient whose complete() yields each response in order.
+
+    Args:
+        raw_responses: Raw response text to return on successive calls.
+
+    Returns:
+        A Mock exposing complete(system_prompt, user_prompt) -> str.
+    """
+    client = mock.Mock()
+    client.complete.side_effect = list(raw_responses)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Fence-stripping
+# ---------------------------------------------------------------------------
+
+
+def test_strip_markdown_fence_unfenced_passthrough():
+    """Text with no fence markers is returned unchanged (aside from whitespace)."""
+    assert _strip_markdown_fence('{"signal": "BULLISH"}') == '{"signal": "BULLISH"}'
+
+
+def test_strip_markdown_fence_closed_fence():
+    """A closed, untagged fence has its markers removed."""
+    raw = '```\n{"signal": "BULLISH"}\n```'
+    assert _strip_markdown_fence(raw) == '{"signal": "BULLISH"}'
+
+
+def test_strip_markdown_fence_json_tagged_fence():
+    """A closed, ```json-tagged fence has both the markers and the language tag removed."""
+    raw = '```json\n{"signal": "BULLISH"}\n```'
+    assert _strip_markdown_fence(raw) == '{"signal": "BULLISH"}'
+
+
+def test_strip_markdown_fence_unterminated_fence():
+    """A single opening ```json marker with no closing fence still strips cleanly."""
+    raw = '```json\n{"signal": "BULLISH"}'
+    assert _strip_markdown_fence(raw) == '{"signal": "BULLISH"}'
+
+
+def test_strip_markdown_fence_preserves_embedded_backticks_in_string_values():
+    """A JSON string value quoting its own fenced snippet must survive intact.
+
+    A global split on every ``` occurrence would truncate the payload at the
+    first embedded fence rather than only stripping the outer one.
+    """
+    raw = (
+        '```json\n'
+        '{"signal": "BULLISH", "conviction": 0.8, '
+        '"reasoning": "See ```python\\nprint(1)\\n``` for reference"}\n'
+        '```'
+    )
+    stripped = _strip_markdown_fence(raw)
+    assert stripped == (
+        '{"signal": "BULLISH", "conviction": 0.8, '
+        '"reasoning": "See ```python\\nprint(1)\\n``` for reference"}'
+    )
+    import json
+
+    assert json.loads(stripped)["reasoning"] == "See ```python\nprint(1)\n``` for reference"
+
+
+# ---------------------------------------------------------------------------
+# decode(): success paths
+# ---------------------------------------------------------------------------
+
+
+def test_decode_returns_validated_instance_on_first_attempt():
+    """A well-formed, schema-valid response decodes on the first attempt."""
+    llm = _mock_llm('{"signal": "BULLISH", "conviction": 0.8}')
+
+    result = decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert result == _Verdict(signal="BULLISH", conviction=0.8)
+    assert llm.complete.call_count == 1
+
+
+def test_decode_strips_fence_before_validating():
+    """A fenced response is stripped before JSON parsing, not rejected as invalid."""
+    llm = _mock_llm('```json\n{"signal": "BEARISH", "conviction": 0.5}\n```')
+
+    result = decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert result == _Verdict(signal="BEARISH", conviction=0.5)
+
+
+def test_decode_retries_invalid_json_then_succeeds():
+    """Invalid JSON on the first attempt is retried and a later valid response succeeds."""
+    llm = _mock_llm("not json at all", '{"signal": "NEUTRAL", "conviction": 0.3}')
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        result = decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert result == _Verdict(signal="NEUTRAL", conviction=0.3)
+    assert llm.complete.call_count == 2
+
+
+def test_decode_retries_schema_violation_then_succeeds():
+    """Valid JSON that fails schema validation is retried and a later valid response succeeds."""
+    llm = _mock_llm(
+        '{"signal": "NEUTRAL"}',  # missing required "conviction"
+        '{"signal": "NEUTRAL", "conviction": 0.3}',
+    )
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        result = decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert result == _Verdict(signal="NEUTRAL", conviction=0.3)
+    assert llm.complete.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# decode(): exhausted-attempts failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_decode_exhausts_attempts_on_invalid_json_raises_json_parse_stage():
+    """Persistently invalid JSON is retried up to the attempt cap, then raises stage=json_parse."""
+    llm = _mock_llm(*(["not json"] * STRUCTURED_OUTPUT.max_attempts))
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        with pytest.raises(StructuredOutputError) as exc_info:
+            decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert exc_info.value.stage == "json_parse"
+    assert exc_info.value.attempts == STRUCTURED_OUTPUT.max_attempts
+    assert llm.complete.call_count == STRUCTURED_OUTPUT.max_attempts
+
+
+def test_decode_exhausts_attempts_on_schema_violation_raises_schema_validation_stage():
+    """Persistently schema-invalid JSON is retried up to the cap, then raises stage=schema_validation."""
+    llm = _mock_llm(*(['{"signal": "NEUTRAL"}'] * STRUCTURED_OUTPUT.max_attempts))
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        with pytest.raises(StructuredOutputError) as exc_info:
+            decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert exc_info.value.stage == "schema_validation"
+    assert exc_info.value.attempts == STRUCTURED_OUTPUT.max_attempts
+
+
+# ---------------------------------------------------------------------------
+# decode(): repair flag
+# ---------------------------------------------------------------------------
+
+
+def test_decode_repair_enabled_appends_prior_failure_to_next_prompt():
+    """With repair=True, the retry's prompt carries the previous attempt's error."""
+    llm = _mock_llm("not json", '{"signal": "NEUTRAL", "conviction": 0.3}')
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        decode(llm, "system", "original user prompt", _Verdict, repair=True)
+
+    second_call_user_prompt = llm.complete.call_args_list[1].args[1]
+    assert "original user prompt" in second_call_user_prompt
+    assert "Your previous response was invalid" in second_call_user_prompt
+
+
+def test_decode_repair_disabled_resends_prompt_unchanged():
+    """With repair=False, every attempt sends the exact same, unmodified prompt."""
+    llm = _mock_llm("not json", '{"signal": "NEUTRAL", "conviction": 0.3}')
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        decode(llm, "system", "original user prompt", _Verdict, repair=False)
+
+    first_call_user_prompt = llm.complete.call_args_list[0].args[1]
+    second_call_user_prompt = llm.complete.call_args_list[1].args[1]
+    assert first_call_user_prompt == "original user prompt"
+    assert second_call_user_prompt == "original user prompt"
+
+
+# ---------------------------------------------------------------------------
+# decode(): governor exceptions propagate unretried
+# ---------------------------------------------------------------------------
+
+
+def test_decode_propagates_rate_limit_exceeded_without_retry():
+    """A RateLimitExceeded from the transport propagates immediately, with no retry attempt."""
+    llm = mock.Mock()
+    llm.complete.side_effect = RateLimitExceeded("daily budget exhausted")
+
+    with pytest.raises(RateLimitExceeded):
+        decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert llm.complete.call_count == 1
+
+
+def test_decode_propagates_unregistered_model_without_retry():
+    """An UnregisteredModel from the transport propagates immediately, with no retry attempt."""
+    llm = mock.Mock()
+    llm.complete.side_effect = UnregisteredModel("no rate-limit profile")
+
+    with pytest.raises(UnregisteredModel):
+        decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert llm.complete.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# decode() against real, fixture-captured responses
+# ---------------------------------------------------------------------------
+
+
+def test_decode_against_fundamental_fixture_response():
+    """decode() validates a real, pre-captured LLM response, not just synthetic JSON."""
+    from pathlib import Path
+
+    from argus.seams import FixtureLLMClient
+
+    class _FundamentalVerdict(BaseModel):
+        signal: str
+        conviction: float
+        moat_score: int
+        reasoning: str
+
+    fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "llm_responses"
+    llm = FixtureLLMClient.from_fixture_file(
+        fixtures_dir / "fundamental.json", key_fn=lambda _prompt: "AAPL"
+    )
+
+    result = decode(llm, "system", "AAPL", _FundamentalVerdict, repair=False)
+
+    assert result.signal == "BEARISH"
+    assert result.conviction == 0.75
+    assert result.moat_score == 8

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
 from argus.params import STRUCTURED_OUTPUT
+from argus.seams import RetryableTransportError
 from argus.structured_output import StructuredOutputError, _strip_markdown_fence, decode
 
 
@@ -133,6 +134,111 @@ def test_decode_retries_schema_violation_then_succeeds():
 
     assert result == _Verdict(signal="NEUTRAL", conviction=0.3)
     assert llm.complete.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# decode(): retryable transport failures
+# ---------------------------------------------------------------------------
+
+
+def test_decode_retries_retryable_transport_error_then_succeeds():
+    """A RetryableTransportError from the transport is retried and the eventual success is returned."""
+    llm = mock.Mock()
+    llm.complete.side_effect = [
+        RetryableTransportError(RuntimeError("connection reset")),
+        '{"signal": "NEUTRAL", "conviction": 0.3}',
+    ]
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        result = decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert result == _Verdict(signal="NEUTRAL", conviction=0.3)
+    assert llm.complete.call_count == 2
+
+
+def test_decode_exhausts_attempts_on_retryable_transport_error_raises_transport_stage():
+    """A persistent transport failure costs the declared attempt cap, then raises stage=transport."""
+    llm = mock.Mock()
+    llm.complete.side_effect = [
+        RetryableTransportError(RuntimeError("connection reset"))
+        for _ in range(STRUCTURED_OUTPUT.max_attempts)
+    ]
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        with pytest.raises(StructuredOutputError) as exc_info:
+            decode(llm, "system", "user", _Verdict, repair=False)
+
+    assert exc_info.value.stage == "transport"
+    assert exc_info.value.attempts == STRUCTURED_OUTPUT.max_attempts
+    assert llm.complete.call_count == STRUCTURED_OUTPUT.max_attempts
+
+
+def test_decode_honors_transport_retry_after_hint():
+    """A RetryableTransportError's retry_after hint is used as the sleep delay verbatim."""
+    llm = mock.Mock()
+    llm.complete.side_effect = [
+        RetryableTransportError(RuntimeError("rate limited"), retry_after=7.5),
+        '{"signal": "NEUTRAL", "conviction": 0.3}',
+    ]
+
+    with mock.patch("argus.structured_output.time.sleep") as mock_sleep:
+        decode(llm, "system", "user", _Verdict, repair=False)
+
+    mock_sleep.assert_called_once_with(7.5)
+
+
+def test_decode_transport_retry_without_hint_uses_jittered_backoff():
+    """Without a retry_after hint, a transport retry uses full-jitter back-off, not a fixed delay.
+
+    The adapter's deleted internal loop used full jitter specifically to
+    desynchronize retries across the parallel agents during a shared
+    provider outage; decode() must preserve that for the unhinted case.
+    """
+    llm = mock.Mock()
+    llm.complete.side_effect = [
+        RetryableTransportError(RuntimeError("connection reset")),
+        '{"signal": "NEUTRAL", "conviction": 0.3}',
+    ]
+
+    with mock.patch("argus.structured_output.time.sleep") as mock_sleep:
+        decode(llm, "system", "user", _Verdict, repair=False)
+
+    delay = mock_sleep.call_args.args[0]
+    assert 0.0 <= delay <= STRUCTURED_OUTPUT.backoff_base_seconds
+
+
+def test_decode_transport_retry_preserves_repair_context_from_earlier_content_failure():
+    """A transport hiccup between two content failures does not discard the pending repair text."""
+    llm = mock.Mock()
+    llm.complete.side_effect = [
+        '{"signal": "NEUTRAL"}',  # missing required "conviction" -> schema_validation failure
+        RetryableTransportError(RuntimeError("connection reset")),  # transport hiccup
+        '{"signal": "NEUTRAL"}',  # still missing "conviction" -> exhausts attempts
+    ]
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        with pytest.raises(StructuredOutputError):
+            decode(llm, "system", "original user prompt", _Verdict, repair=True)
+
+    assert llm.complete.call_count == 3
+    third_call_user_prompt = llm.complete.call_args_list[2].args[1]
+    assert "original user prompt" in third_call_user_prompt
+    assert "Your previous response was invalid" in third_call_user_prompt
+
+
+def test_decode_transport_retry_does_not_append_repair_text():
+    """A transport retry resends the original prompt — repair only makes sense for content failures."""
+    llm = mock.Mock()
+    llm.complete.side_effect = [
+        RetryableTransportError(RuntimeError("connection reset")),
+        '{"signal": "NEUTRAL", "conviction": 0.3}',
+    ]
+
+    with mock.patch("argus.structured_output.time.sleep"):
+        decode(llm, "system", "original user prompt", _Verdict, repair=True)
+
+    second_call_user_prompt = llm.complete.call_args_list[1].args[1]
+    assert second_call_user_prompt == "original user prompt"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Continues #74 under a branch name matching its parent issue, since #67's sub-issues (#68-#73) all landed on one branch/PR by design (expand-contract sequencing).
- Adds `argus/structured_output.py`'s `decode()`, consolidating the fence-strip/parse/validate/retry logic duplicated across the fundamental, sentiment, and portfolio agents into one function composed over the existing `LLMClient` transport port (#69).
- Migrates the fundamental, sentiment, and portfolio agents onto `decode()`, each dropping its own retry loop (#70, #71, #72).
- Removes the Groq adapter's own internal retry loop now that every agent goes through the decoder, so it makes a single invocation and signals a retryable failure via a new `RetryableTransportError` for the decoder to retry (#73). Two deliberate behavior changes: worst-case invocations for a persistent transport failure drop from nine to three, and each retry now independently reserves/invokes/records-or-releases governor capacity instead of sharing one reservation.

Closes #67, #68, #69, #70, #71, #72, #73

## Test plan
- [x] `pytest -q` — full suite, 464 passed
- [x] `mypy` / `ruff check` clean
- [x] `/code-review` at each step, including a pass on #73 that caught and fixed two real bugs (repair context lost across an interleaved transport retry; dropped jitter on unhinted transport backoff reintroducing thundering-herd risk across the three parallel agents) and a reuse duplication (retry-hint header parsing)