### PR TITLE
Render the declared output schema from verdict/proposal models

### DIFF
--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -30,6 +30,7 @@ from pydantic import ValidationError
 
 from argus.config import settings
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel, governor
+from argus.schemas.prompting import field_list
 from argus.schemas.signals import FundamentalSignal, FundamentalVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
 from argus.structured_output import StructuredOutputError, decode
@@ -52,17 +53,6 @@ _SECTOR_PE_MEDIANS: dict[str, float] = {
     "Basic Materials": 16.0,
 }
 _DEFAULT_PE_MEDIAN = 20.0
-
-# Field descriptions for the prompt's "Fields required" line, keyed by the
-# same names as FundamentalVerdict's schema — a drift test (test_fundamental.py)
-# asserts the two stay equal, so a schema change that isn't mirrored here fails
-# loudly instead of leaving the prompt asking for fields the model can't supply.
-_VERDICT_FIELD_DESCRIPTIONS: dict[str, str] = {
-    "signal": "signal (string)",
-    "conviction": "conviction (float 0.0–1.0)",
-    "moat_score": "moat_score (int 1–10)",
-    "reasoning": "reasoning (string ≤80 words, no markdown)",
-}
 
 # Fraction of the configured per-minute request budget held back before a
 # ticker's fundamental analysis is even attempted, so the same-model portfolio
@@ -207,7 +197,7 @@ def build_compact_prompt(ticker: str, pit_data: dict, anon_id: Optional[str] = N
         "(3) null fields do not drive the primary signal.\n"
         "\n"
         "Output ONLY a valid JSON object — no markdown, no preamble, no trailing text.\n"
-        "Fields required: " + ", ".join(_VERDICT_FIELD_DESCRIPTIONS.values()) + "."
+        "Fields required: " + field_list(FundamentalVerdict) + "."
     )
     return prompt.strip()
 

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -31,6 +31,7 @@ import numpy as np
 from argus.config import settings
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
 from argus.params import PORTFOLIO
+from argus.schemas.prompting import schema_block
 from argus.schemas.signals import (
     MacroContext,
     PortfolioAllocation,
@@ -143,33 +144,9 @@ def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContex
     return "\n".join(lines)
 
 
-# Field descriptions for the prompt's declared output schema, keyed by the same
-# names as ProposedPosition's and PortfolioProposal's schemas — a drift test
-# (test_portfolio_enforcement.py) asserts the two stay equal, so a schema change
-# that isn't mirrored here fails loudly instead of leaving the prompt asking for
-# fields the model can't supply.
-_POSITION_FIELD_DESCRIPTIONS: dict[str, str] = {
-    "ticker": '""',
-    "allocation_pct": "0.0",
-    "stop_loss": "0.0",
-    "target_price": "null",
-    "thesis": '"<≤20 words>"',
-    "advisor_note": '"2–4 professional sentences: rationale, key risks, what to monitor"',
-    "composite_conviction": "0.0",
-    "time_horizon": '"3-6 months"',
-}
-_PROPOSAL_FIELD_DESCRIPTIONS: dict[str, str] = {
-    "cash_reserve_pct": "0.0",
-    "rebalance_trigger": '"MONTHLY"',
-}
-_POSITION_SCHEMA_JSON = (
-    "{" + ",".join(f'"{k}":{v}' for k, v in _POSITION_FIELD_DESCRIPTIONS.items()) + "}"
-)
-_PROPOSAL_SCHEMA_JSON = (
-    '{"portfolio":[' + _POSITION_SCHEMA_JSON + "],"
-    + ",".join(f'"{k}":{v}' for k, v in _PROPOSAL_FIELD_DESCRIPTIONS.items())
-    + "}"
-)
+# Rendered from PortfolioProposal's own PromptText markers, recursing into
+# ProposedPosition for the nested "portfolio" list.
+_PROPOSAL_SCHEMA_JSON = schema_block(PortfolioProposal)
 
 
 SYSTEM_PROMPT = (

--- a/argus/agents/sentiment.py
+++ b/argus/agents/sentiment.py
@@ -32,6 +32,7 @@ import numpy as np
 from argus.config import settings
 from argus.data import fetchers
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
+from argus.schemas.prompting import schema_block
 from argus.schemas.signals import SentimentSignal, SentimentVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
 from argus.structured_output import StructuredOutputError, decode
@@ -283,21 +284,10 @@ _SENTIMENT_METRIC_LABELS: dict[str, str] = {
 }
 
 
-# Field descriptions for the prompt's declared output schema, keyed by the same
-# names as SentimentVerdict's schema — a drift test (test_sentiment.py) asserts
-# the two stay equal, so a schema change that isn't mirrored here fails loudly
-# instead of leaving the prompt asking for fields the model can't supply. Shared
-# between _build_synthesis_prompt and SYSTEM_PROMPT so their two schema restatements
-# can't drift apart from each other either.
-_VERDICT_FIELD_DESCRIPTIONS: dict[str, str] = {
-    "signal": '"BULLISH|BEARISH|NEUTRAL"',
-    "conviction": "<float 0.0–1.0>",
-    "sentiment_decay_risk": '"LOW|MEDIUM|HIGH"',
-    "reasoning": '"<≤60 words citing the primary driver>"',
-}
-_VERDICT_SCHEMA_JSON = (
-    "{" + ", ".join(f'"{k}": {v}' for k, v in _VERDICT_FIELD_DESCRIPTIONS.items()) + "}"
-)
+# Rendered from SentimentVerdict's own PromptText markers, shared between
+# _build_synthesis_prompt and SYSTEM_PROMPT so their two schema restatements
+# can't drift apart from each other or from the schema itself.
+_VERDICT_SCHEMA_JSON = schema_block(SentimentVerdict)
 
 
 def _build_synthesis_prompt(ticker: str, metrics: dict) -> str:

--- a/argus/schemas/prompting.py
+++ b/argus/schemas/prompting.py
@@ -1,0 +1,138 @@
+"""
+argus/schemas/prompting.py
+
+Renders each agent's declared LLM output schema directly from its Pydantic
+verdict/proposal model, so the prompt text shown to the model and the
+constraints its response is validated against cannot drift apart (issue
+#76). Depends on pydantic and nothing else — deliberately kept out of
+argus/structured_output.py, which reaches groq, httpx, langchain_groq, and
+pandas through argus/seams.py, and out of argus/schemas/signals.py's own
+import surface being widened with anything heavier, since that module is
+imported by nearly everything in the system.
+
+Responsibilities:
+  - Define the PromptText marker attached to a field's Annotated metadata,
+    carrying the exact text an LLM is shown for that field
+  - Render a model's fields as a prose list (field_list) or a JSON schema
+    block (schema_block), recursing into a nested model or a list of them
+  - Raise when a field's declaration disagrees with its shape: a scalar
+    field with no marker, or a nested-model field that carries one
+
+Not responsible for:
+  - Sending prompts or decoding responses (see argus/structured_output.py)
+  - Defining validation constraints themselves (see argus/schemas/signals.py)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
+
+@dataclass(frozen=True)
+class PromptText:
+    """Annotated marker carrying the exact text an LLM is shown for one field.
+
+    Args:
+        text: Verbatim text for this field — prose for field_list, a JSON
+            value (already quoted if it's a string) for schema_block.
+    """
+
+    text: str
+
+
+def _prompt_text(field: FieldInfo) -> PromptText | None:
+    """Returns the PromptText marker in a field's metadata, if any."""
+    for item in field.metadata:
+        if isinstance(item, PromptText):
+            return item
+    return None
+
+
+def _nested_model(annotation: Any) -> tuple[type[BaseModel] | None, bool]:
+    """Identifies a field annotation as a direct or list-wrapped BaseModel.
+
+    Args:
+        annotation: A field's ``FieldInfo.annotation``.
+
+    Returns:
+        ``(model, is_list)`` where ``model`` is the nested BaseModel type,
+        or ``(None, False)`` if the annotation is neither a BaseModel nor a
+        list of one.
+    """
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation, False
+    if get_origin(annotation) is list:
+        args = get_args(annotation)
+        if len(args) == 1 and isinstance(args[0], type) and issubclass(args[0], BaseModel):
+            return args[0], True
+    return None, False
+
+
+def field_list(model: type[BaseModel]) -> str:
+    """Renders every field's PromptText marker as a comma-space-joined prose list.
+
+    Each marker's text already names its own field, so no field name is
+    added by this function.
+
+    Args:
+        model: Pydantic model whose every field carries a PromptText marker.
+
+    Returns:
+        The fields' marker text, verbatim, joined with ", ".
+
+    Raises:
+        TypeError: If any field lacks a PromptText marker, or is itself a
+            nested model or a list of one.
+    """
+    parts = []
+    for name, field in model.model_fields.items():
+        nested, _ = _nested_model(field.annotation)
+        if nested is not None:
+            raise TypeError(f"{model.__name__}.{name}: field_list does not support nested models")
+        marker = _prompt_text(field)
+        if marker is None:
+            raise TypeError(f"{model.__name__}.{name} has no PromptText marker")
+        parts.append(marker.text)
+    return ", ".join(parts)
+
+
+def schema_block(model: type[BaseModel]) -> str:
+    """Renders a model as a JSON-object-shaped schema block for a prompt.
+
+    A field annotated as a nested model, or a list of one, recurses into
+    its own block instead of reading a marker — list fields are wrapped in
+    brackets. Every other field must carry a PromptText marker giving the
+    JSON value shown for it.
+
+    Args:
+        model: Pydantic model to render.
+
+    Returns:
+        A JSON-object-shaped string, e.g. ``{"ticker":"","allocation_pct":0.0}``,
+        with no insignificant whitespace.
+
+    Raises:
+        TypeError: If a scalar field lacks a PromptText marker, or a
+            nested-model field carries one.
+    """
+    entries = []
+    for name, field in model.model_fields.items():
+        nested, is_list = _nested_model(field.annotation)
+        marker = _prompt_text(field)
+        if nested is not None:
+            if marker is not None:
+                raise TypeError(
+                    f"{model.__name__}.{name} is a nested model and must not carry a PromptText marker"
+                )
+            rendered = schema_block(nested)
+            value = f"[{rendered}]" if is_list else rendered
+        else:
+            if marker is None:
+                raise TypeError(f"{model.__name__}.{name} has no PromptText marker")
+            value = marker.text
+        entries.append(f'"{name}":{value}')
+    return "{" + ",".join(entries) + "}"

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -558,18 +558,29 @@ class ProposedPosition(BaseModel):
     own figure when one exists. See GLOSSARY.md's Proposal entry.
     """
 
-    ticker: str = Field(..., description="Equity ticker symbol")
-    allocation_pct: float = Field(0.0, description="Proposed target portfolio weight")
-    stop_loss: float | None = Field(None, description="Model's own stop-loss estimate")
-    target_price: float | None = Field(None, description="12-month price target (optional)")
-    thesis: str = Field(..., description="One-sentence position thesis")
-    advisor_note: str | None = Field(
-        None, description="Professional multi-sentence advisory rationale (optional)"
+    ticker: Annotated[str, PromptText('""')] = Field(..., description="Equity ticker symbol")
+    allocation_pct: Annotated[float, PromptText("0.0")] = Field(
+        0.0, description="Proposed target portfolio weight"
     )
-    composite_conviction: float = Field(
+    stop_loss: Annotated[float | None, PromptText("0.0")] = Field(
+        None, description="Model's own stop-loss estimate"
+    )
+    target_price: Annotated[float | None, PromptText("null")] = Field(
+        None, description="12-month price target (optional)"
+    )
+    thesis: Annotated[str, PromptText('"<≤20 words>"')] = Field(
+        ..., description="One-sentence position thesis"
+    )
+    advisor_note: Annotated[
+        str | None,
+        PromptText('"2–4 professional sentences: rationale, key risks, what to monitor"'),
+    ] = Field(None, description="Professional multi-sentence advisory rationale (optional)")
+    composite_conviction: Annotated[float, PromptText("0.0")] = Field(
         ..., ge=0.0, le=1.0, description="Aggregated conviction across all agents"
     )
-    time_horizon: str = Field(..., description="Expected holding period, e.g. '30 days'")
+    time_horizon: Annotated[str, PromptText('"3-6 months"')] = Field(
+        ..., description="Expected holding period, e.g. '30 days'"
+    )
 
 
 class PortfolioProposal(BaseModel):
@@ -581,8 +592,10 @@ class PortfolioProposal(BaseModel):
     """
 
     portfolio: list[ProposedPosition] = Field(default_factory=list)
-    cash_reserve_pct: float = Field(..., description="Model's own residual estimate")
-    rebalance_trigger: str = Field(
+    cash_reserve_pct: Annotated[float, PromptText("0.0")] = Field(
+        ..., description="Model's own residual estimate"
+    )
+    rebalance_trigger: Annotated[str, PromptText('"MONTHLY"')] = Field(
         ..., description="Condition that will next trigger rebalancing, e.g. 'VIX > 35'"
     )
 

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -24,7 +24,7 @@ import uuid
 import warnings
 from datetime import date, datetime
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from pydantic import (
     BaseModel,
@@ -35,6 +35,7 @@ from pydantic import (
 )
 
 from argus.params import PORTFOLIO, SYSTEM
+from argus.schemas.prompting import PromptText
 
 logger = logging.getLogger(__name__)
 
@@ -282,12 +283,18 @@ class FundamentalVerdict(BaseModel):
     GLOSSARY.md's Verdict entry.
     """
 
-    signal: Signal = Field(..., description="Directional label")
-    conviction: float = Field(..., ge=0.0, le=_CONVICTION_MAX)
-    moat_score: float = Field(
+    signal: Annotated[Signal, PromptText("signal (string)")] = Field(
+        ..., description="Directional label"
+    )
+    conviction: Annotated[float, PromptText("conviction (float 0.0–1.0)")] = Field(
+        ..., ge=0.0, le=_CONVICTION_MAX
+    )
+    moat_score: Annotated[float, PromptText("moat_score (int 1–10)")] = Field(
         ..., ge=0.0, le=10.0, description="Qualitative competitive moat [0, 10]"
     )
-    reasoning: str = Field(..., description="LLM-generated investment thesis")
+    reasoning: Annotated[str, PromptText("reasoning (string ≤80 words, no markdown)")] = Field(
+        ..., description="LLM-generated investment thesis"
+    )
 
     @field_validator("conviction", mode="before")
     @classmethod

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -349,12 +349,18 @@ class SentimentVerdict(BaseModel):
     in by the agent to build a SentimentSignal. See GLOSSARY.md's Verdict entry.
     """
 
-    signal: Signal = Field(..., description="Directional label")
-    conviction: float = Field(..., ge=0.0, le=_CONVICTION_MAX)
-    sentiment_decay_risk: Literal["LOW", "MEDIUM", "HIGH"] = Field(
-        ..., description="Estimated speed at which the sentiment signal will decay"
+    signal: Annotated[Signal, PromptText('"BULLISH|BEARISH|NEUTRAL"')] = Field(
+        ..., description="Directional label"
     )
-    reasoning: str = Field(..., description="LLM rationale for the signal")
+    conviction: Annotated[float, PromptText("<float 0.0–1.0>")] = Field(
+        ..., ge=0.0, le=_CONVICTION_MAX
+    )
+    sentiment_decay_risk: Annotated[
+        Literal["LOW", "MEDIUM", "HIGH"], PromptText('"LOW|MEDIUM|HIGH"')
+    ] = Field(..., description="Estimated speed at which the sentiment signal will decay")
+    reasoning: Annotated[str, PromptText('"<≤60 words citing the primary driver>"')] = Field(
+        ..., description="LLM rationale for the signal"
+    )
 
     @field_validator("conviction", mode="before")
     @classmethod

--- a/tests/test_fundamental.py
+++ b/tests/test_fundamental.py
@@ -16,7 +16,7 @@ from argus.agents.fundamental import (
     build_compact_prompt,
 )
 from argus.orchestration.governor import BOOTSTRAP_LIMITS, RateLimitGovernor
-from argus.schemas.signals import FundamentalSignal, FundamentalVerdict, Signal
+from argus.schemas.signals import FundamentalSignal, Signal
 from argus.seams import FixtureLLMClient
 
 
@@ -40,15 +40,6 @@ class _RecordingLLMClient:
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         self.last_user_prompt = user_prompt
         return self._response_text
-
-def test_prompt_declared_fields_match_the_verdict_schema():
-    """The prompt's declared output fields and FundamentalVerdict's fields must never drift apart.
-
-    The prompt used to also declare six measured ratios the agent unconditionally
-    overwrote after parsing; this asserts none of those field names sneak back in.
-    """
-    assert set(fundamental_module._VERDICT_FIELD_DESCRIPTIONS) == set(FundamentalVerdict.model_fields)
-
 
 def test_anonymize_ticker():
     """Anonymized IDs are deterministic per (ticker, seed) and vary if either input changes."""

--- a/tests/test_portfolio_enforcement.py
+++ b/tests/test_portfolio_enforcement.py
@@ -16,15 +16,12 @@ from datetime import datetime
 
 import pytest
 
-import argus.agents.portfolio as portfolio_module
 from argus.agents.portfolio import PortfolioManagerAgent
 from argus.orchestration.governor import RateLimitExceeded
 from argus.params import PORTFOLIO, SYSTEM
 from argus.schemas.signals import (
     PortfolioAllocation,
-    PortfolioProposal,
     PositionAllocation,
-    ProposedPosition,
     RiskAssessment,
     RiskVerdict,
 )
@@ -47,14 +44,6 @@ class _CapturingLLMClient:
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         self.last_prompt = user_prompt
         return json.dumps(self._response_json)
-
-
-def test_prompt_declared_fields_match_the_proposal_schema():
-    """The prompt's declared output fields and the proposal schemas' fields must never drift apart."""
-    assert set(portfolio_module._POSITION_FIELD_DESCRIPTIONS) == set(ProposedPosition.model_fields)
-    assert set(portfolio_module._PROPOSAL_FIELD_DESCRIPTIONS) == (
-        set(PortfolioProposal.model_fields) - {"portfolio"}
-    )
 
 
 def test_allocate_reraises_on_governor_exhaustion_without_retrying():

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,0 +1,113 @@
+"""
+Tests for argus/schemas/prompting.py's field_list() and schema_block() — the
+two render functions that turn a Pydantic model's PromptText markers into the
+literal text an LLM prompt shows. No agent is migrated onto this module yet
+(issue #76 is expand-only), so these tests exercise it directly against
+throwaway models built for each case.
+"""
+
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel
+
+from argus.schemas.prompting import PromptText, field_list, schema_block
+
+
+class _Flat(BaseModel):
+    """A flat model with every field marked."""
+
+    signal: Annotated[str, PromptText('"BULLISH|BEARISH|NEUTRAL"')]
+    conviction: Annotated[float, PromptText("<float 0.0-1.0>")]
+
+
+class _MissingMarker(BaseModel):
+    """A flat model where one field carries no PromptText marker."""
+
+    signal: Annotated[str, PromptText('"BULLISH|BEARISH|NEUTRAL"')]
+    conviction: float
+
+
+class _Nested(BaseModel):
+    """A single nested-model field, unmarked as the contract requires."""
+
+    ticker: Annotated[str, PromptText('""')]
+    position: _Flat
+
+
+class _NestedList(BaseModel):
+    """A list-of-nested-model field, unmarked as the contract requires."""
+
+    ticker: Annotated[str, PromptText('""')]
+    positions: list[_Flat]
+
+
+class _NestedWithMarker(BaseModel):
+    """A nested-model field that incorrectly carries a PromptText marker."""
+
+    position: Annotated[_Flat, PromptText("{}")]
+
+
+class _NestedListWithMarker(BaseModel):
+    """A list-of-nested-model field that incorrectly carries a PromptText marker."""
+
+    positions: Annotated[list[_Flat], PromptText("[]")]
+
+
+def test_schema_block_includes_every_field():
+    """Every field's name and marker text appear in the rendered block."""
+    result = schema_block(_Flat)
+    assert result == '{"signal":"BULLISH|BEARISH|NEUTRAL","conviction":<float 0.0-1.0>}'
+
+
+def test_schema_block_uses_marker_text_verbatim():
+    """Marker text is copied through unmodified, not reformatted."""
+    result = schema_block(_Flat)
+    assert '"<float 0.0-1.0>"' not in result  # sanity: conviction's value has no outer quotes
+    assert "<float 0.0-1.0>" in result
+
+
+def test_field_list_includes_every_field_and_joins_with_comma_space():
+    """field_list joins each field's marker text verbatim with ', '."""
+    result = field_list(_Flat)
+    assert result == '"BULLISH|BEARISH|NEUTRAL", <float 0.0-1.0>'
+
+
+def test_schema_block_renders_nested_model_as_its_own_block():
+    """A nested-model field renders as a JSON object, not a marker lookup."""
+    result = schema_block(_Nested)
+    assert result == (
+        '{"ticker":"","position":{"signal":"BULLISH|BEARISH|NEUTRAL","conviction":<float 0.0-1.0>}}'
+    )
+
+
+def test_schema_block_wraps_list_of_nested_model_in_brackets():
+    """A list-of-nested-model field renders its block wrapped in brackets."""
+    result = schema_block(_NestedList)
+    assert result == (
+        '{"ticker":"","positions":[{"signal":"BULLISH|BEARISH|NEUTRAL","conviction":<float 0.0-1.0>}]}'
+    )
+
+
+def test_schema_block_raises_on_scalar_field_with_no_marker():
+    """A scalar field with no PromptText marker fails loudly rather than rendering blank."""
+    with pytest.raises(TypeError):
+        schema_block(_MissingMarker)
+
+
+def test_field_list_raises_on_scalar_field_with_no_marker():
+    """field_list applies the same no-marker enforcement as schema_block."""
+    with pytest.raises(TypeError):
+        field_list(_MissingMarker)
+
+
+def test_schema_block_raises_on_nested_model_field_carrying_a_marker():
+    """A nested-model field must not carry a PromptText marker of its own."""
+    with pytest.raises(TypeError):
+        schema_block(_NestedWithMarker)
+
+
+def test_schema_block_raises_on_nested_list_field_carrying_a_marker():
+    """A list-of-nested-model field must not carry a PromptText marker of its own."""
+    with pytest.raises(TypeError):
+        schema_block(_NestedListWithMarker)

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -5,7 +5,6 @@ Tests for the Sentiment Agent and its pure-Python helpers.
 from datetime import datetime, timedelta
 
 
-import argus.agents.sentiment as sentiment_module
 from argus.agents.sentiment import (
     SentimentAgent,
     aggregate_finbert_scores,

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -13,7 +13,7 @@ from argus.agents.sentiment import (
     _check_earnings_calendar,
 )
 from argus.orchestration.governor import RateLimitExceeded
-from argus.schemas.signals import SentimentSignal, SentimentVerdict, Signal
+from argus.schemas.signals import SentimentSignal, Signal
 
 def test_aggregate_finbert_scores_empty():
     """An empty article list returns the neutral, low-confidence default."""
@@ -112,11 +112,6 @@ class _RecordingLLMClient:
     def complete(self, system_prompt, user_prompt):
         self.last_user_prompt = user_prompt
         return self._response_text
-
-
-def test_prompt_declared_fields_match_the_verdict_schema():
-    """The prompt's declared output fields and SentimentVerdict's fields must never drift apart."""
-    assert set(sentiment_module._VERDICT_FIELD_DESCRIPTIONS) == set(SentimentVerdict.model_fields)
 
 
 def test_analyze_degrades_the_ticker_on_governor_exhaustion_without_retrying(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds `argus/schemas/prompting.py`: a `PromptText` Annotated marker plus `field_list()`/`schema_block()` renderers that generate an agent's declared LLM output schema directly from the Pydantic verdict/proposal model.
- Migrates the fundamental, sentiment, and portfolio agents onto it, deleting four hand-maintained field-description dicts, two hand-assembled schema literals, and the three drift tests that used to be the only thing catching the two copies disagreeing.
- Portfolio's `schema_block(PortfolioProposal)` recurses into `ProposedPosition` for the nested `portfolio` list, removing the hand-assembled nesting and its drift-check carve-out.

Closes #76.

## Test plan
- [x] `tests/test_prompting.py` covers field_list/schema_block: every field renders, marker text is verbatim, nested model and list-of-nested-model recursion, missing-marker and marker-on-nested-field both raise.
- [x] Byte-identity verified against each deleted literal at migration time (portfolio and fundamental exact; sentiment's only difference is JSON-insignificant whitespace, as the issue calls for).
- [x] Full suite (470 tests), mypy, and ruff all pass on this branch.