### PR TITLE
Architecture review: schema rendering, reconciliation, live cache, ticker snapshot, shared TTL cache, LLM port capacity (#76-81)

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -70,7 +70,11 @@ see the notes under each entry.
   (`argus/memory/cultural.py`) that stores trade outcomes and decision snapshots, and
   retrieves regime-scoped historical wisdom and warnings for the portfolio agent.
 
-- **Reconciliation** — the slow-clock pass (`argus/orchestration/reconciliation.py`)
-  that closes the decision-to-outcome loop: computing realized returns, assigning
-  per-agent credit via leave-one-out ablation, and persisting trade outcomes into
-  cultural memory.
+- **Reconciliation** — the slow-clock pass (`argus/orchestration/reconciliation.py`,
+  composed as `run_reconciliation_pass`) that closes the decision-to-outcome loop:
+  computing realized returns, assigning per-agent credit via leave-one-out ablation,
+  persisting trade outcomes into cultural memory, compounding matured runs onto the
+  paper equity curve, and bounding the decisions log, checkpoint database, PENDING
+  snapshots, and applied-runs set so none of them grow forever. The API's background
+  loop and the scheduled CLI script (`scripts/reconcile_outcomes.py`) both run it;
+  only kill-switch sync differs between them, and stays at the API's call site.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -51,7 +51,13 @@ see the notes under each entry.
   callers compress the buffer into session states afterward, via `compress_all`.
 
 - **Decision** — an `ARGUSDecision` (`argus/schemas/signals.py`): a per-ticker snapshot
-  of every agent's output plus the resulting allocation, logged once per session.
+  of every agent's output plus the resulting allocation, logged once per session. A
+  decision is a `TickerSnapshot` plus its allocation and the session's timestamp.
+
+- **TickerSnapshot** (`argus/orchestration/state.py`) — the per-ticker join of every
+  agent's output before an allocation exists: technical, fundamental, sentiment, risk,
+  and aggregated signals. Built on demand from `ARGUSState` by `build_ticker_snapshots`,
+  never stored in state or the checkpoint. What a decision is built from.
 
 - **Allocation** — a `PositionAllocation` or `PortfolioAllocation`
   (`argus/schemas/signals.py`): the risk-enforced target weight(s) a session

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -50,6 +50,13 @@ see the notes under each entry.
   fetching the latest intraday candles for every tracked ticker in the universe. Its
   callers compress the buffer into session states afterward, via `compress_all`.
 
+- **Live session cache** — the `LiveSessionCache` (`argus/data/live_session_cache.py`)
+  holding the session state each tracked ticker was last published with between
+  sweeps. Owns publication, eviction, and the admission rule that decides whether a
+  cached session state is fresh enough to allocate against; the API gateway holds one
+  instance and gates `/analyze` on its `admit()` result rather than reading session
+  states off the pipeline directly.
+
 - **Decision** — an `ARGUSDecision` (`argus/schemas/signals.py`): a per-ticker snapshot
   of every agent's output plus the resulting allocation, logged once per session.
 

--- a/api/main.py
+++ b/api/main.py
@@ -62,14 +62,9 @@ from argus.orchestration.collector import (
 )
 from argus.orchestration.governor import REGISTERED_MODELS, RateLimitExceeded, UnregisteredModel, governor
 from argus.orchestration.graph import build_graph
-from argus.orchestration.reconciliation import (
-    compact_decisions_jsonl,
-    load_decisions_from_jsonl,
-    prune_checkpoints,
-    reconcile_decisions,
-)
+from argus.orchestration.reconciliation import run_reconciliation_pass
 from argus.orchestration.state import ARGUSState
-from argus.params import RECONCILIATION, SYSTEM
+from argus.params import SYSTEM
 from argus.risk import paper_book
 from argus.risk.kill_switch import get_kill_switch, initialize_kill_switch
 from argus.seams import LiveMarketDataProvider
@@ -203,84 +198,38 @@ async def _collector_loop(pipeline: MFTDataPipeline, compiled_graph) -> None:
         await asyncio.sleep(settings.ARGUS_COLLECTOR_INTERVAL_SECONDS)
 
 
-def _prune_growing_stores(decisions_log: str) -> None:
-    """Bounds the decision/checkpoint/PENDING-snapshot stores, all on one horizon-plus-margin cutoff (PR 6).
-
-    Runs after reconcile_decisions has already had its chance at every session
-    up to the same cutoff, so nothing pruned here was still reconcilable.
-    Failures are logged and swallowed independently per store — a checkpoint
-    DB VACUUM failing must not skip compacting decisions.jsonl, or vice versa.
-
-    Args:
-        decisions_log: Same decisions.jsonl path the caller just reconciled.
-    """
-    cutoff = datetime.now() - timedelta(  # noqa: DTZ005
-        days=RECONCILIATION.horizon_days + RECONCILIATION.retention_margin_days
-    )
-
-    try:
-        kept = compact_decisions_jsonl(decisions_log, cutoff)
-        logger.info("[Reconcile] compacted decisions.jsonl to %d retained decision(s)", kept)
-    except Exception:
-        logger.exception("[Reconcile] decisions.jsonl compaction failed")
-
-    try:
-        checkpoint_db = f"{settings.ARGUS_DATA_DIR}/argus_graph.db"
-        pruned = prune_checkpoints(checkpoint_db, cutoff)
-        logger.info("[Reconcile] pruned %d stale checkpoint thread(s)", pruned)
-    except Exception:
-        logger.exception("[Reconcile] checkpoint pruning failed")
-
-    try:
-        expired = get_cultural_memory().expire_pending_snapshots(cutoff)
-        logger.info("[Reconcile] expired %d stale PENDING snapshot(s)", expired)
-    except Exception:
-        logger.exception("[Reconcile] PENDING snapshot expiry failed")
-
-
 def _reconcile_once() -> None:
-    """Runs one reconciliation pass: outcome backfill, paper-book update, kill-switch sync, store pruning.
+    """Runs one reconciliation pass, then syncs the kill switch off its resulting equity.
 
     Synchronous by design — `_reconcile_loop` runs this via `asyncio.to_thread`
     since it performs per-ticker yfinance fetches directly, which would
     otherwise block the event loop for the whole app for the duration of a run.
+    Kill-switch sync stays here rather than in run_reconciliation_pass: this is
+    the caller with a daemon to sync to, and it's skipped when the paper-book
+    step itself failed — syncing a fresh report's zeroed-out default equity
+    would read as a total portfolio loss (issue #77).
     """
-    decisions_log = f"{settings.ARGUS_DATA_DIR}/decisions.jsonl"
-    decisions = load_decisions_from_jsonl(decisions_log)
-    market_data = LiveMarketDataProvider()
-    stored = reconcile_decisions(
-        decisions,
-        market_data=market_data,
-        cultural=get_cultural_memory(),
-        horizon_days=RECONCILIATION.horizon_days,
+    report = run_reconciliation_pass(
+        LiveMarketDataProvider(),
+        get_cultural_memory(),
+        f"{settings.ARGUS_DATA_DIR}/paper_equity.json",
+        decisions_log_path=f"{settings.ARGUS_DATA_DIR}/decisions.jsonl",
+        checkpoint_db_path=f"{settings.ARGUS_DATA_DIR}/argus_graph.db",
     )
-    logger.info("[Reconcile] stored %d/%d outcome(s)", stored, len(decisions))
+    logger.info(
+        "[Reconcile] stored %d/%d outcome(s), equity=$%.2f (drawdown=%.1f%%)",
+        report.outcomes_stored,
+        report.decisions_loaded,
+        report.equity,
+        report.drawdown * 100,
+    )
+    for error in report.errors:
+        logger.error("[Reconcile] %s", error)
 
-    try:
-        book_path = f"{settings.ARGUS_DATA_DIR}/paper_equity.json"
-        book = paper_book.load(book_path)
-        for run_timestamp, run_return in paper_book.compute_run_returns(
-            decisions, market_data, RECONCILIATION.horizon_days
-        ):
-            book.apply_run(run_timestamp, run_return)
-        book.prune_runs_applied(
-            datetime.now()  # noqa: DTZ005
-            - timedelta(days=RECONCILIATION.horizon_days + RECONCILIATION.retention_margin_days)
-        )
-        paper_book.save(book, book_path)
-
+    if report.paper_book_updated:
         ks = get_kill_switch()
         if ks is not None:
-            ks.update_portfolio_value(book.equity)
-        logger.info(
-            "[Reconcile] paper equity=$%.2f (drawdown=%.1f%%)",
-            book.equity,
-            book.drawdown_from_peak() * 100,
-        )
-    except Exception:
-        logger.exception("[Reconcile] paper-book update failed")
-
-    _prune_growing_stores(decisions_log)
+            ks.update_portfolio_value(report.equity)
 
 
 def _seconds_until_next_reconcile(now_et: datetime, hour: int) -> float:
@@ -306,7 +255,7 @@ def _seconds_until_next_reconcile(now_et: datetime, hour: int) -> float:
 
 
 async def _reconcile_loop() -> None:
-    """Runs reconcile_decisions once a day at settings.ARGUS_RECONCILE_HOUR_ET."""
+    """Runs the reconciliation pass once a day at settings.ARGUS_RECONCILE_HOUR_ET."""
     while True:
         now_et = datetime.now(_ET)
         await asyncio.sleep(_seconds_until_next_reconcile(now_et, settings.ARGUS_RECONCILE_HOUR_ET))

--- a/api/main.py
+++ b/api/main.py
@@ -52,7 +52,8 @@ from pydantic import BaseModel, Field, field_validator
 import argus
 from argus.agents.macro import MacroStatisticalAgent
 from argus.config import settings
-from argus.data.pipeline import MFTDataPipeline, max_bar_age_seconds, session_state_ttl_seconds
+from argus.data.live_session_cache import max_bar_age_seconds, session_state_ttl_seconds
+from argus.data.pipeline import MFTDataPipeline
 from argus.data.tickers import TICKER_PATTERN
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.collector import (

--- a/api/main.py
+++ b/api/main.py
@@ -194,12 +194,19 @@ def _reconcile_once() -> None:
         checkpoint_db_path=f"{settings.ARGUS_DATA_DIR}/argus_graph.db",
     )
     logger.info(
-        "[Reconcile] stored %d/%d outcome(s), equity=$%.2f (drawdown=%.1f%%)",
-        report.outcomes_stored,
-        report.decisions_loaded,
-        report.equity,
-        report.drawdown * 100,
+        "[Reconcile] stored %d/%d outcome(s)", report.outcomes_stored, report.decisions_loaded
     )
+    # Only meaningful once the paper-book step actually ran (see docstring) —
+    # otherwise these are still their zeroed-out defaults, not a real value
+    if report.paper_book_updated:
+        logger.info(
+            "[Reconcile] equity=$%.2f (drawdown=%.1f%%)", report.equity, report.drawdown * 100
+        )
+    if report.decisions_compacted is not None:
+        logger.info("[Reconcile] decisions.jsonl compacted: %d retained", report.decisions_compacted)
+    if report.checkpoints_pruned is not None:
+        logger.info("[Reconcile] checkpoint threads pruned: %d", report.checkpoints_pruned)
+    logger.info("[Reconcile] PENDING snapshots expired: %d", report.pending_snapshots_expired)
     for error in report.errors:
         logger.error("[Reconcile] %s", error)
 

--- a/api/main.py
+++ b/api/main.py
@@ -122,7 +122,8 @@ async def _mft_session_callback(session_states: dict) -> None:
         _live_cache.publish(session_states, _mft_pipeline.tickers)
 
     logger.info(
-        "[MFT] Live session cache updated: %d ticker(s)", len(_live_cache) if _live_cache else 0
+        "[MFT] Live session cache updated: %d ticker(s)",
+        len(_live_cache) if _live_cache is not None else 0,
     )
 
 
@@ -737,7 +738,7 @@ async def analyze(req: AnalysisRequest):
 
     # Admission answers only "how old is this" for each ticker; the ordering
     # against market hours above is what decides whether that age matters
-    # right now (issue #78).
+    # right now (issue #78)
     admission = _live_cache.admit(req.tickers, datetime.now(_ET))
 
     if admission.absent:

--- a/api/main.py
+++ b/api/main.py
@@ -52,7 +52,7 @@ from pydantic import BaseModel, Field, field_validator
 import argus
 from argus.agents.macro import MacroStatisticalAgent
 from argus.config import settings
-from argus.data.live_session_cache import max_bar_age_seconds, session_state_ttl_seconds
+from argus.data.live_session_cache import LiveSessionCache
 from argus.data.pipeline import MFTDataPipeline
 from argus.data.tickers import TICKER_PATTERN
 from argus.memory.cultural import get_cultural_memory
@@ -74,7 +74,7 @@ logger = logging.getLogger("argus.api")
 
 _ET = ZoneInfo("America/New_York")
 
-_live_session_cache: dict[str, tuple[dict, datetime]] = {}
+_live_cache: LiveSessionCache | None = None
 
 # Initialized during lifespan startup; tickers are registered dynamically per
 # /analyze request in addition to the ARGUS_UNIVERSE seed
@@ -109,46 +109,21 @@ _macro_status_agent: MacroStatisticalAgent | None = None
 async def _mft_session_callback(session_states: dict) -> None:
     """Receives compressed technical feature dicts from the MFT pipeline on every sweep.
 
-    Updates the module-level live cache so the next /analyze call picks up
-    fresh intraday indicators without re-fetching historical data. Each entry
-    stores a (state_dict, updated_at) tuple for TTL-based staleness detection.
+    Publishes them into the module-level live cache so the next /analyze call
+    picks up fresh intraday indicators without re-fetching historical data.
+    Eviction of tickers no longer tracked (API-9) happens inside
+    LiveSessionCache.publish, keyed off the pipeline's current tracked
+    universe.
 
     Args:
         session_states: Mapping of ticker → technical feature dict from MFTDataPipeline.
     """
-    now = datetime.now()  # noqa: DTZ005
-    for ticker, state in session_states.items():
-        _live_session_cache[ticker] = (state, now)
+    if _live_cache is not None and _mft_pipeline is not None:
+        _live_cache.publish(session_states, _mft_pipeline.tickers)
 
-    # Drops entries for tickers no longer tracked (API-9) — without this the
-    # cache only ever grows, holding a stale allocation-eligible entry for any
-    # ticker that was ever registered even after it stops being tracked
-    if _mft_pipeline is not None:
-        tracked = set(_mft_pipeline.tickers)
-        for ticker in list(_live_session_cache):
-            if ticker not in tracked:
-                del _live_session_cache[ticker]
-
-    logger.info("[MFT] Live session cache updated: %d ticker(s)", len(_live_session_cache))
-
-
-def _bar_age_seconds(state: dict, now_et: datetime) -> Optional[float]:
-    """Computes a session state's bar age in seconds, failing closed on a bad timestamp (API-11).
-
-    A missing, malformed, or naive ``timestamp`` must not raise out of
-    /analyze or /pipeline/status — it's treated as staleness instead.
-
-    Args:
-        state: A compressed technical feature dict from the live cache.
-        now_et: Current time, ET-aware, to measure age against.
-
-    Returns:
-        Age in seconds, or None if ``timestamp`` can't be parsed against `now_et`.
-    """
-    try:
-        return (now_et - datetime.fromisoformat(state["timestamp"])).total_seconds()
-    except (KeyError, TypeError, ValueError):
-        return None
+    logger.info(
+        "[MFT] Live session cache updated: %d ticker(s)", len(_live_cache) if _live_cache else 0
+    )
 
 
 def _log_task_exception(task: asyncio.Task, name: str) -> None:
@@ -412,7 +387,7 @@ def _assert_registered_models() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Starts background tasks on startup and stops them cleanly on shutdown."""
-    global _mft_pipeline, _pipeline_task, _collector_task, _reconcile_task, _graph, _macro_status_agent
+    global _mft_pipeline, _pipeline_task, _collector_task, _reconcile_task, _graph, _macro_status_agent, _live_cache
 
     _configure_logging()
     _warn_on_permissive_security_defaults()
@@ -433,6 +408,7 @@ async def lifespan(app: FastAPI):
     # Seeded from ARGUS_UNIVERSE so the pipeline starts collecting immediately
     # rather than waiting for a first /analyze call to register any tickers
     _mft_pipeline = MFTDataPipeline(tickers=list(settings.ARGUS_UNIVERSE))
+    _live_cache = LiveSessionCache(interval_minutes=_mft_pipeline.interval_minutes)
     _pipeline_task = asyncio.create_task(_mft_pipeline.start(on_session_ready=_mft_session_callback))
     _pipeline_task.add_done_callback(lambda t: _log_task_exception(t, "MFTDataPipeline"))
     logger.info(
@@ -631,11 +607,10 @@ async def health():
     ks = get_kill_switch()
 
     newest_cache_entry_age_seconds = None
-    if _mft_pipeline is not None and _mft_pipeline.is_market_hours() and _live_session_cache:
-        now = datetime.now()  # noqa: DTZ005
-        newest_cache_entry_age_seconds = min(
-            (now - updated_at).total_seconds() for _, updated_at in _live_session_cache.values()
-        )
+    if _mft_pipeline is not None and _mft_pipeline.is_market_hours() and _live_cache is not None:
+        cache_age_seconds, _ = _live_cache.ages(datetime.now(), datetime.now(_ET))  # noqa: DTZ005
+        if cache_age_seconds:
+            newest_cache_entry_age_seconds = min(cache_age_seconds.values())
 
     body = {
         "status": "ok" if not dead_tasks else "degraded",
@@ -675,13 +650,9 @@ async def pipeline_status():
 
     now = datetime.now()  # noqa: DTZ005
     now_et = datetime.now(_ET)
-    cache_age_seconds = {
-        ticker: (now - updated_at).total_seconds()
-        for ticker, (_, updated_at) in _live_session_cache.items()
-    }
-    bar_age_seconds = {
-        ticker: _bar_age_seconds(state, now_et) for ticker, (state, _) in _live_session_cache.items()
-    }
+    cache_age_seconds, bar_age_seconds = (
+        _live_cache.ages(now, now_et) if _live_cache is not None else ({}, {})
+    )
 
     return {
         "tracked_tickers": list(_mft_pipeline.tickers),
@@ -763,43 +734,34 @@ async def analyze(req: AnalysisRequest):
     # tracked-universe cap
     _mft_pipeline.register_tickers(req.tickers)
 
-    absent = [t for t in req.tickers if t not in _live_session_cache]
-    if absent:
+    if _live_cache is None:
+        raise HTTPException(503, "Live session cache not yet initialized.")
+
+    # Admission answers only "how old is this" for each ticker; the ordering
+    # against market hours above is what decides whether that age matters
+    # right now (issue #78).
+    admission = _live_cache.admit(req.tickers, datetime.now(), datetime.now(_ET))  # noqa: DTZ005
+
+    if admission.absent:
         raise HTTPException(
             503,
-            f"MFT live cache not yet populated for: {absent}. "
+            f"MFT live cache not yet populated for: {admission.absent}. "
             "The pipeline is warming up — retry after the next sweep (~5 min).",
         )
-
-    now = datetime.now()  # noqa: DTZ005
-    stalled = [
-        t for t in req.tickers
-        if (now - _live_session_cache[t][1]).total_seconds() > session_state_ttl_seconds()
-    ]
-    if stalled:
+    if admission.stalled:
         raise HTTPException(
             503,
-            f"MFT pipeline appears stalled for: {stalled}. "
+            f"MFT pipeline appears stalled for: {admission.stalled}. "
             "The live cache hasn't been refreshed recently — check /pipeline/status.",
         )
-
-    # Catches what a write-time TTL can't: a restart that republishes old candles
-    # under a fresh write timestamp (MFT-1). A timestamp that fails to parse
-    # fails closed as stale rather than raising (API-11).
-    now_et = datetime.now(_ET)
-    max_bar_age = max_bar_age_seconds(_mft_pipeline.interval_minutes)
-    stale = [
-        t for t in req.tickers
-        if (age := _bar_age_seconds(_live_session_cache[t][0], now_et)) is None or age > max_bar_age
-    ]
-    if stale:
+    if admission.stale:
         raise HTTPException(
             503,
-            f"MFT cache data is stale for: {stale}. "
+            f"MFT cache data is stale for: {admission.stale}. "
             "The underlying candles are older than expected — check /pipeline/status.",
         )
 
-    live_states = {t: _live_session_cache[t][0] for t in req.tickers}
+    live_states = admission.admitted
     logger.info("[API] MFT cache hit for all %d tickers", len(live_states))
 
     state = ARGUSState(

--- a/api/main.py
+++ b/api/main.py
@@ -608,7 +608,7 @@ async def health():
 
     newest_cache_entry_age_seconds = None
     if _mft_pipeline is not None and _mft_pipeline.is_market_hours() and _live_cache is not None:
-        cache_age_seconds, _ = _live_cache.ages(datetime.now(), datetime.now(_ET))  # noqa: DTZ005
+        cache_age_seconds, _ = _live_cache.ages(datetime.now(_ET))
         if cache_age_seconds:
             newest_cache_entry_age_seconds = min(cache_age_seconds.values())
 
@@ -648,10 +648,8 @@ async def pipeline_status():
 
     buffer_depth = await asyncio.to_thread(_mft_pipeline.buffer.row_counts)
 
-    now = datetime.now()  # noqa: DTZ005
-    now_et = datetime.now(_ET)
     cache_age_seconds, bar_age_seconds = (
-        _live_cache.ages(now, now_et) if _live_cache is not None else ({}, {})
+        _live_cache.ages(datetime.now(_ET)) if _live_cache is not None else ({}, {})
     )
 
     return {
@@ -740,7 +738,7 @@ async def analyze(req: AnalysisRequest):
     # Admission answers only "how old is this" for each ticker; the ordering
     # against market hours above is what decides whether that age matters
     # right now (issue #78).
-    admission = _live_cache.admit(req.tickers, datetime.now(), datetime.now(_ET))  # noqa: DTZ005
+    admission = _live_cache.admit(req.tickers, datetime.now(_ET))
 
     if admission.absent:
         raise HTTPException(

--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -23,12 +23,13 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any, Optional
 
 from pydantic import ValidationError
 
 from argus.config import settings
+from argus.data.cache import TTLCache
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel, governor
 from argus.schemas.signals import FundamentalSignal, FundamentalVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
@@ -250,60 +251,6 @@ SYSTEM_PROMPT = (
 )
 
 
-class FundamentalCache:
-    """In-memory cache for fundamental signals with a 7-day expiration (TTL).
-
-    Fundamental data changes infrequently; caching avoids redundant LLM calls
-    within a week-long window without meaningfully degrading signal quality.
-
-    Keyed on (ticker, session_seed) rather than ticker alone: two backtest
-    sessions replaying the same ticker on different simulated dates must not
-    serve each other's cached signal, and a live call (session_seed=None)
-    must not be conflated with either.
-    """
-
-    def __init__(self) -> None:
-        """Initializes an empty per-(ticker, session_seed) cache."""
-        self._cache: dict[tuple[str, Optional[int]], tuple[FundamentalSignal, datetime]] = {}
-        self._ttl_days = 7
-
-    def get(self, ticker: str, session_seed: Optional[int] = None) -> Optional[FundamentalSignal]:
-        """Returns a cached signal if it exists and has not exceeded the TTL.
-
-        Args:
-            ticker: Equity ticker symbol.
-            session_seed: Session scope the signal was cached under.
-
-        Returns:
-            Cached FundamentalSignal, or None if absent or expired.
-        """
-        key = (ticker, session_seed)
-        if key in self._cache:
-            signal, cached_at = self._cache[key]
-            if (datetime.now() - cached_at).days < self._ttl_days:  # noqa: DTZ005
-                return signal
-        return None
-
-    def set(self, ticker: str, signal: FundamentalSignal, session_seed: Optional[int] = None) -> None:
-        """Stores a fundamental signal coupled with the current timestamp.
-
-        Args:
-            ticker: Equity ticker symbol.
-            signal: Validated FundamentalSignal to cache.
-            session_seed: Session scope to cache the signal under.
-        """
-        self._cache[(ticker, session_seed)] = (signal, datetime.now())  # noqa: DTZ005
-
-    def is_stale(self, ticker: str, session_seed: Optional[int] = None) -> bool:
-        """Returns True if the (ticker, session_seed) has no valid cached signal.
-
-        Args:
-            ticker: Equity ticker symbol.
-            session_seed: Session scope to check.
-        """
-        return self.get(ticker, session_seed) is None
-
-
 class FundamentalAgent:
     """Agent coordinating LLM valuation and economic moat auditing.
 
@@ -342,7 +289,12 @@ class FundamentalAgent:
             )
         self.llm_client = llm_client
         self.market_data = market_data or LiveMarketDataProvider()
-        self.cache = FundamentalCache()
+        # Keyed on (ticker, session_seed): two backtest sessions replaying the same
+        # ticker on different simulated dates must not serve each other's cached
+        # signal, and a live call (session_seed=None) must not be conflated with either
+        self.cache: TTLCache[tuple[str, Optional[int]], FundamentalSignal] = TTLCache(
+            ttl=timedelta(days=7)
+        )
 
     def analyze(
         self,
@@ -369,11 +321,10 @@ class FundamentalAgent:
         Returns:
             A validated FundamentalSignal, or None if decoding ultimately fails.
         """
-        if not self.cache.is_stale(ticker, session_seed):
-            cached = self.cache.get(ticker, session_seed)
-            if cached:
-                logger.debug("FundamentalAgent.analyze: Cache hit for %s", ticker)
-                return cached
+        cached = self.cache.get((ticker, session_seed))
+        if cached:
+            logger.debug("FundamentalAgent.analyze: Cache hit for %s", ticker)
+            return cached
 
         capacity_reserve = max(1, int(settings.ARGUS_GROQ_RPM * _CAPACITY_RESERVE_FRACTION))
         if governor.get_remaining_capacity(settings.ARGUS_FUNDAMENTAL_MODEL) < capacity_reserve:
@@ -453,7 +404,7 @@ class FundamentalAgent:
                 errors.append(f"fundamental_analysis[{ticker}]: measured data failed validation: {e}")
             return None
 
-        self.cache.set(ticker, signal, session_seed)
+        self.cache.set((ticker, session_seed), signal)
         logger.debug(
             "[Fundamental] Analysis complete for %s -> %s", ticker, signal.signal.value
         )

--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -30,6 +30,7 @@ from pydantic import ValidationError
 
 from argus.config import settings
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel, governor
+from argus.schemas.prompting import field_list
 from argus.schemas.signals import FundamentalSignal, FundamentalVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
 from argus.structured_output import StructuredOutputError, decode
@@ -52,17 +53,6 @@ _SECTOR_PE_MEDIANS: dict[str, float] = {
     "Basic Materials": 16.0,
 }
 _DEFAULT_PE_MEDIAN = 20.0
-
-# Field descriptions for the prompt's "Fields required" line, keyed by the
-# same names as FundamentalVerdict's schema — a drift test (test_fundamental.py)
-# asserts the two stay equal, so a schema change that isn't mirrored here fails
-# loudly instead of leaving the prompt asking for fields the model can't supply.
-_VERDICT_FIELD_DESCRIPTIONS: dict[str, str] = {
-    "signal": "signal (string)",
-    "conviction": "conviction (float 0.0–1.0)",
-    "moat_score": "moat_score (int 1–10)",
-    "reasoning": "reasoning (string ≤80 words, no markdown)",
-}
 
 # Fraction of the configured per-minute request budget held back before a
 # ticker's fundamental analysis is even attempted, so the same-model portfolio
@@ -207,7 +197,7 @@ def build_compact_prompt(ticker: str, pit_data: dict, anon_id: Optional[str] = N
         "(3) null fields do not drive the primary signal.\n"
         "\n"
         "Output ONLY a valid JSON object — no markdown, no preamble, no trailing text.\n"
-        "Fields required: " + ", ".join(_VERDICT_FIELD_DESCRIPTIONS.values()) + "."
+        "Fields required: " + field_list(FundamentalVerdict) + "."
     )
     return prompt.strip()
 

--- a/argus/agents/fundamental.py
+++ b/argus/agents/fundamental.py
@@ -29,7 +29,7 @@ from typing import Any, Optional
 from pydantic import ValidationError
 
 from argus.config import settings
-from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel, governor
+from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
 from argus.schemas.signals import FundamentalSignal, FundamentalVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
 from argus.structured_output import StructuredOutputError, decode
@@ -309,8 +309,9 @@ class FundamentalAgent:
 
     Uses an injected LLMClient (Groq by default) to construct structured
     investment theses from ratio payloads fetched via an injected
-    MarketDataProvider, applying local caches, governor rate limits, and the
-    shared structured-output decoder's parse/validate/retry (with repair).
+    MarketDataProvider, applying local caches, the client's remaining-capacity
+    reserve, and the shared structured-output decoder's parse/validate/retry
+    (with repair).
     """
 
     def __init__(
@@ -353,9 +354,10 @@ class FundamentalAgent:
     ) -> Optional[FundamentalSignal]:
         """Audits fundamentals for a single ticker and returns a validated Pydantic signal.
 
-        Checks the local cache first, enforces governor capacity, fetches current
-        financial ratios, and decodes a FundamentalVerdict from the LLM via
-        argus.structured_output.decode (with repair enabled).
+        Checks the local cache first, enforces the injected LLM client's
+        remaining capacity, fetches current financial ratios, and decodes a
+        FundamentalVerdict from the LLM via argus.structured_output.decode
+        (with repair enabled).
 
         Args:
             ticker: Equity ticker symbol.
@@ -376,12 +378,12 @@ class FundamentalAgent:
                 return cached
 
         capacity_reserve = max(1, int(settings.ARGUS_GROQ_RPM * _CAPACITY_RESERVE_FRACTION))
-        if governor.get_remaining_capacity(settings.ARGUS_FUNDAMENTAL_MODEL) < capacity_reserve:
+        if self.llm_client.remaining_capacity() < capacity_reserve:
             logger.warning(
                 "[Fundamental] Low capacity for %s, skipping %s", settings.ARGUS_FUNDAMENTAL_MODEL, ticker
             )
             if errors is not None:
-                errors.append(f"fundamental_analysis[{ticker}]: governor capacity too low, skipped")
+                errors.append(f"fundamental_analysis[{ticker}]: LLM capacity too low, skipped")
             return None
 
         try:

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -25,15 +25,16 @@ import json
 import logging
 import time
 from datetime import datetime
-from typing import Optional, TypeGuard
+from typing import Optional
 from uuid import uuid4
 
 import numpy as np
 
 from argus.config import settings
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
+from argus.orchestration.state import TickerSnapshot
 from argus.params import PORTFOLIO
-from argus.schemas.signals import MacroContext, PortfolioAllocation, RiskAssessment, RiskVerdict, Signal
+from argus.schemas.signals import MacroContext, PortfolioAllocation, Signal
 from argus.seams import GroqLLMClient, LLMClient
 
 logger = logging.getLogger("argus.portfolio")
@@ -70,20 +71,7 @@ def half_kelly_weight(
     return float(np.clip(half_kelly, 0.0, max_position))
 
 
-def _is_risk_approved(risk: Optional[RiskAssessment]) -> TypeGuard[RiskAssessment]:
-    """Whether a ticker's risk verdict permits an equity allocation.
-
-    Args:
-        risk: The ticker's RiskAssessment, or None if the risk node never evaluated it.
-
-    Returns:
-        True for APPROVE or REDUCE; False for VETO or a missing assessment. Shared
-        by the prompt table and post-LLM enforcement so the two cannot drift.
-    """
-    return risk is not None and risk.verdict in (RiskVerdict.APPROVE, RiskVerdict.REDUCE)
-
-
-def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContext]) -> str:
+def build_signal_table(snapshots: dict[str, TickerSnapshot], macro: Optional[MacroContext]) -> str:
     """Constructs a consolidated prompt table mapping approved specialist signal values.
 
     Only includes tickers with APPROVE or REDUCE risk verdicts. Signal values are
@@ -91,10 +79,10 @@ def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContex
     hallucination on missing or None data fields.
 
     Args:
-        all_signals: Mapping of ticker → dict of signal objects keyed by agent name.
+        snapshots: Mapping of ticker → TickerSnapshot.
         macro: Current macroeconomic context used for the table header, or None
             when MacroStatisticalAgent's data source was unavailable this session —
-            the specialist signals in all_signals don't depend on it (see
+            the specialist signals in snapshots don't depend on it (see
             orchestration/graph.py's topology).
 
     Returns:
@@ -111,15 +99,16 @@ def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContex
         lines.append("MACRO: unavailable this session (data source failure) — allocate on specialist signals alone")
     lines.append("")
 
-    for ticker, sigs in all_signals.items():
-        risk = sigs.get("risk")
-        if not _is_risk_approved(risk):
+    for ticker, snap in snapshots.items():
+        if not snap.risk_approved:
             continue
+        risk = snap.risk
+        assert risk is not None  # risk_approved guarantees this
 
-        f = sigs.get("fundamental")
-        t = sigs.get("technical")
-        s = sigs.get("sentiment")
-        agg = sigs.get("aggregated")
+        f = snap.fundamental
+        t = snap.technical
+        s = snap.sentiment
+        agg = snap.aggregated
 
         fsig = f"{f.signal.value}({f.conviction:.2f})" if f else "N/A"
         tsig = f"{t.signal.value}({t.conviction:.2f})" if t else "N/A"
@@ -213,7 +202,7 @@ class PortfolioManagerAgent:
     def allocate(
         self,
         user_profile: dict,
-        all_signals: dict[str, dict],
+        snapshots: dict[str, TickerSnapshot],
         macro: Optional[MacroContext],
         cultural_wisdom: Optional[list[str]] = None,
         cultural_warnings: Optional[list[str]] = None,
@@ -229,7 +218,7 @@ class PortfolioManagerAgent:
 
         Args:
             user_profile: Dict with keys ``total_wealth``, ``invest_pct``, ``risk_tolerance``.
-            all_signals: Mapping of ticker → dict of signal objects keyed by agent name.
+            snapshots: Mapping of ticker → TickerSnapshot.
             macro: Current macroeconomic context, or None when it was unavailable
                 this session — allocation proceeds on the specialist signals alone.
             cultural_wisdom: Optional list of historical wisdom strings from cultural memory.
@@ -260,7 +249,7 @@ class PortfolioManagerAgent:
         # LLM against this base, not twice
         investable = float(total_wealth) if total_wealth is not None else 0.0
 
-        approved_tickers = [t for t, s in all_signals.items() if _is_risk_approved(s.get("risk"))]
+        approved_tickers = [t for t, s in snapshots.items() if s.risk_approved]
 
         if not approved_tickers:
             logger.debug("[Portfolio] No approved tickers. Reverting to all-cash.")
@@ -271,11 +260,11 @@ class PortfolioManagerAgent:
         # ceiling (rather than raw invest_pct) in the prompt keeps ALLOCATION RULE 3's target
         # reachable instead of silently unmeetable for a small approved universe.
         invest_pct = float(user_profile.get("invest_pct", 1.0))
-        approved_cap_sum = sum(
-            all_signals[t]["risk"].approved_weight
-            for t in approved_tickers
-            if all_signals[t].get("risk")
-        )
+        approved_cap_sum = 0.0
+        for t in approved_tickers:
+            risk = snapshots[t].risk
+            assert risk is not None  # approved_tickers is filtered by risk_approved
+            approved_cap_sum += risk.approved_weight
         deployment_ceiling = min(invest_pct, approved_cap_sum)
 
         # Compute Half-Kelly baselines to anchor the LLM's sizing distribution, using
@@ -288,7 +277,7 @@ class PortfolioManagerAgent:
         # all without re-querying cultural memory.
         reliability_n: dict[str, int] = {}
         for ticker in approved_tickers:
-            agg = all_signals[ticker].get("aggregated")
+            agg = snapshots[ticker].aggregated
             if agg and agg.reliability_n:
                 reliability_n = agg.reliability_n
                 break
@@ -297,19 +286,19 @@ class PortfolioManagerAgent:
         kelly_suggestions = {}
         if have_accuracy_data:
             for ticker in approved_tickers:
-                agg = all_signals[ticker].get("aggregated")
-                risk_signal = all_signals[ticker].get("risk")
+                agg = snapshots[ticker].aggregated
+                risk_signal = snapshots[ticker].risk
                 max_pos = risk_signal.approved_weight if risk_signal else self.max_position_pct
                 # Anchors are for NEUTRAL/BULLISH sizing only (matches the prompt text below)
                 if not agg or agg.signal == Signal.BEARISH or not agg.weighted_votes:
                     continue
-                driver = max(agg.weighted_votes, key=agg.weighted_votes.get)
+                driver = max(agg.weighted_votes, key=lambda k: agg.weighted_votes[k])
                 win_prob = agg.reliability.get(driver, 0.5)
                 kelly_suggestions[ticker] = half_kelly_weight(
                     win_probability=win_prob, max_position=max_pos
                 )
 
-        signal_table = build_signal_table(all_signals, macro)
+        signal_table = build_signal_table(snapshots, macro)
         wisdom_text = "\n".join(f"- {w}" for w in (cultural_wisdom or [])[:3])
         warnings_text = "\n".join(f"- {w}" for w in (cultural_warnings or [])[:3])
         if kelly_suggestions:
@@ -397,7 +386,7 @@ class PortfolioManagerAgent:
                 enforced_portfolio = []
                 for pos in data.get("portfolio", []):
                     ticker = pos["ticker"]
-                    if ticker not in all_signals:
+                    if ticker not in snapshots:
                         msg = (
                             f"portfolio_allocation: dropped {ticker} "
                             "(not in this session's signal universe)"
@@ -407,9 +396,10 @@ class PortfolioManagerAgent:
                             adjustments.append(msg)
                         continue
 
-                    risk = all_signals[ticker].get("risk")
+                    snap = snapshots[ticker]
+                    risk = snap.risk
                     proposed_pct = pos.get("allocation_pct", 0.0)
-                    if not _is_risk_approved(risk):
+                    if not snap.risk_approved:
                         if proposed_pct:
                             verdict = risk.verdict.value if risk else "MISSING"
                             msg = (
@@ -421,6 +411,7 @@ class PortfolioManagerAgent:
                                 adjustments.append(msg)
                         pos["allocation_pct"] = 0.0
                     else:
+                        assert risk is not None  # snap.risk_approved guarantees this
                         cap = risk.approved_weight
                         if proposed_pct > cap + 1e-9:
                             msg = (

--- a/argus/agents/portfolio.py
+++ b/argus/agents/portfolio.py
@@ -31,6 +31,7 @@ import numpy as np
 from argus.config import settings
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
 from argus.params import PORTFOLIO
+from argus.schemas.prompting import schema_block
 from argus.schemas.signals import (
     MacroContext,
     PortfolioAllocation,
@@ -143,33 +144,9 @@ def build_signal_table(all_signals: dict[str, dict], macro: Optional[MacroContex
     return "\n".join(lines)
 
 
-# Field descriptions for the prompt's declared output schema, keyed by the same
-# names as ProposedPosition's and PortfolioProposal's schemas — a drift test
-# (test_portfolio_enforcement.py) asserts the two stay equal, so a schema change
-# that isn't mirrored here fails loudly instead of leaving the prompt asking for
-# fields the model can't supply.
-_POSITION_FIELD_DESCRIPTIONS: dict[str, str] = {
-    "ticker": '""',
-    "allocation_pct": "0.0",
-    "stop_loss": "0.0",
-    "target_price": "null",
-    "thesis": '"<≤20 words>"',
-    "advisor_note": '"2–4 professional sentences: rationale, key risks, what to monitor"',
-    "composite_conviction": "0.0",
-    "time_horizon": '"3-6 months"',
-}
-_PROPOSAL_FIELD_DESCRIPTIONS: dict[str, str] = {
-    "cash_reserve_pct": "0.0",
-    "rebalance_trigger": '"MONTHLY"',
-}
-_POSITION_SCHEMA_JSON = (
-    "{" + ",".join(f'"{k}":{v}' for k, v in _POSITION_FIELD_DESCRIPTIONS.items()) + "}"
-)
-_PROPOSAL_SCHEMA_JSON = (
-    '{"portfolio":[' + _POSITION_SCHEMA_JSON + "],"
-    + ",".join(f'"{k}":{v}' for k, v in _PROPOSAL_FIELD_DESCRIPTIONS.items())
-    + "}"
-)
+# Rendered from PortfolioProposal's own PromptText markers, recursing into
+# ProposedPosition for the nested "portfolio" list.
+_PROPOSAL_SCHEMA_JSON = schema_block(PortfolioProposal)
 
 
 SYSTEM_PROMPT = (

--- a/argus/agents/sentiment.py
+++ b/argus/agents/sentiment.py
@@ -24,13 +24,14 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional
 
 import numpy as np
 
 from argus.config import settings
 from argus.data import fetchers
+from argus.data.cache import TTLCache
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
 from argus.schemas.signals import SentimentSignal, SentimentVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
@@ -183,51 +184,6 @@ def aggregate_finbert_scores(scored: list[dict], decay_rate: float = 0.95) -> di
         "pct_neg": round(pct_neg, 3),
         "confidence": round(confidence, 3),
     }
-
-
-class SentimentDailyCache:
-    """In-memory per-ticker cache for SentimentSignals with a 1-day TTL.
-
-    Avoids redundant FinBERT inference and LLM calls for the same ticker
-    within a single trading session.
-    """
-
-    def __init__(self) -> None:
-        """Initializes an empty per-ticker cache."""
-        self._cache: dict[str, tuple[SentimentSignal, datetime]] = {}
-        self._ttl_days = 1
-
-    def get(self, ticker: str) -> Optional[SentimentSignal]:
-        """Returns a cached signal if it exists and is within the TTL window.
-
-        Args:
-            ticker: Equity ticker symbol.
-
-        Returns:
-            Cached SentimentSignal, or None if absent or stale.
-        """
-        if ticker in self._cache:
-            signal, cached_at = self._cache[ticker]
-            if (datetime.now() - cached_at).total_seconds() < self._ttl_days * 86400:  # noqa: DTZ005
-                return signal
-        return None
-
-    def set(self, ticker: str, signal: SentimentSignal) -> None:
-        """Stores a signal with the current timestamp.
-
-        Args:
-            ticker: Equity ticker symbol.
-            signal: Validated SentimentSignal to cache.
-        """
-        self._cache[ticker] = (signal, datetime.now())  # noqa: DTZ005
-
-    def is_stale(self, ticker: str) -> bool:
-        """Returns True if the ticker has no valid cached signal.
-
-        Args:
-            ticker: Equity ticker symbol.
-        """
-        return self.get(ticker) is None
 
 
 def _check_earnings_calendar(ticker: str) -> bool:
@@ -412,7 +368,7 @@ class SentimentAgent:
             )
         self.llm_client = llm_client
         self.market_data = market_data or LiveMarketDataProvider()
-        self.cache = SentimentDailyCache()
+        self.cache: TTLCache[str, SentimentSignal] = TTLCache(ttl=timedelta(days=1))
 
     def analyze(
         self,
@@ -439,10 +395,9 @@ class SentimentAgent:
         Returns:
             A validated SentimentSignal, or None if decoding ultimately fails.
         """
-        if not self.cache.is_stale(ticker):
-            cached = self.cache.get(ticker)
-            if cached:
-                return cached
+        cached = self.cache.get(ticker)
+        if cached:
+            return cached
 
         try:
             news = self.market_data.news(ticker, company_name or ticker, days_back=7)

--- a/argus/agents/sentiment.py
+++ b/argus/agents/sentiment.py
@@ -32,6 +32,7 @@ import numpy as np
 from argus.config import settings
 from argus.data import fetchers
 from argus.orchestration.governor import RateLimitExceeded, UnregisteredModel
+from argus.schemas.prompting import schema_block
 from argus.schemas.signals import SentimentSignal, SentimentVerdict
 from argus.seams import GroqLLMClient, LiveMarketDataProvider, LLMClient, MarketDataProvider
 from argus.structured_output import StructuredOutputError, decode
@@ -283,21 +284,10 @@ _SENTIMENT_METRIC_LABELS: dict[str, str] = {
 }
 
 
-# Field descriptions for the prompt's declared output schema, keyed by the same
-# names as SentimentVerdict's schema — a drift test (test_sentiment.py) asserts
-# the two stay equal, so a schema change that isn't mirrored here fails loudly
-# instead of leaving the prompt asking for fields the model can't supply. Shared
-# between _build_synthesis_prompt and SYSTEM_PROMPT so their two schema restatements
-# can't drift apart from each other either.
-_VERDICT_FIELD_DESCRIPTIONS: dict[str, str] = {
-    "signal": '"BULLISH|BEARISH|NEUTRAL"',
-    "conviction": "<float 0.0–1.0>",
-    "sentiment_decay_risk": '"LOW|MEDIUM|HIGH"',
-    "reasoning": '"<≤60 words citing the primary driver>"',
-}
-_VERDICT_SCHEMA_JSON = (
-    "{" + ", ".join(f'"{k}": {v}' for k, v in _VERDICT_FIELD_DESCRIPTIONS.items()) + "}"
-)
+# Rendered from SentimentVerdict's own PromptText markers, shared between
+# _build_synthesis_prompt and SYSTEM_PROMPT so their two schema restatements
+# can't drift apart from each other or from the schema itself.
+_VERDICT_SCHEMA_JSON = schema_block(SentimentVerdict)
 
 
 def _build_synthesis_prompt(ticker: str, metrics: dict) -> str:

--- a/argus/data/__init__.py
+++ b/argus/data/__init__.py
@@ -1,1 +1,1 @@
-"""Data sub-package for ARGUS. Exports fetchers, pipeline, and cache utilities."""
+"""Data sub-package for ARGUS. Exports fetchers, pipeline, cache, and live session cache utilities."""

--- a/argus/data/cache.py
+++ b/argus/data/cache.py
@@ -1,13 +1,16 @@
 """
 argus/data/cache.py
 
-SQLite-backed caches for OHLCV price candles: a rolling intraday buffer and a
-per-trading-day cache for daily bars.
+SQLite-backed caches for OHLCV price candles — a rolling intraday buffer and a
+per-trading-day cache for daily bars — plus a generic in-memory TTL cache for
+agents that only need to dedupe within a process lifetime.
 
 Responsibilities:
   - Buffer rolling intraday OHLCV candles with a configurable max-rows limit
   - Cache daily OHLCV bars keyed by (ticker, trading_date), so a ticker
     refreshed earlier the same UTC day is served from disk rather than refetched
+  - Provide a generic in-memory time-to-live cache, keyed and windowed by the
+    caller, for agent-level result caches that don't need to survive a restart
 
 Not responsible for:
   - Fetching raw data (see data/fetchers.py)
@@ -26,13 +29,66 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Generic, Hashable, Optional, TypeVar
 
 import pandas as pd
 
 logger = logging.getLogger("argus.cache")
+
+_K = TypeVar("_K", bound=Hashable)
+_V = TypeVar("_V")
+
+
+class TTLCache(Generic[_K, _V]):
+    """Generic in-memory cache whose entries expire after a fixed time window.
+
+    Callers supply their own key type and expiry window at construction — the
+    fundamental and sentiment agents each keep one of these rather than a
+    bespoke cache class (see argus/agents/fundamental.py and
+    argus/agents/sentiment.py).
+    """
+
+    def __init__(self, ttl: timedelta, clock: Callable[[], datetime] = datetime.now) -> None:
+        """Initializes an empty cache.
+
+        Args:
+            ttl: Age at which a stored entry stops being returned.
+            clock: Returns the current time; defaults to wall-clock time.
+                Overridable so expiry can be tested at its boundary instead of
+                waiting for `ttl` to actually elapse.
+        """
+        self._ttl = ttl
+        self._clock = clock
+        self._entries: dict[_K, tuple[_V, datetime]] = {}
+
+    def get(self, key: _K) -> Optional[_V]:
+        """Returns the cached value for key, or None if absent or expired.
+
+        Args:
+            key: Cache key.
+
+        Returns:
+            The cached value, or None.
+        """
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        value, cached_at = entry
+        if self._clock() - cached_at >= self._ttl:
+            return None
+        return value
+
+    def set(self, key: _K, value: _V) -> None:
+        """Stores value under key, timestamped at the current clock time.
+
+        Args:
+            key: Cache key.
+            value: Value to store.
+        """
+        self._entries[key] = (value, self._clock())
+
 
 _ET = "America/New_York"
 

--- a/argus/data/live_session_cache.py
+++ b/argus/data/live_session_cache.py
@@ -27,11 +27,11 @@ Not responsible for:
     argus.schemas.signals.missing_session_state_keys)
 
 Publication and admission both measure age against one timezone-aware
-America/New_York clock. Publication used to stamp entries with naive local
-time while admission measured bar age against ET — two clocks that happened
-to agree only because this deployment already ran in ET, the same class of
-latent bug GLOSSARY.md and this module's sibling docs already call out
-elsewhere in the freshness path.
+America/New_York clock, via `datetime.timestamp()` rather than plain
+subtraction — two aware datetimes sharing the same ZoneInfo instance (as
+every clock read here does) compare their naive wall-clock fields instead of
+real elapsed time, which is wrong by exactly the DST offset across a
+transition.
 
 Dependencies:
   - argus.data.pipeline (_FETCH_INTERVAL, the sweep cadence both thresholds
@@ -191,7 +191,10 @@ class LiveSessionCache:
                 continue
 
             state, published_at = entry
-            if (now - published_at).total_seconds() > ttl:
+            # now and published_at share the same ZoneInfo instance, so plain
+            # subtraction would compare wall-clock fields and drift by an hour
+            # across a DST transition; timestamp() avoids that
+            if (now.timestamp() - published_at.timestamp()) > ttl:
                 result.stalled.append(ticker)
                 continue
 
@@ -221,8 +224,9 @@ class LiveSessionCache:
             ticker -> seconds; bar_age_seconds values are None where the
             entry's timestamp can't be parsed.
         """
+        # timestamp(), not subtraction — see admit()
         cache_age_seconds = {
-            ticker: (now - published_at).total_seconds()
+            ticker: now.timestamp() - published_at.timestamp()
             for ticker, (_, published_at) in self._states.items()
         }
         bar_age_seconds = {

--- a/argus/data/live_session_cache.py
+++ b/argus/data/live_session_cache.py
@@ -26,6 +26,13 @@ Not responsible for:
     by the pipeline's compress_all (see
     argus.schemas.signals.missing_session_state_keys)
 
+Publication and admission both measure age against one timezone-aware
+America/New_York clock. Publication used to stamp entries with naive local
+time while admission measured bar age against ET — two clocks that happened
+to agree only because this deployment already ran in ET, the same class of
+latent bug GLOSSARY.md and this module's sibling docs already call out
+elsewhere in the freshness path.
+
 Dependencies:
   - argus.data.pipeline (_FETCH_INTERVAL, the sweep cadence both thresholds
     below are built from)
@@ -38,9 +45,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from argus.data.pipeline import _FETCH_INTERVAL
 from argus.params import SYSTEM
+
+_ET = ZoneInfo("America/New_York")
 
 
 def session_state_ttl_seconds() -> int:
@@ -144,10 +154,11 @@ class LiveSessionCache:
                 absent from `session_states` — a repeated call with a
                 shrinking universe is what actually evicts a dropped ticker.
             now: Publication timestamp to stamp every entry with. Defaults
-                to the current local time; tests pass an explicit value to
-                control write age without reaching into private state.
+                to the current ET-aware time — the same clock admit()/ages()
+                measure against; tests pass an explicit value to control
+                write age without reaching into private state.
         """
-        published_at = now if now is not None else datetime.now()  # noqa: DTZ005
+        published_at = now if now is not None else datetime.now(_ET)
         for ticker, state in session_states.items():
             self._states[ticker] = (state, published_at)
 
@@ -156,16 +167,14 @@ class LiveSessionCache:
             if ticker not in tracked:
                 del self._states[ticker]
 
-    def admit(self, tickers: Iterable[str], now: datetime, now_et: datetime) -> AdmissionResult:
+    def admit(self, tickers: Iterable[str], now: datetime) -> AdmissionResult:
         """Determines which of the requested tickers may be allocated against right now.
 
         Args:
             tickers: Tickers to check.
-            now: Current local time, matching the clock `publish` stamped
-                entries with, to measure publication age against
-                session_state_ttl_seconds.
-            now_et: Current time, ET-aware, to measure each entry's own bar
-                age against max_bar_age_seconds.
+            now: Current time, ET-aware — the one clock both publication age
+                (against session_state_ttl_seconds) and bar age (against
+                max_bar_age_seconds) are measured against.
 
         Returns:
             An AdmissionResult with every ticker sorted into exactly one of
@@ -186,7 +195,7 @@ class LiveSessionCache:
                 result.stalled.append(ticker)
                 continue
 
-            age = _bar_age_seconds(state, now_et)
+            age = _bar_age_seconds(state, now)
             if age is None or age > max_bar_age:
                 result.stale.append(ticker)
                 continue
@@ -195,9 +204,7 @@ class LiveSessionCache:
 
         return result
 
-    def ages(
-        self, now: datetime, now_et: datetime
-    ) -> tuple[dict[str, float], dict[str, Optional[float]]]:
+    def ages(self, now: datetime) -> tuple[dict[str, float], dict[str, Optional[float]]]:
         """Reports per-ticker publication age and bar age for everything held.
 
         A different question from admit(): this answers "how old is X" for
@@ -206,9 +213,8 @@ class LiveSessionCache:
         rejecting requests.
 
         Args:
-            now: Current local time, matching the clock `publish` stamped
+            now: Current time, ET-aware — the same clock `publish` stamps
                 entries with.
-            now_et: Current time, ET-aware.
 
         Returns:
             Tuple of (cache_age_seconds, bar_age_seconds), each a mapping of
@@ -220,6 +226,6 @@ class LiveSessionCache:
             for ticker, (_, published_at) in self._states.items()
         }
         bar_age_seconds = {
-            ticker: _bar_age_seconds(state, now_et) for ticker, (state, _) in self._states.items()
+            ticker: _bar_age_seconds(state, now) for ticker, (state, _) in self._states.items()
         }
         return cache_age_seconds, bar_age_seconds

--- a/argus/data/live_session_cache.py
+++ b/argus/data/live_session_cache.py
@@ -1,0 +1,225 @@
+"""
+argus/data/live_session_cache.py
+
+The live session cache: the named seam between the MFT pipeline that
+produces per-ticker session states and the API gateway that allocates
+against them. Owns publication, eviction, admission, and age reporting for
+the freshness rule an /analyze request must clear before a cached session
+state can be used (issue #78).
+
+Responsibilities:
+  - Publish a sweep's compressed session states, evicting entries for
+    tickers no longer in the caller's tracked universe
+  - Admit a requested set of tickers against an explicit clock, sorting
+    rejections into absent / stalled / stale so a caller can report each
+    distinctly
+  - Report per-ticker publication and bar age for everything held, for a
+    status endpoint that needs numbers rather than a pass/fail verdict
+  - Own the two freshness thresholds (session_state_ttl_seconds,
+    max_bar_age_seconds) beside the rule that applies them
+
+Not responsible for:
+  - Market hours — a property of the market, not of this cache's own data;
+    stays a route concern (see api/main.py)
+  - Fetching, buffering, or compressing candles (see argus/data/pipeline.py)
+  - Re-validating session-state readiness at publish time — enforced once,
+    by the pipeline's compress_all (see
+    argus.schemas.signals.missing_session_state_keys)
+
+Dependencies:
+  - argus.data.pipeline (_FETCH_INTERVAL, the sweep cadence both thresholds
+    below are built from)
+  - argus.params (SYSTEM.freshness_margin_seconds)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from argus.data.pipeline import _FETCH_INTERVAL
+from argus.params import SYSTEM
+
+
+def session_state_ttl_seconds() -> int:
+    """Derives how old a cache entry's publication time may be before admit() treats it as stalled.
+
+    Returns:
+        Budget in seconds: two fetch sweeps — tolerating one missed sweep
+        before an entry counts as stalled — plus a fixed jitter margin.
+    """
+    return 2 * _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
+
+
+def max_bar_age_seconds(interval_minutes: int) -> int:
+    """Derives how old a session state's own bar timestamp may be before admit() treats it as stale.
+
+    Distinct from session_state_ttl_seconds: that budget catches an entry
+    that stopped being refreshed, this one catches a fresh publish that
+    republishes an old bar (e.g. a restart replaying the persistent buffer).
+
+    Args:
+        interval_minutes: Native candle resolution in minutes.
+
+    Returns:
+        Budget in seconds: one fetch sweep plus two candle intervals plus a
+        fixed jitter margin.
+    """
+    return _FETCH_INTERVAL + 2 * interval_minutes * 60 + SYSTEM.freshness_margin_seconds
+
+
+def _bar_age_seconds(state: dict, now_et: datetime) -> Optional[float]:
+    """Computes a session state's bar age in seconds, failing closed on a bad timestamp (API-11).
+
+    A missing, malformed, or naive ``timestamp`` must not raise out of
+    admit() or ages() — it's treated as staleness instead.
+
+    Args:
+        state: A compressed technical feature dict.
+        now_et: Current time, ET-aware, to measure age against.
+
+    Returns:
+        Age in seconds, or None if ``timestamp`` can't be parsed against `now_et`.
+    """
+    try:
+        return (now_et - datetime.fromisoformat(state["timestamp"])).total_seconds()
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+@dataclass
+class AdmissionResult:
+    """Outcome of one LiveSessionCache.admit() call.
+
+    Rejections are sorted into three lists rather than a single verdict:
+    each means something operationally different (warming up vs. pipeline
+    stalled vs. stale candles after a restart), and a caller building a
+    response for each needs the grouping, not just a reason string.
+    """
+
+    admitted: dict[str, dict] = field(default_factory=dict)
+    absent: list[str] = field(default_factory=list)
+    stalled: list[str] = field(default_factory=list)
+    stale: list[str] = field(default_factory=list)
+
+
+class LiveSessionCache:
+    """Publication, eviction, admission, and age reporting for MFT session states (issue #78).
+
+    Constructed once at startup and held in one module global by its
+    caller. Holds no pipeline reference of its own — publish() takes the
+    tracked universe as a plain argument, so eviction can be tested without
+    a stand-in pipeline object.
+    """
+
+    def __init__(self, interval_minutes: int) -> None:
+        """Creates an empty cache sized for the given candle resolution.
+
+        Args:
+            interval_minutes: Native candle resolution the tracked pipeline
+                fetches at, used to size the max-bar-age threshold.
+        """
+        self._interval_minutes = interval_minutes
+        self._states: dict[str, tuple[dict, datetime]] = {}
+
+    def __len__(self) -> int:
+        """Count of tickers currently held."""
+        return len(self._states)
+
+    def publish(
+        self,
+        session_states: dict[str, dict],
+        tracked_universe: Iterable[str],
+        now: Optional[datetime] = None,
+    ) -> None:
+        """Stores one sweep's compressed session states and evicts untracked tickers.
+
+        Args:
+            session_states: Mapping of ticker -> compressed technical feature
+                dict, e.g. from MFTDataPipeline.compress_all().
+            tracked_universe: The caller's full current tracked-ticker set.
+                Every held ticker outside this set is dropped, not just ones
+                absent from `session_states` — a repeated call with a
+                shrinking universe is what actually evicts a dropped ticker.
+            now: Publication timestamp to stamp every entry with. Defaults
+                to the current local time; tests pass an explicit value to
+                control write age without reaching into private state.
+        """
+        published_at = now if now is not None else datetime.now()  # noqa: DTZ005
+        for ticker, state in session_states.items():
+            self._states[ticker] = (state, published_at)
+
+        tracked = set(tracked_universe)
+        for ticker in list(self._states):
+            if ticker not in tracked:
+                del self._states[ticker]
+
+    def admit(self, tickers: Iterable[str], now: datetime, now_et: datetime) -> AdmissionResult:
+        """Determines which of the requested tickers may be allocated against right now.
+
+        Args:
+            tickers: Tickers to check.
+            now: Current local time, matching the clock `publish` stamped
+                entries with, to measure publication age against
+                session_state_ttl_seconds.
+            now_et: Current time, ET-aware, to measure each entry's own bar
+                age against max_bar_age_seconds.
+
+        Returns:
+            An AdmissionResult with every ticker sorted into exactly one of
+            `admitted`, `absent`, `stalled`, or `stale`.
+        """
+        result = AdmissionResult()
+        ttl = session_state_ttl_seconds()
+        max_bar_age = max_bar_age_seconds(self._interval_minutes)
+
+        for ticker in tickers:
+            entry = self._states.get(ticker)
+            if entry is None:
+                result.absent.append(ticker)
+                continue
+
+            state, published_at = entry
+            if (now - published_at).total_seconds() > ttl:
+                result.stalled.append(ticker)
+                continue
+
+            age = _bar_age_seconds(state, now_et)
+            if age is None or age > max_bar_age:
+                result.stale.append(ticker)
+                continue
+
+            result.admitted[ticker] = state
+
+        return result
+
+    def ages(
+        self, now: datetime, now_et: datetime
+    ) -> tuple[dict[str, float], dict[str, Optional[float]]]:
+        """Reports per-ticker publication age and bar age for everything held.
+
+        A different question from admit(): this answers "how old is X" for
+        every cached ticker regardless of whether it would pass admission,
+        for a status endpoint watching freshness degrade before it starts
+        rejecting requests.
+
+        Args:
+            now: Current local time, matching the clock `publish` stamped
+                entries with.
+            now_et: Current time, ET-aware.
+
+        Returns:
+            Tuple of (cache_age_seconds, bar_age_seconds), each a mapping of
+            ticker -> seconds; bar_age_seconds values are None where the
+            entry's timestamp can't be parsed.
+        """
+        cache_age_seconds = {
+            ticker: (now - published_at).total_seconds()
+            for ticker, (_, published_at) in self._states.items()
+        }
+        bar_age_seconds = {
+            ticker: _bar_age_seconds(state, now_et) for ticker, (state, _) in self._states.items()
+        }
+        return cache_age_seconds, bar_age_seconds

--- a/argus/data/pipeline.py
+++ b/argus/data/pipeline.py
@@ -203,37 +203,6 @@ def _return_since(
     return (float(close_s.iloc[-1]) / located_close) - 1.0
 
 
-def session_state_ttl_seconds() -> int:
-    """Derives how old a live-cache entry's write time may be before api/main.py treats it as missing.
-
-    Owned here rather than in api/main.py because the budget is built from
-    `_FETCH_INTERVAL`, which this module owns; api/ is deliberately outside
-    `mypy argus/`'s scope.
-
-    Returns:
-        Budget in seconds: two fetch sweeps — tolerating one missed sweep
-        before a cache entry counts as stalled — plus a fixed jitter margin.
-    """
-    return 2 * _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
-
-
-def max_bar_age_seconds(interval_minutes: int) -> int:
-    """Derives how old a session state's own bar timestamp may be before it counts as stale.
-
-    Distinct from `session_state_ttl_seconds`: that budget catches a cache
-    entry that stopped being refreshed, this one catches a fresh write that
-    republishes an old bar (e.g. a restart replaying the persistent buffer).
-
-    Args:
-        interval_minutes: Native candle resolution in minutes.
-
-    Returns:
-        Budget in seconds: one fetch sweep plus two candle intervals plus a
-        fixed jitter margin.
-    """
-    return _FETCH_INTERVAL + 2 * interval_minutes * 60 + SYSTEM.freshness_margin_seconds
-
-
 def _resample_ohlcv(df: pd.DataFrame, interval_minutes: int, target_minutes: int) -> pd.DataFrame:
     """Resamples raw OHLCV candles to a coarser resolution.
 

--- a/argus/orchestration/graph.py
+++ b/argus/orchestration/graph.py
@@ -50,7 +50,7 @@ from argus.agents.technical import TechnicalStatisticalAgent
 from argus.config import settings
 from argus.memory.cultural import get_cultural_memory
 from argus.orchestration.aggregator import HybridSignalAggregator
-from argus.orchestration.state import ARGUSState
+from argus.orchestration.state import ARGUSState, build_ticker_snapshots
 from argus.params import RISK
 from argus.schemas.signals import AggregatedSignal, ARGUSDecision, RiskAssessment, RiskVerdict, Signal
 from argus.seams import LiveMarketDataProvider, LLMClient, MarketDataProvider
@@ -577,19 +577,12 @@ def build_graph(
             Partial state update with ``portfolio_allocation``.
         """
         # Scoped to tickers with an aggregated signal, not the whole universe: a
-        # ticker every specialist failed on has nothing to allocate against, and
-        # an all-None entry would still pass build_signal_table's is-approved
-        # filter through to _is_risk_approved(None) -> False silently rather than
-        # never appearing in all_signals at all
-        signals_dict = {}
-        for ticker in state.get("aggregated_signals", {}):
-            signals_dict[ticker] = {
-                "technical": state.get("technical_signals", {}).get(ticker),
-                "fundamental": state.get("fundamental_signals", {}).get(ticker),
-                "sentiment": state.get("sentiment_signals", {}).get(ticker),
-                "risk": state.get("risk_assessments", {}).get(ticker),
-                "aggregated": state.get("aggregated_signals", {}).get(ticker),
-            }
+        # ticker every specialist failed on has nothing to allocate against.
+        snapshots = {
+            ticker: snap
+            for ticker, snap in build_ticker_snapshots(state).items()
+            if snap.aggregated is not None
+        }
 
         profile = {
             "total_wealth": state.get("total_wealth"),
@@ -610,7 +603,7 @@ def build_graph(
         warnings = mem.get("warnings", [])
 
         alloc = portfolio_agent.allocate(
-            profile, signals_dict, macro, wisdom, warnings, adjustments=errors
+            profile, snapshots, macro, wisdom, warnings, adjustments=errors
         )
         if alloc is None:
             # allocate() has already appended the specific failing stage (LLM call,
@@ -651,25 +644,27 @@ def build_graph(
             logger.warning("node_log_decisions: cultural memory unavailable: %s", exc)
             memory = None
 
-        snapshots_stored = 0
+        ticker_snapshots = build_ticker_snapshots(state)
+        stored_count = 0
         for ticker in state.get("universe", []):
             try:
+                snap = ticker_snapshots[ticker]
                 decision = ARGUSDecision(
                     ticker=ticker,
                     session_timestamp=now,
-                    technical=state.get("technical_signals", {}).get(ticker),
+                    technical=snap.technical,
                     macro=state.get("macro_context"),
-                    fundamental=state.get("fundamental_signals", {}).get(ticker),
-                    sentiment=state.get("sentiment_signals", {}).get(ticker),
-                    risk=state.get("risk_assessments", {}).get(ticker),
-                    aggregated=state.get("aggregated_signals", {}).get(ticker),
+                    fundamental=snap.fundamental,
+                    sentiment=snap.sentiment,
+                    risk=snap.risk,
+                    aggregated=snap.aggregated,
                     allocation=positions.get(ticker),
                 )
                 decisions.append(decision)
 
                 # Snapshot stored pre-confirmation to enable pre-settlement similarity retrieval
                 if memory is not None and memory.store_decision_snapshot(decision):
-                    snapshots_stored += 1
+                    stored_count += 1
 
             except Exception as exc:
                 msg = f"log_decisions: failed to build decision for {ticker}: {exc}"
@@ -678,7 +673,7 @@ def build_graph(
 
         logger.info(
             "[log_decisions] Logged %d/%d decisions to cultural memory.",
-            snapshots_stored,
+            stored_count,
             len(state.get("universe", [])),
         )
         return {"decisions": decisions, "errors": errors}

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -21,6 +21,9 @@ Responsibilities:
     decisions.jsonl log (the unattended collector's lighter-weight alternative)
   - prune_checkpoints / compact_decisions_jsonl: bound the two decision
     stores above so neither grows forever (PR 6)
+  - run_reconciliation_pass: compose the above plus the paper-book update
+    into the one reconciliation sequence both api/main.py and
+    scripts/reconcile_outcomes.py run (issue #77)
 
 Not responsible for:
   - Deciding what a "good" outcome is, or evaluation metrics (see
@@ -32,6 +35,8 @@ Dependencies:
   - argus.orchestration.graph (build_checkpoint_serde)
   - argus.memory.cultural (CulturalMemoryManager)
   - argus.seams (MarketDataProvider)
+  - argus.risk.paper_book (PaperBook; imported inside run_reconciliation_pass
+    to break the cycle, since paper_book imports back into this module)
   - langgraph (SqliteSaver, to read argus_graph.db)
 """
 
@@ -39,6 +44,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
@@ -521,3 +527,143 @@ def prune_checkpoints(db_path: str, cutoff: datetime) -> int:
         cutoff_naive.isoformat(),
     )
     return len(stale_threads)
+
+
+@dataclass
+class ReconciliationReport:
+    """Outcome of one run_reconciliation_pass() call."""
+
+    decisions_loaded: int = 0
+    outcomes_stored: int = 0
+    equity: float = 0.0
+    drawdown: float = 0.0
+    runs_applied_pruned: int = 0
+    pending_snapshots_expired: int = 0
+    decisions_compacted: Optional[int] = None
+    """Retained decisions.jsonl count, or None if decisions_log_path wasn't given."""
+    checkpoints_pruned: Optional[int] = None
+    """Deleted checkpoint-thread count, or None if checkpoint_db_path wasn't given."""
+    errors: list[str] = field(default_factory=list)
+    """One entry per independent step that failed; every other step still ran."""
+
+
+def run_reconciliation_pass(
+    market_data: MarketDataProvider,
+    cultural: CulturalMemoryManager,
+    paper_book_path: str,
+    *,
+    decisions_log_path: Optional[str] = None,
+    checkpoint_db_path: Optional[str] = None,
+    horizon_days: int = RECONCILIATION.horizon_days,
+) -> ReconciliationReport:
+    """Runs the one reconciliation sequence shared by api/main.py and scripts/reconcile_outcomes.py (issue #77).
+
+    Loads decisions, reconciles the matured ones against market_data, updates
+    the paper book, and bounds every growing store whose path was supplied.
+    Kill-switch sync is deliberately not part of this: it stays at the API's
+    call site, fed by the returned report's equity, so a scheduled runner
+    with no daemon to sync simply doesn't call it — that difference is one
+    line at the call site rather than an argument silently omitted here.
+
+    The decisions log wins as the read source when decisions_log_path is
+    given; the checkpoint database otherwise. Every store whose path is
+    known is bounded regardless of which one was the read source, so a
+    caller supplying both (api/main.py) gets both bounded and a caller
+    supplying only one (a collector-only deployment) gets exactly that one.
+
+    Args:
+        market_data: Source of each ticker's daily close price series.
+        cultural: CulturalMemoryManager to persist outcomes to and expire
+            PENDING snapshots from.
+        paper_book_path: Path the paper equity curve is loaded from and
+            saved to.
+        decisions_log_path: Path to a decisions.jsonl log. Read source when
+            given, and compacted at the end of the pass. Omit for a
+            deployment with no jsonl log.
+        checkpoint_db_path: Path to the LangGraph checkpoint database. Read
+            source when decisions_log_path is omitted; pruned at the end of
+            the pass whenever given. Omit for a deployment with no
+            checkpoint database.
+        horizon_days: Calendar days after session_timestamp defining each
+            decision's target exit date.
+
+    Returns:
+        A ReconciliationReport describing what happened. Failures in the
+        paper-book update and in each independently-bounded store
+        (decisions.jsonl compaction, checkpoint pruning, PENDING snapshot
+        expiry) are caught, logged, and recorded in `errors` — one store
+        failing never skips another. The paper-book update is one atomic
+        load/compute/apply/prune/save step: on failure nothing from it is
+        saved, so the persisted book is never left partially applied.
+
+    Raises:
+        ValueError: Neither decisions_log_path nor checkpoint_db_path was
+            given, so there is no decision source to read.
+        Exception: Whatever loading decisions or reconcile_decisions raises —
+            unlike the bounded stores below, these aren't independent of the
+            rest of the pass, so a failure here is the caller's to handle.
+    """
+    # Deferred: argus.risk.paper_book imports this module for
+    # _needs_reconciliation/compute_realized_return, so importing it at
+    # module level here would be circular.
+    from argus.risk import paper_book
+
+    if decisions_log_path:
+        decisions = load_decisions_from_jsonl(decisions_log_path)
+    elif checkpoint_db_path:
+        decisions = load_decisions_from_checkpoints(checkpoint_db_path)
+    else:
+        raise ValueError(
+            "run_reconciliation_pass requires decisions_log_path or checkpoint_db_path"
+        )
+
+    report = ReconciliationReport(decisions_loaded=len(decisions))
+    report.outcomes_stored = reconcile_decisions(
+        decisions, market_data=market_data, cultural=cultural, horizon_days=horizon_days
+    )
+    logger.info("[Reconcile] stored %d/%d outcome(s)", report.outcomes_stored, len(decisions))
+
+    cutoff = datetime.now() - timedelta(  # noqa: DTZ005
+        days=horizon_days + RECONCILIATION.retention_margin_days
+    )
+
+    try:
+        book = paper_book.load(paper_book_path)
+        for run_timestamp, run_return in paper_book.compute_run_returns(
+            decisions, market_data, horizon_days
+        ):
+            book.apply_run(run_timestamp, run_return)
+        report.runs_applied_pruned = book.prune_runs_applied(cutoff)
+        paper_book.save(book, paper_book_path)
+        report.equity = book.equity
+        report.drawdown = book.drawdown_from_peak()
+        logger.info(
+            "[Reconcile] paper equity=$%.2f (drawdown=%.1f%%)",
+            report.equity,
+            report.drawdown * 100,
+        )
+    except Exception as exc:
+        logger.exception("[Reconcile] paper-book update failed")
+        report.errors.append(f"paper-book update failed: {exc}")
+
+    if decisions_log_path:
+        try:
+            report.decisions_compacted = compact_decisions_jsonl(decisions_log_path, cutoff)
+        except Exception as exc:
+            logger.exception("[Reconcile] decisions.jsonl compaction failed")
+            report.errors.append(f"decisions.jsonl compaction failed: {exc}")
+
+    if checkpoint_db_path:
+        try:
+            report.checkpoints_pruned = prune_checkpoints(checkpoint_db_path, cutoff)
+        except Exception as exc:
+            logger.exception("[Reconcile] checkpoint pruning failed")
+            report.errors.append(f"checkpoint pruning failed: {exc}")
+
+    try:
+        report.pending_snapshots_expired = cultural.expire_pending_snapshots(cutoff)
+    except Exception as exc:
+        logger.exception("[Reconcile] PENDING snapshot expiry failed")
+        report.errors.append(f"PENDING snapshot expiry failed: {exc}")
+
+    return report

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -609,7 +609,7 @@ def run_reconciliation_pass(
     """
     # Deferred: argus.risk.paper_book imports this module for
     # _needs_reconciliation/compute_realized_return, so importing it at
-    # module level here would be circular.
+    # module level here would be circular
     from argus.risk import paper_book
 
     if decisions_log_path:
@@ -625,7 +625,6 @@ def run_reconciliation_pass(
     report.outcomes_stored = reconcile_decisions(
         decisions, market_data=market_data, cultural=cultural, horizon_days=horizon_days
     )
-    logger.info("[Reconcile] stored %d/%d outcome(s)", report.outcomes_stored, len(decisions))
 
     cutoff = datetime.now() - timedelta(  # noqa: DTZ005
         days=horizon_days + RECONCILIATION.retention_margin_days
@@ -642,11 +641,6 @@ def run_reconciliation_pass(
         report.equity = book.equity
         report.drawdown = book.drawdown_from_peak()
         report.paper_book_updated = True
-        logger.info(
-            "[Reconcile] paper equity=$%.2f (drawdown=%.1f%%)",
-            report.equity,
-            report.drawdown * 100,
-        )
     except Exception as exc:
         logger.exception("[Reconcile] paper-book update failed")
         report.errors.append(f"paper-book update failed: {exc}")

--- a/argus/orchestration/reconciliation.py
+++ b/argus/orchestration/reconciliation.py
@@ -535,6 +535,10 @@ class ReconciliationReport:
 
     decisions_loaded: int = 0
     outcomes_stored: int = 0
+    paper_book_updated: bool = False
+    """False if the paper-book step raised — equity/drawdown are then still
+    their unset defaults, not a real (zeroed-out) portfolio value, so a
+    caller syncing a kill switch off `equity` must gate on this first."""
     equity: float = 0.0
     drawdown: float = 0.0
     runs_applied_pruned: int = 0
@@ -637,6 +641,7 @@ def run_reconciliation_pass(
         paper_book.save(book, paper_book_path)
         report.equity = book.equity
         report.drawdown = book.drawdown_from_peak()
+        report.paper_book_updated = True
         logger.info(
             "[Reconcile] paper equity=$%.2f (drawdown=%.1f%%)",
             report.equity,

--- a/argus/orchestration/state.py
+++ b/argus/orchestration/state.py
@@ -6,6 +6,7 @@ Shared state dictionary schema for the ARGUS LangGraph execution graph.
 Responsibilities:
   - Define the TypedDict shared across all LangGraph nodes
   - Document input/output field contracts per execution stage
+  - Project each ticker's specialist outputs into one typed TickerSnapshot
 
 Not responsible for:
   - State mutation (handled by individual node functions in graph.py)
@@ -15,6 +16,7 @@ Not responsible for:
 from __future__ import annotations
 
 import operator
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Annotated, Any, Optional, TypedDict
 
@@ -24,6 +26,7 @@ from argus.schemas.signals import (
     MacroContext,
     PortfolioAllocation,
     RiskAssessment,
+    RiskVerdict,
     SentimentSignal,
     TechnicalSignal,
 )
@@ -122,3 +125,68 @@ class ARGUSState(TypedDict):
     in parallel off fetch_price_history and write this key concurrently, and
     LangGraph raises InvalidUpdateError on concurrent writes to a key
     without one."""
+
+
+@dataclass(frozen=True)
+class TickerSnapshot:
+    """The per-ticker join of every specialist agent's output for one session.
+
+    A pure, on-demand projection of ARGUSState's parallel per-ticker maps —
+    never stored in state or the checkpoint, and never validated or
+    serialized the way the schemas.signals models are. See build_ticker_snapshots.
+
+    Args:
+        technical: This ticker's TechnicalSignal, or None if absent.
+        fundamental: This ticker's FundamentalSignal, or None if absent.
+        sentiment: This ticker's SentimentSignal, or None if absent.
+        risk: This ticker's RiskAssessment, or None if the risk node never evaluated it.
+        aggregated: This ticker's AggregatedSignal, or None if absent.
+    """
+
+    technical: Optional[TechnicalSignal] = None
+    fundamental: Optional[FundamentalSignal] = None
+    sentiment: Optional[SentimentSignal] = None
+    risk: Optional[RiskAssessment] = None
+    aggregated: Optional[AggregatedSignal] = None
+
+    @property
+    def risk_approved(self) -> bool:
+        """Whether this ticker's risk verdict permits an equity allocation.
+
+        Returns:
+            True for APPROVE or REDUCE; False for VETO or a missing assessment.
+        """
+        return self.risk is not None and self.risk.verdict in (
+            RiskVerdict.APPROVE,
+            RiskVerdict.REDUCE,
+        )
+
+
+def build_ticker_snapshots(state: ARGUSState) -> dict[str, TickerSnapshot]:
+    """Joins every specialist agent's per-ticker output into one TickerSnapshot per ticker.
+
+    Covers the whole session universe, leaving a ticker's fields empty where a
+    specialist never produced output for it. Callers that want a narrower scope
+    (e.g. only tickers with an aggregated signal) filter the result themselves.
+
+    Args:
+        state: ARGUSState with the specialist and risk maps populated.
+
+    Returns:
+        Mapping of ticker → TickerSnapshot, one entry per ticker in state["universe"].
+    """
+    technical_signals = state.get("technical_signals", {})
+    fundamental_signals = state.get("fundamental_signals", {})
+    sentiment_signals = state.get("sentiment_signals", {})
+    risk_assessments = state.get("risk_assessments", {})
+    aggregated_signals = state.get("aggregated_signals", {})
+    return {
+        ticker: TickerSnapshot(
+            technical=technical_signals.get(ticker),
+            fundamental=fundamental_signals.get(ticker),
+            sentiment=sentiment_signals.get(ticker),
+            risk=risk_assessments.get(ticker),
+            aggregated=aggregated_signals.get(ticker),
+        )
+        for ticker in state.get("universe", [])
+    }

--- a/argus/schemas/prompting.py
+++ b/argus/schemas/prompting.py
@@ -1,0 +1,138 @@
+"""
+argus/schemas/prompting.py
+
+Renders each agent's declared LLM output schema directly from its Pydantic
+verdict/proposal model, so the prompt text shown to the model and the
+constraints its response is validated against cannot drift apart (issue
+#76). Depends on pydantic and nothing else — deliberately kept out of
+argus/structured_output.py, which reaches groq, httpx, langchain_groq, and
+pandas through argus/seams.py, and out of argus/schemas/signals.py's own
+import surface being widened with anything heavier, since that module is
+imported by nearly everything in the system.
+
+Responsibilities:
+  - Define the PromptText marker attached to a field's Annotated metadata,
+    carrying the exact text an LLM is shown for that field
+  - Render a model's fields as a prose list (field_list) or a JSON schema
+    block (schema_block), recursing into a nested model or a list of them
+  - Raise when a field's declaration disagrees with its shape: a scalar
+    field with no marker, or a nested-model field that carries one
+
+Not responsible for:
+  - Sending prompts or decoding responses (see argus/structured_output.py)
+  - Defining validation constraints themselves (see argus/schemas/signals.py)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, get_args, get_origin
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
+
+@dataclass(frozen=True)
+class PromptText:
+    """Annotated marker carrying the exact text an LLM is shown for one field.
+
+    Args:
+        text: Verbatim text for this field — prose for field_list, a JSON
+            value (already quoted if it's a string) for schema_block.
+    """
+
+    text: str
+
+
+def _prompt_text(field: FieldInfo) -> PromptText | None:
+    """Returns the PromptText marker in a field's metadata, if any."""
+    for item in field.metadata:
+        if isinstance(item, PromptText):
+            return item
+    return None
+
+
+def _nested_model(annotation: Any) -> tuple[type[BaseModel] | None, bool]:
+    """Identifies a field annotation as a direct or list-wrapped BaseModel.
+
+    Args:
+        annotation: A field's ``FieldInfo.annotation``.
+
+    Returns:
+        ``(model, is_list)`` where ``model`` is the nested BaseModel type,
+        or ``(None, False)`` if the annotation is neither a BaseModel nor a
+        list of one.
+    """
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation, False
+    if get_origin(annotation) is list:
+        args = get_args(annotation)
+        if len(args) == 1 and isinstance(args[0], type) and issubclass(args[0], BaseModel):
+            return args[0], True
+    return None, False
+
+
+def field_list(model: type[BaseModel]) -> str:
+    """Renders every field's PromptText marker as a comma-space-joined prose list.
+
+    Each marker's text already names its own field, so no field name is
+    added by this function.
+
+    Args:
+        model: Pydantic model whose every field carries a PromptText marker.
+
+    Returns:
+        The fields' marker text, verbatim, joined with ", ".
+
+    Raises:
+        TypeError: If any field lacks a PromptText marker, or is itself a
+            nested model or a list of one.
+    """
+    parts = []
+    for name, field in model.model_fields.items():
+        nested, _ = _nested_model(field.annotation)
+        if nested is not None:
+            raise TypeError(f"{model.__name__}.{name}: field_list does not support nested models")
+        marker = _prompt_text(field)
+        if marker is None:
+            raise TypeError(f"{model.__name__}.{name} has no PromptText marker")
+        parts.append(marker.text)
+    return ", ".join(parts)
+
+
+def schema_block(model: type[BaseModel]) -> str:
+    """Renders a model as a JSON-object-shaped schema block for a prompt.
+
+    A field annotated as a nested model, or a list of one, recurses into
+    its own block instead of reading a marker — list fields are wrapped in
+    brackets. Every other field must carry a PromptText marker giving the
+    JSON value shown for it.
+
+    Args:
+        model: Pydantic model to render.
+
+    Returns:
+        A JSON-object-shaped string, e.g. ``{"ticker":"","allocation_pct":0.0}``,
+        with no insignificant whitespace.
+
+    Raises:
+        TypeError: If a scalar field lacks a PromptText marker, or a
+            nested-model field carries one.
+    """
+    entries = []
+    for name, field in model.model_fields.items():
+        nested, is_list = _nested_model(field.annotation)
+        marker = _prompt_text(field)
+        if nested is not None:
+            if marker is not None:
+                raise TypeError(
+                    f"{model.__name__}.{name} is a nested model and must not carry a PromptText marker"
+                )
+            rendered = schema_block(nested)
+            value = f"[{rendered}]" if is_list else rendered
+        else:
+            if marker is None:
+                raise TypeError(f"{model.__name__}.{name} has no PromptText marker")
+            value = marker.text
+        entries.append(f'"{name}":{value}')
+    return "{" + ",".join(entries) + "}"

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -558,18 +558,29 @@ class ProposedPosition(BaseModel):
     own figure when one exists. See GLOSSARY.md's Proposal entry.
     """
 
-    ticker: str = Field(..., description="Equity ticker symbol")
-    allocation_pct: float = Field(0.0, description="Proposed target portfolio weight")
-    stop_loss: float | None = Field(None, description="Model's own stop-loss estimate")
-    target_price: float | None = Field(None, description="12-month price target (optional)")
-    thesis: str = Field(..., description="One-sentence position thesis")
-    advisor_note: str | None = Field(
-        None, description="Professional multi-sentence advisory rationale (optional)"
+    ticker: Annotated[str, PromptText('""')] = Field(..., description="Equity ticker symbol")
+    allocation_pct: Annotated[float, PromptText("0.0")] = Field(
+        0.0, description="Proposed target portfolio weight"
     )
-    composite_conviction: float = Field(
+    stop_loss: Annotated[float | None, PromptText("0.0")] = Field(
+        None, description="Model's own stop-loss estimate"
+    )
+    target_price: Annotated[float | None, PromptText("null")] = Field(
+        None, description="12-month price target (optional)"
+    )
+    thesis: Annotated[str, PromptText('"<≤20 words>"')] = Field(
+        ..., description="One-sentence position thesis"
+    )
+    advisor_note: Annotated[
+        str | None,
+        PromptText('"2–4 professional sentences: rationale, key risks, what to monitor"'),
+    ] = Field(None, description="Professional multi-sentence advisory rationale (optional)")
+    composite_conviction: Annotated[float, PromptText("0.0")] = Field(
         ..., ge=0.0, le=1.0, description="Aggregated conviction across all agents"
     )
-    time_horizon: str = Field(..., description="Expected holding period, e.g. '30 days'")
+    time_horizon: Annotated[str, PromptText('"3-6 months"')] = Field(
+        ..., description="Expected holding period, e.g. '30 days'"
+    )
 
 
 class PortfolioProposal(BaseModel):
@@ -581,8 +592,10 @@ class PortfolioProposal(BaseModel):
     """
 
     portfolio: list[ProposedPosition] = Field(default_factory=list)
-    cash_reserve_pct: float = Field(..., description="Model's own residual estimate")
-    rebalance_trigger: str = Field(
+    cash_reserve_pct: Annotated[float, PromptText("0.0")] = Field(
+        ..., description="Model's own residual estimate"
+    )
+    rebalance_trigger: Annotated[str, PromptText('"MONTHLY"')] = Field(
         ..., description="Condition that will next trigger rebalancing, e.g. 'VIX > 35'"
     )
 

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -24,7 +24,7 @@ import uuid
 import warnings
 from datetime import date, datetime
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
 from pydantic import (
     BaseModel,
@@ -35,6 +35,7 @@ from pydantic import (
 )
 
 from argus.params import PORTFOLIO, SYSTEM
+from argus.schemas.prompting import PromptText
 
 logger = logging.getLogger(__name__)
 
@@ -282,12 +283,18 @@ class FundamentalVerdict(BaseModel):
     GLOSSARY.md's Verdict entry.
     """
 
-    signal: Signal = Field(..., description="Directional label")
-    conviction: float = Field(..., ge=0.0, le=_CONVICTION_MAX)
-    moat_score: float = Field(
+    signal: Annotated[Signal, PromptText("signal (string)")] = Field(
+        ..., description="Directional label"
+    )
+    conviction: Annotated[float, PromptText("conviction (float 0.0–1.0)")] = Field(
+        ..., ge=0.0, le=_CONVICTION_MAX
+    )
+    moat_score: Annotated[float, PromptText("moat_score (int 1–10)")] = Field(
         ..., ge=0.0, le=10.0, description="Qualitative competitive moat [0, 10]"
     )
-    reasoning: str = Field(..., description="LLM-generated investment thesis")
+    reasoning: Annotated[str, PromptText("reasoning (string ≤80 words, no markdown)")] = Field(
+        ..., description="LLM-generated investment thesis"
+    )
 
     @field_validator("conviction", mode="before")
     @classmethod

--- a/argus/schemas/signals.py
+++ b/argus/schemas/signals.py
@@ -349,12 +349,18 @@ class SentimentVerdict(BaseModel):
     in by the agent to build a SentimentSignal. See GLOSSARY.md's Verdict entry.
     """
 
-    signal: Signal = Field(..., description="Directional label")
-    conviction: float = Field(..., ge=0.0, le=_CONVICTION_MAX)
-    sentiment_decay_risk: Literal["LOW", "MEDIUM", "HIGH"] = Field(
-        ..., description="Estimated speed at which the sentiment signal will decay"
+    signal: Annotated[Signal, PromptText('"BULLISH|BEARISH|NEUTRAL"')] = Field(
+        ..., description="Directional label"
     )
-    reasoning: str = Field(..., description="LLM rationale for the signal")
+    conviction: Annotated[float, PromptText("<float 0.0–1.0>")] = Field(
+        ..., ge=0.0, le=_CONVICTION_MAX
+    )
+    sentiment_decay_risk: Annotated[
+        Literal["LOW", "MEDIUM", "HIGH"], PromptText('"LOW|MEDIUM|HIGH"')
+    ] = Field(..., description="Estimated speed at which the sentiment signal will decay")
+    reasoning: Annotated[str, PromptText('"<≤60 words citing the primary driver>"')] = Field(
+        ..., description="LLM rationale for the signal"
+    )
 
     @field_validator("conviction", mode="before")
     @classmethod

--- a/argus/seams.py
+++ b/argus/seams.py
@@ -14,9 +14,12 @@ Each boundary gets one Protocol and two implementations:
     and is the sole choke point for governor rate-limiting and header-driven
     limit observation; classifies which failures are worth retrying and
     raises RetryableTransportError for those, but the retry loop itself
-    lives in argus/structured_output.py's decode() — see its own docstring)
+    lives in argus/structured_output.py's decode() — see its own docstring;
+    also answers `remaining_capacity()` by delegating to the governor, so a
+    caller can back off before spending a call it would only lose)
     / `FixtureLLMClient` (serves pre-captured response text from
-    tests/fixtures/llm_responses/, never touches the governor or the network).
+    tests/fixtures/llm_responses/, never touches the governor or the network,
+    and answers `remaining_capacity()` from a value fixed at construction).
 
 Agents accept these via constructor injection with a real default, so
 production wiring (graph.py's `build_graph()`) is unchanged unless a
@@ -183,11 +186,13 @@ class FixtureMarketDataProvider:
 
 
 class LLMClient(Protocol):
-    """A single structured-text call: system + user prompt in, raw response text out.
+    """A structured-text call plus the back-pressure a caller needs to schedule it.
 
     Callers keep owning response parsing (JSON extraction, markdown-fence
     stripping, schema validation) — this seam only replaces "how do I get an
-    LLM to answer this prompt," not "what does the answer mean."
+    LLM to answer this prompt," not "what does the answer mean." Back-pressure
+    is part of the same contract: an agent deciding whether a call is worth
+    making asks its own port, not a global.
 
     An implementation makes exactly one invocation per call — it does not
     loop. A transient failure worth a caller-side retry (see
@@ -198,6 +203,10 @@ class LLMClient(Protocol):
 
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         """Sends a system + user prompt to the LLM and returns the raw response text."""
+        ...
+
+    def remaining_capacity(self) -> int:
+        """Returns how many more calls this client can make right now without waiting."""
         ...
 
 
@@ -315,6 +324,10 @@ class GroqLLMClient:
         """
         governor.observe_headers(self._model, response.headers)
 
+    def remaining_capacity(self) -> int:
+        """Returns the governor's remaining rolling-window request capacity for this model."""
+        return governor.get_remaining_capacity(self._model)
+
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         """Invokes the Groq model once and returns its response as plain text.
 
@@ -382,16 +395,27 @@ class FixtureLLMClient:
     guess call order.
     """
 
-    def __init__(self, responses: dict[str, str], key_fn: Optional[Any] = None) -> None:
+    _UNLIMITED_CAPACITY = 1_000_000
+
+    def __init__(
+        self,
+        responses: dict[str, str],
+        key_fn: Optional[Any] = None,
+        capacity: int = _UNLIMITED_CAPACITY,
+    ) -> None:
         """Stores the response map and the key function used to look up responses.
 
         Args:
             responses: Mapping of key → pre-captured raw response text.
             key_fn: Function deriving a lookup key from the user prompt. Defaults
                 to using the user prompt itself as the key.
+            capacity: Fixed value `remaining_capacity()` reports. Defaults to
+                effectively unlimited, so a fixture-backed test only sees
+                back-pressure when it deliberately asks for a low value.
         """
         self._responses = responses
         self._key_fn = key_fn or (lambda user_prompt: user_prompt)
+        self._capacity = capacity
 
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         """Returns the pre-captured response text keyed by ``key_fn(user_prompt)``.
@@ -403,6 +427,10 @@ class FixtureLLMClient:
         if key not in self._responses:
             raise KeyError(f"FixtureLLMClient has no recorded response for key {key!r}")
         return self._responses[key]
+
+    def remaining_capacity(self) -> int:
+        """Returns the fixed capacity value supplied at construction."""
+        return self._capacity
 
     @classmethod
     def from_fixture_file(cls, path: Path, key_fn: Optional[Any] = None) -> "FixtureLLMClient":

--- a/scripts/reconcile_outcomes.py
+++ b/scripts/reconcile_outcomes.py
@@ -1,18 +1,10 @@
 """
 scripts/reconcile_outcomes.py
 
-CLI entry point for argus/orchestration/reconciliation.py — reads every
-decision back out of the LangGraph checkpoint (argus_graph.db) or a
-decisions.jsonl log, reconciles whichever ones have cleared
-RECONCILIATION.horizon_days against live market data, and reports how many
-outcomes were stored to cultural memory. Also applies matured runs onto the
-persisted paper equity curve (argus/risk/paper_book.py) so the scheduled
-GitHub Actions runner — which has no long-lived KillSwitch daemon to feed —
-still keeps that curve current for whichever process reads it next. Finally
-prunes decisions.jsonl, the checkpoint DB, PENDING snapshots, and
-runs_applied back to a bounded window (PR 6), the same cleanup api/main.py's
-_reconcile_once performs, since this script is the only reconcile pass a
-collector-only deployment (no long-lived API process) ever gets.
+CLI entry point for run_reconciliation_pass
+(argus/orchestration/reconciliation.py) — the scheduled GitHub Actions
+runner's reconciliation pass for deployments with no long-lived API process
+to run api/main.py's own daily loop.
 
     .venv/bin/python scripts/reconcile_outcomes.py [--db PATH] [--horizon-days N]
     .venv/bin/python scripts/reconcile_outcomes.py --decisions-log PATH
@@ -20,32 +12,33 @@ collector-only deployment (no long-lived API process) ever gets.
 Meant to run periodically (e.g. a daily cron) against the live checkpoint
 database, or — for the unattended collector, which doesn't carry the full
 checkpoint DB around — against its decisions.jsonl log.
+
+Responsibilities:
+  - Parse CLI args into run_reconciliation_pass's store paths and print its
+    returned report
+
+Not responsible for:
+  - The reconciliation sequence itself, or which stores get bounded (see
+    argus/orchestration/reconciliation.py, which api/main.py's own
+    reconciliation loop also calls)
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
-from datetime import datetime, timedelta
 
 from argus.config import settings
 from argus.memory.cultural import get_cultural_memory
-from argus.orchestration.reconciliation import (
-    compact_decisions_jsonl,
-    load_decisions_from_checkpoints,
-    load_decisions_from_jsonl,
-    prune_checkpoints,
-    reconcile_decisions,
-)
+from argus.orchestration.reconciliation import run_reconciliation_pass
 from argus.params import RECONCILIATION
-from argus.risk import paper_book
 from argus.seams import LiveMarketDataProvider
 
 logger = logging.getLogger("argus.reconcile_outcomes")
 
 
 def main() -> None:
-    """Parses CLI args, reconciles cleared decisions, and prints the outcome count."""
+    """Parses CLI args, runs one reconciliation pass, and prints its report."""
     logging.basicConfig(level=logging.INFO)
 
     parser = argparse.ArgumentParser(description=__doc__)
@@ -67,49 +60,30 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    if args.decisions_log:
-        decisions = load_decisions_from_jsonl(args.decisions_log)
-        source = args.decisions_log
-    else:
-        decisions = load_decisions_from_checkpoints(args.db)
-        source = args.db
-    print(f"Loaded {len(decisions)} decision(s) from {source}")
-
-    market_data = LiveMarketDataProvider()
-    stored = reconcile_decisions(
-        decisions,
-        market_data=market_data,
-        cultural=get_cultural_memory(),
+    report = run_reconciliation_pass(
+        LiveMarketDataProvider(),
+        get_cultural_memory(),
+        f"{settings.ARGUS_DATA_DIR}/paper_equity.json",
+        decisions_log_path=args.decisions_log,
+        checkpoint_db_path=args.db,
         horizon_days=args.horizon_days,
     )
-    print(f"Reconciled {stored}/{len(decisions)} decision(s) (horizon={args.horizon_days}d)")
 
-    book_path = f"{settings.ARGUS_DATA_DIR}/paper_equity.json"
-    book = paper_book.load(book_path)
-    for run_timestamp, run_return in paper_book.compute_run_returns(
-        decisions, market_data, args.horizon_days
-    ):
-        book.apply_run(run_timestamp, run_return)
-
-    cutoff = datetime.now() - timedelta(  # noqa: DTZ005
-        days=args.horizon_days + RECONCILIATION.retention_margin_days
-    )
-    book.prune_runs_applied(cutoff)
-    paper_book.save(book, book_path)
+    source = args.decisions_log or args.db
+    print(f"Loaded {report.decisions_loaded} decision(s) from {source}")
     print(
-        f"Paper equity: ${book.equity:,.2f} "
-        f"(drawdown={book.drawdown_from_peak():.1%} from peak ${book.high_water_mark:,.2f})"
+        f"Reconciled {report.outcomes_stored}/{report.decisions_loaded} decision(s) "
+        f"(horizon={args.horizon_days}d)"
     )
-
-    if args.decisions_log:
-        kept = compact_decisions_jsonl(args.decisions_log, cutoff)
-        print(f"Compacted {args.decisions_log}: {kept} decision(s) retained")
-
-    pruned = prune_checkpoints(args.db, cutoff)
-    print(f"Pruned {pruned} stale checkpoint thread(s) from {args.db}")
-
-    expired = get_cultural_memory().expire_pending_snapshots(cutoff)
-    print(f"Expired {expired} stale PENDING snapshot(s)")
+    if report.paper_book_updated:
+        print(f"Paper equity: ${report.equity:,.2f} (drawdown={report.drawdown:.1%} from peak)")
+    if report.decisions_compacted is not None:
+        print(f"Compacted {args.decisions_log}: {report.decisions_compacted} decision(s) retained")
+    if report.checkpoints_pruned is not None:
+        print(f"Pruned {report.checkpoints_pruned} stale checkpoint thread(s) from {args.db}")
+    print(f"Expired {report.pending_snapshots_expired} stale PENDING snapshot(s)")
+    for error in report.errors:
+        print(f"WARNING: {error}")
 
 
 if __name__ == "__main__":

--- a/tests/test_api_concurrency.py
+++ b/tests/test_api_concurrency.py
@@ -28,6 +28,7 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 import argus.risk.kill_switch as kill_switch_module
+from argus.data.live_session_cache import LiveSessionCache
 from argus.risk.kill_switch import KillSwitch
 from argus.schemas.signals import ARGUSDecision
 
@@ -36,9 +37,9 @@ _PAYLOAD = {"tickers": ["AAPL"], "total_wealth": 100_000, "invest_pct": 0.5}
 
 @pytest.fixture(autouse=True)
 def _reset_singletons(monkeypatch):
-    """Clears the kill-switch singleton and live session cache around each test."""
+    """Clears the kill-switch singleton and installs a fresh live session cache around each test."""
     kill_switch_module._kill_switch = None
-    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    monkeypatch.setattr(api_main, "_live_cache", LiveSessionCache(interval_minutes=1))
     monkeypatch.setattr(api_main.settings, "ARGUS_API_KEY", "")
     monkeypatch.setattr(api_main, "_analyze_semaphore", asyncio.Semaphore(1))
     yield
@@ -61,10 +62,10 @@ def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
 
 
 def _seed_cache(ticker: str, *, bar_age_seconds: float, write_age_seconds: float = 0.0):
-    """Populates `_live_session_cache` with a state whose bar and write times are both controlled."""
+    """Populates `_live_cache` with a state whose bar and write times are both controlled."""
     bar_ts = datetime.now(api_main._ET) - timedelta(seconds=bar_age_seconds)
     write_ts = datetime.now() - timedelta(seconds=write_age_seconds)
-    api_main._live_session_cache[ticker] = ({"timestamp": bar_ts.isoformat()}, write_ts)
+    api_main._live_cache.publish({ticker: {"timestamp": bar_ts.isoformat()}}, [ticker], now=write_ts)
 
 
 def _ready(client, monkeypatch):
@@ -182,12 +183,13 @@ async def test_mft_session_callback_evicts_untracked_tickers(monkeypatch):
     fake_pipeline = mock.Mock()
     fake_pipeline.tickers = ["AAPL"]
     monkeypatch.setattr(api_main, "_mft_pipeline", fake_pipeline)
-    api_main._live_session_cache["MSFT"] = ({"timestamp": "stale"}, datetime.now())
+    api_main._live_cache.publish({"MSFT": {"timestamp": "stale"}}, ["MSFT"])
 
     await api_main._mft_session_callback({"AAPL": {"timestamp": "2024-01-02T09:30:00-05:00"}})
 
-    assert "MSFT" not in api_main._live_session_cache
-    assert "AAPL" in api_main._live_session_cache
+    result = api_main._live_cache.admit(["MSFT", "AAPL"], datetime.now(), datetime.now(api_main._ET))
+    assert "MSFT" in result.absent
+    assert "AAPL" not in result.absent
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_concurrency.py
+++ b/tests/test_api_concurrency.py
@@ -63,8 +63,9 @@ def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
 
 def _seed_cache(ticker: str, *, bar_age_seconds: float, write_age_seconds: float = 0.0):
     """Populates `_live_cache` with a state whose bar and write times are both controlled."""
-    bar_ts = datetime.now(api_main._ET) - timedelta(seconds=bar_age_seconds)
-    write_ts = datetime.now() - timedelta(seconds=write_age_seconds)
+    now = datetime.now(api_main._ET)
+    bar_ts = now - timedelta(seconds=bar_age_seconds)
+    write_ts = now - timedelta(seconds=write_age_seconds)
     api_main._live_cache.publish({ticker: {"timestamp": bar_ts.isoformat()}}, [ticker], now=write_ts)
 
 
@@ -187,7 +188,7 @@ async def test_mft_session_callback_evicts_untracked_tickers(monkeypatch):
 
     await api_main._mft_session_callback({"AAPL": {"timestamp": "2024-01-02T09:30:00-05:00"}})
 
-    result = api_main._live_cache.admit(["MSFT", "AAPL"], datetime.now(), datetime.now(api_main._ET))
+    result = api_main._live_cache.admit(["MSFT", "AAPL"], datetime.now(api_main._ET))
     assert "MSFT" in result.absent
     assert "AAPL" not in result.absent
 

--- a/tests/test_api_event_loop_hygiene.py
+++ b/tests/test_api_event_loop_hygiene.py
@@ -23,14 +23,15 @@ import pytest
 from fastapi.testclient import TestClient
 
 import api.main as api_main
+from argus.data.live_session_cache import LiveSessionCache
 
 _ET = ZoneInfo("America/New_York")
 
 
 @pytest.fixture(autouse=True)
 def _reset_singletons(monkeypatch):
-    """Clears the live session cache around each test."""
-    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    """Installs a fresh live session cache around each test."""
+    monkeypatch.setattr(api_main, "_live_cache", LiveSessionCache(interval_minutes=1))
     yield
 
 

--- a/tests/test_api_freshness.py
+++ b/tests/test_api_freshness.py
@@ -61,9 +61,8 @@ def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
 def test_analyze_market_closed_outranks_bar_age(client, monkeypatch):
     """A hopelessly stale bar still surfaces as market-closed, not stale, outside session hours (issue #78)."""
     _pipeline(monkeypatch, market_hours=False)
-    bar_ts = datetime.now(api_main._ET) - timedelta(days=9)
-    write_ts = datetime.now() - timedelta(days=9)
-    api_main._live_cache.publish({"AAPL": {"timestamp": bar_ts.isoformat()}}, ["AAPL"], now=write_ts)
+    now = datetime.now(api_main._ET) - timedelta(days=9)
+    api_main._live_cache.publish({"AAPL": {"timestamp": now.isoformat()}}, ["AAPL"], now=now)
 
     response = client.post("/analyze", json=_PAYLOAD)
 

--- a/tests/test_api_freshness.py
+++ b/tests/test_api_freshness.py
@@ -1,20 +1,21 @@
 """
 tests/test_api_freshness.py
 
-Tests for /analyze's freshness gate added in PR2 (MFT-1, API-5): the gate
-must reject on bar age, not just cache-write age, and must check market
-hours before either age check so bar-age is never evaluated outside a
-weekday 09:30-16:00 ET session.
+Route-level tests for /analyze's freshness gate (issue #78). The four
+freshness clauses themselves — absent/stalled/stale/malformed/naive/
+one-full-interval-old — now live at the LiveSessionCache seam (see
+tests/test_live_session_cache.py) and are verified there with an explicit
+clock, no HTTP client required.
 
-Also covers PR3's MFT-14 (publication merged into the fetch loop, so a bar
-published a full fetch interval ago still clears the gate) and API-11 (a
-malformed or naive bar timestamp fails closed as staleness instead of
-raising).
+What's genuinely a route concern and stays here: market hours outranking
+every age check, each admission group mapping to its own response text, and
+ticker registration happening only after the earlier gates pass — none of
+that is LiveSessionCache's to know about.
 
 These exercise the route function directly via FastAPI's TestClient rather
 than going through the app's lifespan, so no MFT pipeline, collector, or
-reconcile loop needs to start. `_mft_pipeline` and `_live_session_cache`
-are set directly on the api.main module instead.
+reconcile loop needs to start. `_mft_pipeline` and `_live_cache` are set
+directly on the api.main module instead.
 """
 
 from __future__ import annotations
@@ -27,16 +28,16 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 import argus.risk.kill_switch as kill_switch_module
-from argus.data.pipeline import _FETCH_INTERVAL
+from argus.data.live_session_cache import AdmissionResult, LiveSessionCache
 
 _PAYLOAD = {"tickers": ["AAPL"], "total_wealth": 100_000, "invest_pct": 0.5}
 
 
 @pytest.fixture(autouse=True)
 def _reset_singletons(monkeypatch):
-    """Clears the kill-switch singleton and live session cache around each test."""
+    """Clears the kill-switch singleton and installs a fresh live session cache around each test."""
     kill_switch_module._kill_switch = None
-    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    monkeypatch.setattr(api_main, "_live_cache", LiveSessionCache(interval_minutes=1))
     monkeypatch.setattr(api_main.settings, "ARGUS_API_KEY", "")
     yield
     kill_switch_module._kill_switch = None
@@ -57,119 +58,46 @@ def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
     return fake
 
 
-def _seed_cache(ticker: str, *, bar_age_seconds: float, write_age_seconds: float = 0.0):
-    """Populates `_live_session_cache` with a state whose bar and write times are both controlled."""
-    bar_ts = datetime.now(api_main._ET) - timedelta(seconds=bar_age_seconds)
-    write_ts = datetime.now() - timedelta(seconds=write_age_seconds)
-    api_main._live_session_cache[ticker] = ({"timestamp": bar_ts.isoformat()}, write_ts)
-
-
-def test_analyze_rejects_when_market_closed(client, monkeypatch):
-    """Market-closed is checked before any cache lookup, regardless of what's cached."""
-    _pipeline(monkeypatch, market_hours=False)
-    response = client.post("/analyze", json=_PAYLOAD)
-    assert response.status_code == 503
-    assert "closed" in response.json()["detail"].lower()
-
-
-def test_analyze_rejects_absent_ticker_as_warming_up(client, monkeypatch):
-    """A ticker never seen by the pipeline is reported as warming up, not stalled or stale."""
-    _pipeline(monkeypatch, market_hours=True)
-    response = client.post("/analyze", json=_PAYLOAD)
-    assert response.status_code == 503
-    assert "warming up" in response.json()["detail"].lower()
-
-
-def test_analyze_rejects_stalled_write_before_checking_bar_age(client, monkeypatch):
-    """A cache entry that stopped being refreshed is reported as stalled, even with a fresh bar."""
-    _pipeline(monkeypatch, market_hours=True)
-    _seed_cache("AAPL", bar_age_seconds=5, write_age_seconds=10_000)
-    response = client.post("/analyze", json=_PAYLOAD)
-    assert response.status_code == 503
-    assert "stalled" in response.json()["detail"].lower()
-
-
-def test_analyze_rejects_stale_bar_reproduced_case(client, monkeypatch):
-    """The reproduced MFT-1 case: a bar 9 days old, written just now, is rejected as stale."""
-    _pipeline(monkeypatch, market_hours=True)
-    _seed_cache("AAPL", bar_age_seconds=9 * 24 * 3600, write_age_seconds=5)
-    response = client.post("/analyze", json=_PAYLOAD)
-    assert response.status_code == 503
-    assert "stale" in response.json()["detail"].lower()
-
-
-def test_analyze_rejects_stale_bar_on_a_weekday_holiday(client, monkeypatch):
-    """is_market_hours only checks weekday, so a holiday's stale republished bar must fail-close."""
-    _pipeline(monkeypatch, market_hours=True)
-    _seed_cache("AAPL", bar_age_seconds=2 * 24 * 3600, write_age_seconds=5)
-    response = client.post("/analyze", json=_PAYLOAD)
-    assert response.status_code == 503
-    assert "stale" in response.json()["detail"].lower()
-
-
 def test_analyze_market_closed_outranks_bar_age(client, monkeypatch):
-    """A hopelessly stale bar still surfaces as market-closed, not stale, outside session hours."""
+    """A hopelessly stale bar still surfaces as market-closed, not stale, outside session hours (issue #78)."""
     _pipeline(monkeypatch, market_hours=False)
-    _seed_cache("AAPL", bar_age_seconds=9 * 24 * 3600, write_age_seconds=9 * 24 * 3600)
+    bar_ts = datetime.now(api_main._ET) - timedelta(days=9)
+    write_ts = datetime.now() - timedelta(days=9)
+    api_main._live_cache.publish({"AAPL": {"timestamp": bar_ts.isoformat()}}, ["AAPL"], now=write_ts)
+
     response = client.post("/analyze", json=_PAYLOAD)
+
     assert response.status_code == 503
     assert "closed" in response.json()["detail"].lower()
 
 
-def test_analyze_passes_freshness_gate_with_a_current_bar(client, monkeypatch):
-    """A fresh write and a fresh bar clear every freshness check and reach the graph."""
+@pytest.mark.parametrize(
+    "admission_field, expected_substring",
+    [
+        ("absent", "warming up"),
+        ("stalled", "stalled"),
+        ("stale", "stale"),
+    ],
+)
+def test_analyze_maps_each_admission_group_to_its_own_response_text(
+    client, monkeypatch, admission_field, expected_substring
+):
+    """Each of LiveSessionCache.admit()'s three rejection groups produces distinct response wording."""
     _pipeline(monkeypatch, market_hours=True)
-    _seed_cache("AAPL", bar_age_seconds=5, write_age_seconds=5)
-    fake_graph = mock.Mock()
-    fake_graph.invoke.side_effect = RuntimeError("sentinel: freshness gate cleared")
-    monkeypatch.setattr(api_main, "_graph", fake_graph)
-
-    response = client.post("/analyze", json=_PAYLOAD)
-
-    # A 500 (rather than any of the 503 freshness variants) proves every gate
-    # above was cleared and the graph itself was reached; the exception text
-    # is redacted behind a correlation ref (API-7, see test_api_validation.py)
-    # so it isn't asserted here.
-    assert response.status_code == 500
-    assert fake_graph.invoke.called
-
-
-def test_analyze_passes_freshness_gate_with_a_bar_one_full_fetch_interval_old(client, monkeypatch):
-    """MFT-14: publication now runs on the same cadence as the fetch sweep, so a bar as old as one
-    full _FETCH_INTERVAL still clears max_bar_age_seconds — the case that a slower, decoupled
-    publish timer used to miss for most of each cycle.
-    """
-    _pipeline(monkeypatch, market_hours=True)
-    _seed_cache("AAPL", bar_age_seconds=_FETCH_INTERVAL, write_age_seconds=5)
-    fake_graph = mock.Mock()
-    fake_graph.invoke.side_effect = RuntimeError("sentinel: freshness gate cleared")
-    monkeypatch.setattr(api_main, "_graph", fake_graph)
-
-    response = client.post("/analyze", json=_PAYLOAD)
-
-    assert response.status_code == 500
-    assert fake_graph.invoke.called
-
-
-def test_analyze_rejects_a_malformed_bar_timestamp_as_stale(client, monkeypatch):
-    """API-11: a non-ISO timestamp fails closed as staleness (503) instead of raising a 500."""
-    _pipeline(monkeypatch, market_hours=True)
-    write_ts = datetime.now()
-    api_main._live_session_cache["AAPL"] = ({"timestamp": "not-a-timestamp"}, write_ts)
+    result = AdmissionResult(**{admission_field: ["AAPL"]})
+    monkeypatch.setattr(api_main._live_cache, "admit", mock.Mock(return_value=result))
 
     response = client.post("/analyze", json=_PAYLOAD)
 
     assert response.status_code == 503
-    assert "stale" in response.json()["detail"].lower()
+    assert expected_substring in response.json()["detail"].lower()
 
 
-def test_analyze_rejects_a_naive_bar_timestamp_as_stale(client, monkeypatch):
-    """API-11: a naive (tz-less) timestamp fails closed as staleness rather than raising a TypeError."""
-    _pipeline(monkeypatch, market_hours=True)
-    write_ts = datetime.now()
-    api_main._live_session_cache["AAPL"] = ({"timestamp": datetime.now().isoformat()}, write_ts)
+def test_analyze_market_closed_skips_ticker_registration(client, monkeypatch):
+    """A rejected-by-market-hours request must not mutate pipeline state (API-12)."""
+    fake_pipeline = _pipeline(monkeypatch, market_hours=False)
 
     response = client.post("/analyze", json=_PAYLOAD)
 
     assert response.status_code == 503
-    assert "stale" in response.json()["detail"].lower()
+    fake_pipeline.register_tickers.assert_not_called()

--- a/tests/test_api_startup.py
+++ b/tests/test_api_startup.py
@@ -22,7 +22,6 @@ import asyncio
 import contextlib
 import fcntl
 import logging
-from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -31,6 +30,7 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 import argus.risk.kill_switch as kill_switch_module
+from argus.data.live_session_cache import LiveSessionCache
 from argus.risk.kill_switch import KillSwitch
 
 
@@ -197,7 +197,7 @@ def _reset_health_globals(monkeypatch):
     monkeypatch.setattr(api_main, "_collector_task", None)
     monkeypatch.setattr(api_main, "_reconcile_task", None)
     monkeypatch.setattr(api_main, "_mft_pipeline", None)
-    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    monkeypatch.setattr(api_main, "_live_cache", LiveSessionCache(interval_minutes=1))
     kill_switch_module._kill_switch = None
     yield
     kill_switch_module._kill_switch = None
@@ -279,11 +279,9 @@ def test_health_reports_newest_cache_entry_age_during_market_hours(monkeypatch, 
     fake_pipeline = mock.Mock()
     fake_pipeline.is_market_hours.return_value = True
     monkeypatch.setattr(api_main, "_mft_pipeline", fake_pipeline)
-    monkeypatch.setattr(
-        api_main,
-        "_live_session_cache",
-        {"AAPL": ({}, datetime.now())},
-    )
+    cache = LiveSessionCache(interval_minutes=1)
+    cache.publish({"AAPL": {}}, ["AAPL"])
+    monkeypatch.setattr(api_main, "_live_cache", cache)
 
     response = health_client.get("/health")
 

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -20,15 +20,16 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 import argus.risk.kill_switch as kill_switch_module
+from argus.data.live_session_cache import LiveSessionCache
 
 _PAYLOAD = {"tickers": ["AAPL"], "total_wealth": 100_000, "invest_pct": 0.5}
 
 
 @pytest.fixture(autouse=True)
 def _reset_singletons(monkeypatch):
-    """Clears the kill-switch singleton and live session cache around each test."""
+    """Clears the kill-switch singleton and installs a fresh live session cache around each test."""
     kill_switch_module._kill_switch = None
-    monkeypatch.setattr(api_main, "_live_session_cache", {})
+    monkeypatch.setattr(api_main, "_live_cache", LiveSessionCache(interval_minutes=1))
     monkeypatch.setattr(api_main.settings, "ARGUS_API_KEY", "")
     yield
     kill_switch_module._kill_switch = None
@@ -50,10 +51,10 @@ def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
 
 
 def _seed_cache(ticker: str, *, bar_age_seconds: float, write_age_seconds: float = 0.0):
-    """Populates `_live_session_cache` with a state whose bar and write times are both controlled."""
+    """Populates `_live_cache` with a state whose bar and write times are both controlled."""
     bar_ts = datetime.now(api_main._ET) - timedelta(seconds=bar_age_seconds)
     write_ts = datetime.now() - timedelta(seconds=write_age_seconds)
-    api_main._live_session_cache[ticker] = ({"timestamp": bar_ts.isoformat()}, write_ts)
+    api_main._live_cache.publish({ticker: {"timestamp": bar_ts.isoformat()}}, [ticker], now=write_ts)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api_validation.py
+++ b/tests/test_api_validation.py
@@ -52,8 +52,9 @@ def _pipeline(monkeypatch, *, market_hours: bool, interval_minutes: int = 1):
 
 def _seed_cache(ticker: str, *, bar_age_seconds: float, write_age_seconds: float = 0.0):
     """Populates `_live_cache` with a state whose bar and write times are both controlled."""
-    bar_ts = datetime.now(api_main._ET) - timedelta(seconds=bar_age_seconds)
-    write_ts = datetime.now() - timedelta(seconds=write_age_seconds)
+    now = datetime.now(api_main._ET)
+    bar_ts = now - timedelta(seconds=bar_age_seconds)
+    write_ts = now - timedelta(seconds=write_age_seconds)
     api_main._live_cache.publish({ticker: {"timestamp": bar_ts.isoformat()}}, [ticker], now=write_ts)
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,17 +1,19 @@
 """
 Tests for argus/data/cache.py: DailyBarCache, the per-(ticker, trading_date)
 disk cache that lets fetch_multiple_daily skip the network on same-day
-re-runs, and OHLCVBuffer, the rolling intraday candle buffer.
+re-runs, OHLCVBuffer, the rolling intraday candle buffer, and TTLCache, the
+generic in-memory cache shared by the fundamental and sentiment agents.
 """
 
 import logging
 import sqlite3
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 import pandas as pd
 import pytest
 
-from argus.data.cache import DailyBarCache, OHLCVBuffer
+from argus.data.cache import DailyBarCache, OHLCVBuffer, TTLCache
 from tests.helpers.candles import dst_straddling_candles
 
 
@@ -300,3 +302,72 @@ def test_interval_change_logs_the_discarded_count(tmp_path, caplog):
         OHLCVBuffer(db_path=db_path, buffer_size=20, interval="5m")
 
     assert any("discarded 3" in record.message for record in caplog.records)
+
+
+class _FakeClock:
+    """A settable clock for driving TTLCache expiry without waiting on wall time."""
+
+    def __init__(self, now: datetime) -> None:
+        self.now = now
+
+    def __call__(self) -> datetime:
+        return self.now
+
+
+def test_ttl_cache_returns_a_value_stored_within_the_window():
+    """A value stored and read back before the TTL elapses is returned."""
+    clock = _FakeClock(datetime(2026, 1, 1, 12, 0, 0))
+    cache: TTLCache[str, str] = TTLCache(ttl=timedelta(days=1), clock=clock)
+
+    cache.set("AAPL", "bullish")
+    clock.now += timedelta(hours=23)
+
+    assert cache.get("AAPL") == "bullish"
+
+
+def test_ttl_cache_does_not_return_a_value_once_the_window_has_passed():
+    """The same value is no longer returned once the clock passes the TTL."""
+    clock = _FakeClock(datetime(2026, 1, 1, 12, 0, 0))
+    cache: TTLCache[str, str] = TTLCache(ttl=timedelta(days=1), clock=clock)
+
+    cache.set("AAPL", "bullish")
+    clock.now += timedelta(days=1)
+
+    assert cache.get("AAPL") is None
+
+
+def test_ttl_cache_returns_none_for_a_key_that_was_never_stored():
+    """A key with no prior `set` call returns nothing rather than raising."""
+    cache: TTLCache[str, str] = TTLCache(ttl=timedelta(days=1))
+
+    assert cache.get("AAPL") is None
+
+
+def test_ttl_cache_keys_differing_only_in_one_component_do_not_share_a_value():
+    """Two tuple keys differing only in their second element don't serve each other's value.
+
+    Mirrors FundamentalCache's (ticker, session_seed) key: two backtest
+    sessions replaying the same ticker must not share a cached value, and a
+    live call (session_seed=None) must not be conflated with either.
+    """
+    cache: TTLCache[tuple[str, Optional[int]], str] = TTLCache(ttl=timedelta(days=7))
+
+    cache.set(("AAPL", 20240101), "session 1")
+    cache.set(("AAPL", 20240102), "session 2")
+
+    assert cache.get(("AAPL", 20240101)) == "session 1"
+    assert cache.get(("AAPL", 20240102)) == "session 2"
+    assert cache.get(("AAPL", None)) is None
+
+
+def test_ttl_cache_set_refreshes_the_stored_timestamp():
+    """Storing a key again resets its expiry clock rather than keeping the original timestamp."""
+    clock = _FakeClock(datetime(2026, 1, 1, 12, 0, 0))
+    cache: TTLCache[str, str] = TTLCache(ttl=timedelta(days=1), clock=clock)
+
+    cache.set("AAPL", "bullish")
+    clock.now += timedelta(hours=23)
+    cache.set("AAPL", "neutral")
+    clock.now += timedelta(hours=23)
+
+    assert cache.get("AAPL") == "neutral"

--- a/tests/test_fundamental.py
+++ b/tests/test_fundamental.py
@@ -3,20 +3,19 @@ Tests for the Fundamental Agent and its pure-Python helpers.
 """
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime
 
 
 import argus.agents.fundamental as fundamental_module
 from argus.agents.fundamental import (
     FundamentalAgent,
-    FundamentalCache,
     _session_seed_to_date,
     _use_backtest_seed,
     anonymize_ticker,
     build_compact_prompt,
 )
 from argus.orchestration.governor import BOOTSTRAP_LIMITS, RateLimitGovernor
-from argus.schemas.signals import FundamentalSignal, FundamentalVerdict, Signal
+from argus.schemas.signals import FundamentalVerdict
 from argus.seams import FixtureLLMClient
 
 
@@ -88,61 +87,6 @@ def test_build_compact_prompt():
     assert 'ticker="COMP_XYZ"' in prompt_anon
     assert 'sector="Technology"' in prompt_anon
     assert "AAPL" not in prompt_anon
-
-def test_fundamental_cache():
-    """A cached signal is served until it exceeds the 7-day TTL, then evicted."""
-    cache = FundamentalCache()
-    assert cache.is_stale("AAPL")
-
-    signal = FundamentalSignal(
-        ticker="AAPL",
-        sector="Technology",
-        industry="Consumer Electronics",
-        data_as_of_date=datetime.now().date(),
-        signal=Signal.BULLISH,
-        conviction=0.9,
-        moat_score=8,
-        reasoning="Test",
-        api_calls_used=0,
-        timestamp=datetime.now(),
-    )
-
-    cache.set("AAPL", signal)
-    assert not cache.is_stale("AAPL")
-    assert cache.get("AAPL") == signal
-
-    # Backdate the entry past the 7-day TTL rather than waiting for it to expire
-    cache._cache[("AAPL", None)] = (signal, datetime.now() - timedelta(days=8))
-    assert cache.is_stale("AAPL")
-    assert cache.get("AAPL") is None
-
-def test_fundamental_cache_keys_on_session_seed():
-    """Two backtest sessions with different session_seed must not share a cached signal."""
-    cache = FundamentalCache()
-
-    def make_signal(reasoning: str) -> FundamentalSignal:
-        return FundamentalSignal(
-            ticker="AAPL",
-            sector="Technology",
-            industry="Consumer Electronics",
-            data_as_of_date=datetime.now().date(),
-            signal=Signal.BULLISH,
-            conviction=0.9,
-            moat_score=8,
-            reasoning=reasoning,
-            api_calls_used=0,
-            timestamp=datetime.now(),
-        )
-
-    sig_session_1 = make_signal("session 1")
-    sig_session_2 = make_signal("session 2")
-
-    cache.set("AAPL", sig_session_1, session_seed=20240101)
-    cache.set("AAPL", sig_session_2, session_seed=20240102)
-
-    assert cache.get("AAPL", session_seed=20240101) == sig_session_1
-    assert cache.get("AAPL", session_seed=20240102) == sig_session_2
-    assert cache.get("AAPL") is None
 
 def test_use_backtest_seed_treats_zero_as_a_valid_seed():
     """session_seed=0 is a legal Optional[int] and must not be treated as falsy."""

--- a/tests/test_fundamental.py
+++ b/tests/test_fundamental.py
@@ -15,7 +15,6 @@ from argus.agents.fundamental import (
     anonymize_ticker,
     build_compact_prompt,
 )
-from argus.orchestration.governor import BOOTSTRAP_LIMITS, RateLimitGovernor
 from argus.schemas.signals import FundamentalSignal, FundamentalVerdict, Signal
 from argus.seams import FixtureLLMClient
 
@@ -40,6 +39,9 @@ class _RecordingLLMClient:
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         self.last_user_prompt = user_prompt
         return self._response_text
+
+    def remaining_capacity(self) -> int:
+        return 1_000_000
 
 def test_prompt_declared_fields_match_the_verdict_schema():
     """The prompt's declared output fields and FundamentalVerdict's fields must never drift apart.
@@ -225,6 +227,9 @@ def test_analyze_retries_with_the_prior_validation_error_in_the_prompt():
                 {"signal": "NEUTRAL", "conviction": 0.5, "moat_score": 5, "reasoning": "r"}
             )
 
+        def remaining_capacity(self) -> int:
+            return 1_000_000
+
     agent = FundamentalAgent(llm_client=_FlakyThenValidLLMClient(), market_data=market_data)
     signal = agent.analyze("AAPL")
 
@@ -244,6 +249,9 @@ def test_analyze_degrades_the_ticker_on_governor_exhaustion_without_retrying():
         def complete(self, system_prompt: str, user_prompt: str) -> str:
             self.calls += 1
             raise fundamental_module.RateLimitExceeded("gpt-oss-120b quota exhausted")
+
+        def remaining_capacity(self) -> int:
+            return 1_000_000
 
     llm = _RateLimitedLLMClient()
     agent = FundamentalAgent(llm_client=llm, market_data=market_data)
@@ -281,20 +289,16 @@ def test_analyze_degrades_the_ticker_when_measured_data_fails_signal_validation(
 
 def test_analyze_does_not_skip_every_ticker_at_a_low_configured_rpm(monkeypatch):
     """A low ARGUS_GROQ_RPM must not make the pre-flight capacity reserve exceed
-    the budget itself (GOV-13) — an idle governor should still admit the call.
-
-    BOOTSTRAP_LIMITS is a dict computed once from settings at governor import
-    time, not re-read per call, so simulating ARGUS_GROQ_RPM=10 requires
-    patching it directly rather than just monkeypatching settings.
+    the budget itself (GOV-13) — a client reporting that full budget as remaining
+    capacity should still admit the call.
     """
-    model = fundamental_module.settings.ARGUS_FUNDAMENTAL_MODEL
     monkeypatch.setattr(fundamental_module.settings, "ARGUS_GROQ_RPM", 10)
-    monkeypatch.setitem(BOOTSTRAP_LIMITS[model], "requests_per_minute", 10)
-    monkeypatch.setattr(fundamental_module, "governor", RateLimitGovernor())
 
     market_data = _StubMarketData({"sector": "Technology", "industry": "Consumer Electronics"})
-    llm = _RecordingLLMClient(
-        json.dumps({"signal": "NEUTRAL", "conviction": 0.5, "moat_score": 5, "reasoning": "r"})
+    llm = FixtureLLMClient(
+        {"only": json.dumps({"signal": "NEUTRAL", "conviction": 0.5, "moat_score": 5, "reasoning": "r"})},
+        key_fn=lambda _p: "only",
+        capacity=10,
     )
     agent = FundamentalAgent(llm_client=llm, market_data=market_data)
 
@@ -303,3 +307,26 @@ def test_analyze_does_not_skip_every_ticker_at_a_low_configured_rpm(monkeypatch)
 
     assert signal is not None
     assert errors == []
+
+
+def test_analyze_skips_the_ticker_and_makes_no_calls_when_capacity_is_low():
+    """A low-capacity client skips the ticker before any market-data fetch or LLM call.
+
+    The capacity check must stay ahead of the fetch so a skipped ticker still
+    costs no network call — asserted here by a market-data stub that raises
+    if it is ever invoked.
+    """
+
+    class _ExplodingMarketData:
+        def fundamentals(self, ticker: str) -> dict:
+            raise AssertionError("fundamentals() must not be called when capacity is low")
+
+    llm = FixtureLLMClient({}, capacity=0)
+    agent = FundamentalAgent(llm_client=llm, market_data=_ExplodingMarketData())
+
+    errors: list[str] = []
+    signal = agent.analyze("AAPL", errors=errors)
+
+    assert signal is None
+    assert len(errors) == 1
+    assert "capacity too low" in errors[0]

--- a/tests/test_fundamental.py
+++ b/tests/test_fundamental.py
@@ -16,7 +16,7 @@ from argus.agents.fundamental import (
     build_compact_prompt,
 )
 from argus.orchestration.governor import BOOTSTRAP_LIMITS, RateLimitGovernor
-from argus.schemas.signals import FundamentalSignal, FundamentalVerdict, Signal
+from argus.schemas.signals import FundamentalSignal, Signal
 from argus.seams import FixtureLLMClient
 
 
@@ -40,15 +40,6 @@ class _RecordingLLMClient:
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         self.last_user_prompt = user_prompt
         return self._response_text
-
-def test_prompt_declared_fields_match_the_verdict_schema():
-    """The prompt's declared output fields and FundamentalVerdict's fields must never drift apart.
-
-    The prompt used to also declare six measured ratios the agent unconditionally
-    overwrote after parsing; this asserts none of those field names sneak back in.
-    """
-    assert set(fundamental_module._VERDICT_FIELD_DESCRIPTIONS) == set(FundamentalVerdict.model_fields)
-
 
 def test_anonymize_ticker():
     """Anonymized IDs are deterministic per (ticker, seed) and vary if either input changes."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -176,7 +176,7 @@ class TestEndToEnd:
 
         def portfolio_side_effect(
             user_profile,
-            all_signals,
+            snapshots,
             macro,
             cultural_wisdom=None,
             cultural_warnings=None,
@@ -186,7 +186,7 @@ class TestEndToEnd:
 
             Args:
                 user_profile: Dict with total_wealth/invest_pct/risk_tolerance.
-                all_signals: Mapping of ticker -> dict of signal objects; unused.
+                snapshots: Mapping of ticker -> TickerSnapshot; unused.
                 macro: Current macroeconomic context; unused.
                 cultural_wisdom: Unused; accepted to match the real signature.
                 cultural_warnings: Unused; accepted to match the real signature.

--- a/tests/test_live_session_cache.py
+++ b/tests/test_live_session_cache.py
@@ -1,0 +1,171 @@
+"""
+tests/test_live_session_cache.py
+
+Tests for LiveSessionCache (issue #78): the freshness gate for MFT session
+states, extracted from api/main.py so each clause can be verified by calling
+a function with an explicit clock instead of standing up an HTTP client and
+monkeypatching two module globals.
+
+These exercise LiveSessionCache directly — no FastAPI app, no
+MFTDataPipeline instance. publish() takes the tracked universe as a plain
+argument instead of holding a pipeline reference.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from argus.data.live_session_cache import (
+    LiveSessionCache,
+    max_bar_age_seconds,
+    session_state_ttl_seconds,
+)
+from argus.data.pipeline import _FETCH_INTERVAL
+from argus.params import SYSTEM
+
+_ET = ZoneInfo("America/New_York")
+
+
+def _state(*, bar_age_seconds: float, now_et: datetime) -> dict:
+    """Builds a session-state dict whose bar timestamp is `bar_age_seconds` old."""
+    return {"timestamp": (now_et - timedelta(seconds=bar_age_seconds)).isoformat()}
+
+
+def _publish(
+    cache: LiveSessionCache,
+    ticker: str,
+    *,
+    now: datetime,
+    now_et: datetime,
+    bar_age_seconds: float,
+    write_age_seconds: float = 0.0,
+    tracked_universe=None,
+) -> None:
+    """Publishes one ticker with independently controlled bar age and write age."""
+    state = _state(bar_age_seconds=bar_age_seconds, now_et=now_et)
+    published_at = now - timedelta(seconds=write_age_seconds)
+    cache.publish(
+        {ticker: state},
+        tracked_universe if tracked_universe is not None else [ticker],
+        now=published_at,
+    )
+
+
+def test_session_state_ttl_seconds_tolerates_one_missed_sweep():
+    """The write-age TTL covers two fetch sweeps (MFT-14), not one decision cycle's worth."""
+    assert session_state_ttl_seconds() == 2 * _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
+
+
+def test_max_bar_age_seconds_scales_with_interval():
+    """The bar-age budget grows with the candle interval, matching the issue's 480s-at-1m figure."""
+    assert max_bar_age_seconds(1) == _FETCH_INTERVAL + 2 * 1 * 60 + SYSTEM.freshness_margin_seconds
+    assert max_bar_age_seconds(1) == 480
+    assert max_bar_age_seconds(5) > max_bar_age_seconds(1)
+
+
+def test_admit_reports_a_never_published_ticker_as_absent():
+    """A ticker with no cache entry at all is absent, not stalled or stale."""
+    cache = LiveSessionCache(interval_minutes=1)
+    now, now_et = datetime.now(), datetime.now(_ET)
+
+    result = cache.admit(["AAPL"], now, now_et)
+
+    assert result.absent == ["AAPL"]
+    assert result.stalled == []
+    assert result.stale == []
+    assert result.admitted == {}
+
+
+def test_admit_reports_a_ticker_not_refreshed_recently_as_stalled():
+    """A cache entry whose publication time exceeds the TTL is stalled, even with a fresh bar."""
+    cache = LiveSessionCache(interval_minutes=1)
+    now, now_et = datetime.now(), datetime.now(_ET)
+    _publish(cache, "AAPL", now=now, now_et=now_et, bar_age_seconds=5, write_age_seconds=10_000)
+
+    result = cache.admit(["AAPL"], now, now_et)
+
+    assert result.stalled == ["AAPL"]
+
+
+def test_admit_reports_an_old_bar_as_stale():
+    """A bar older than max_bar_age_seconds is stale, independent of how recently it was written."""
+    cache = LiveSessionCache(interval_minutes=1)
+    now, now_et = datetime.now(), datetime.now(_ET)
+    _publish(
+        cache, "AAPL", now=now, now_et=now_et, bar_age_seconds=9 * 24 * 3600, write_age_seconds=5
+    )
+
+    result = cache.admit(["AAPL"], now, now_et)
+
+    assert result.stale == ["AAPL"]
+
+
+def test_admit_fails_closed_on_a_malformed_bar_timestamp():
+    """API-11: a non-ISO timestamp is treated as stale rather than raising."""
+    cache = LiveSessionCache(interval_minutes=1)
+    now, now_et = datetime.now(), datetime.now(_ET)
+    cache.publish({"AAPL": {"timestamp": "not-a-timestamp"}}, ["AAPL"], now=now)
+
+    result = cache.admit(["AAPL"], now, now_et)
+
+    assert result.stale == ["AAPL"]
+
+
+def test_admit_fails_closed_on_a_naive_bar_timestamp():
+    """API-11: a tz-less timestamp is treated as stale rather than raising a TypeError."""
+    cache = LiveSessionCache(interval_minutes=1)
+    now, now_et = datetime.now(), datetime.now(_ET)
+    cache.publish({"AAPL": {"timestamp": datetime.now().isoformat()}}, ["AAPL"], now=now)
+
+    result = cache.admit(["AAPL"], now, now_et)
+
+    assert result.stale == ["AAPL"]
+
+
+def test_admit_passes_a_bar_one_full_fetch_interval_old():
+    """MFT-14: a bar as old as one full _FETCH_INTERVAL still clears max_bar_age_seconds."""
+    cache = LiveSessionCache(interval_minutes=1)
+    now, now_et = datetime.now(), datetime.now(_ET)
+    _publish(
+        cache,
+        "AAPL",
+        now=now,
+        now_et=now_et,
+        bar_age_seconds=_FETCH_INTERVAL,
+        write_age_seconds=5,
+    )
+
+    result = cache.admit(["AAPL"], now, now_et)
+
+    assert "AAPL" in result.admitted
+    assert result.stale == []
+    assert result.stalled == []
+
+
+def test_publish_evicts_tickers_no_longer_in_the_tracked_universe():
+    """A ticker dropped from the tracked universe is dropped from the cache on the next publish."""
+    cache = LiveSessionCache(interval_minutes=1)
+    now, now_et = datetime.now(), datetime.now(_ET)
+    _publish(cache, "MSFT", now=now, now_et=now_et, bar_age_seconds=5, tracked_universe=["MSFT"])
+
+    cache.publish({"AAPL": _state(bar_age_seconds=5, now_et=now_et)}, ["AAPL"], now=now)
+
+    assert len(cache) == 1
+    result = cache.admit(["MSFT", "AAPL"], now, now_et)
+    assert result.absent == ["MSFT"]
+    assert "AAPL" in result.admitted
+
+
+def test_ages_reports_publication_and_bar_age_for_everything_held():
+    """ages() reports numeric ages for every cached ticker, independent of whether it would pass admission."""
+    cache = LiveSessionCache(interval_minutes=1)
+    now, now_et = datetime.now(), datetime.now(_ET)
+    _publish(cache, "AAPL", now=now, now_et=now_et, bar_age_seconds=30, write_age_seconds=10)
+
+    cache_age_seconds, bar_age_seconds = cache.ages(now, now_et)
+
+    assert cache_age_seconds["AAPL"] == pytest.approx(10)
+    assert bar_age_seconds["AAPL"] == pytest.approx(30)

--- a/tests/test_live_session_cache.py
+++ b/tests/test_live_session_cache.py
@@ -8,7 +8,9 @@ monkeypatching two module globals.
 
 These exercise LiveSessionCache directly — no FastAPI app, no
 MFTDataPipeline instance. publish() takes the tracked universe as a plain
-argument instead of holding a pipeline reference.
+argument instead of holding a pipeline reference. Publication age and bar
+age are measured against one ET-aware clock (see the module docstring's note
+on clock unification).
 """
 
 from __future__ import annotations
@@ -29,23 +31,17 @@ from argus.params import SYSTEM
 _ET = ZoneInfo("America/New_York")
 
 
-def _state(*, bar_age_seconds: float, now_et: datetime) -> dict:
-    """Builds a session-state dict whose bar timestamp is `bar_age_seconds` old."""
-    return {"timestamp": (now_et - timedelta(seconds=bar_age_seconds)).isoformat()}
-
-
 def _publish(
     cache: LiveSessionCache,
     ticker: str,
     *,
     now: datetime,
-    now_et: datetime,
     bar_age_seconds: float,
     write_age_seconds: float = 0.0,
     tracked_universe=None,
 ) -> None:
     """Publishes one ticker with independently controlled bar age and write age."""
-    state = _state(bar_age_seconds=bar_age_seconds, now_et=now_et)
+    state = {"timestamp": (now - timedelta(seconds=bar_age_seconds)).isoformat()}
     published_at = now - timedelta(seconds=write_age_seconds)
     cache.publish(
         {ticker: state},
@@ -69,9 +65,9 @@ def test_max_bar_age_seconds_scales_with_interval():
 def test_admit_reports_a_never_published_ticker_as_absent():
     """A ticker with no cache entry at all is absent, not stalled or stale."""
     cache = LiveSessionCache(interval_minutes=1)
-    now, now_et = datetime.now(), datetime.now(_ET)
+    now = datetime.now(_ET)
 
-    result = cache.admit(["AAPL"], now, now_et)
+    result = cache.admit(["AAPL"], now)
 
     assert result.absent == ["AAPL"]
     assert result.stalled == []
@@ -82,10 +78,10 @@ def test_admit_reports_a_never_published_ticker_as_absent():
 def test_admit_reports_a_ticker_not_refreshed_recently_as_stalled():
     """A cache entry whose publication time exceeds the TTL is stalled, even with a fresh bar."""
     cache = LiveSessionCache(interval_minutes=1)
-    now, now_et = datetime.now(), datetime.now(_ET)
-    _publish(cache, "AAPL", now=now, now_et=now_et, bar_age_seconds=5, write_age_seconds=10_000)
+    now = datetime.now(_ET)
+    _publish(cache, "AAPL", now=now, bar_age_seconds=5, write_age_seconds=10_000)
 
-    result = cache.admit(["AAPL"], now, now_et)
+    result = cache.admit(["AAPL"], now)
 
     assert result.stalled == ["AAPL"]
 
@@ -93,12 +89,10 @@ def test_admit_reports_a_ticker_not_refreshed_recently_as_stalled():
 def test_admit_reports_an_old_bar_as_stale():
     """A bar older than max_bar_age_seconds is stale, independent of how recently it was written."""
     cache = LiveSessionCache(interval_minutes=1)
-    now, now_et = datetime.now(), datetime.now(_ET)
-    _publish(
-        cache, "AAPL", now=now, now_et=now_et, bar_age_seconds=9 * 24 * 3600, write_age_seconds=5
-    )
+    now = datetime.now(_ET)
+    _publish(cache, "AAPL", now=now, bar_age_seconds=9 * 24 * 3600, write_age_seconds=5)
 
-    result = cache.admit(["AAPL"], now, now_et)
+    result = cache.admit(["AAPL"], now)
 
     assert result.stale == ["AAPL"]
 
@@ -106,10 +100,10 @@ def test_admit_reports_an_old_bar_as_stale():
 def test_admit_fails_closed_on_a_malformed_bar_timestamp():
     """API-11: a non-ISO timestamp is treated as stale rather than raising."""
     cache = LiveSessionCache(interval_minutes=1)
-    now, now_et = datetime.now(), datetime.now(_ET)
+    now = datetime.now(_ET)
     cache.publish({"AAPL": {"timestamp": "not-a-timestamp"}}, ["AAPL"], now=now)
 
-    result = cache.admit(["AAPL"], now, now_et)
+    result = cache.admit(["AAPL"], now)
 
     assert result.stale == ["AAPL"]
 
@@ -117,10 +111,10 @@ def test_admit_fails_closed_on_a_malformed_bar_timestamp():
 def test_admit_fails_closed_on_a_naive_bar_timestamp():
     """API-11: a tz-less timestamp is treated as stale rather than raising a TypeError."""
     cache = LiveSessionCache(interval_minutes=1)
-    now, now_et = datetime.now(), datetime.now(_ET)
+    now = datetime.now(_ET)
     cache.publish({"AAPL": {"timestamp": datetime.now().isoformat()}}, ["AAPL"], now=now)
 
-    result = cache.admit(["AAPL"], now, now_et)
+    result = cache.admit(["AAPL"], now)
 
     assert result.stale == ["AAPL"]
 
@@ -128,17 +122,10 @@ def test_admit_fails_closed_on_a_naive_bar_timestamp():
 def test_admit_passes_a_bar_one_full_fetch_interval_old():
     """MFT-14: a bar as old as one full _FETCH_INTERVAL still clears max_bar_age_seconds."""
     cache = LiveSessionCache(interval_minutes=1)
-    now, now_et = datetime.now(), datetime.now(_ET)
-    _publish(
-        cache,
-        "AAPL",
-        now=now,
-        now_et=now_et,
-        bar_age_seconds=_FETCH_INTERVAL,
-        write_age_seconds=5,
-    )
+    now = datetime.now(_ET)
+    _publish(cache, "AAPL", now=now, bar_age_seconds=_FETCH_INTERVAL, write_age_seconds=5)
 
-    result = cache.admit(["AAPL"], now, now_et)
+    result = cache.admit(["AAPL"], now)
 
     assert "AAPL" in result.admitted
     assert result.stale == []
@@ -148,13 +135,13 @@ def test_admit_passes_a_bar_one_full_fetch_interval_old():
 def test_publish_evicts_tickers_no_longer_in_the_tracked_universe():
     """A ticker dropped from the tracked universe is dropped from the cache on the next publish."""
     cache = LiveSessionCache(interval_minutes=1)
-    now, now_et = datetime.now(), datetime.now(_ET)
-    _publish(cache, "MSFT", now=now, now_et=now_et, bar_age_seconds=5, tracked_universe=["MSFT"])
+    now = datetime.now(_ET)
+    _publish(cache, "MSFT", now=now, bar_age_seconds=5, tracked_universe=["MSFT"])
 
-    cache.publish({"AAPL": _state(bar_age_seconds=5, now_et=now_et)}, ["AAPL"], now=now)
+    _publish(cache, "AAPL", now=now, bar_age_seconds=5)
 
     assert len(cache) == 1
-    result = cache.admit(["MSFT", "AAPL"], now, now_et)
+    result = cache.admit(["MSFT", "AAPL"], now)
     assert result.absent == ["MSFT"]
     assert "AAPL" in result.admitted
 
@@ -162,10 +149,27 @@ def test_publish_evicts_tickers_no_longer_in_the_tracked_universe():
 def test_ages_reports_publication_and_bar_age_for_everything_held():
     """ages() reports numeric ages for every cached ticker, independent of whether it would pass admission."""
     cache = LiveSessionCache(interval_minutes=1)
-    now, now_et = datetime.now(), datetime.now(_ET)
-    _publish(cache, "AAPL", now=now, now_et=now_et, bar_age_seconds=30, write_age_seconds=10)
+    now = datetime.now(_ET)
+    _publish(cache, "AAPL", now=now, bar_age_seconds=30, write_age_seconds=10)
 
-    cache_age_seconds, bar_age_seconds = cache.ages(now, now_et)
+    cache_age_seconds, bar_age_seconds = cache.ages(now)
 
     assert cache_age_seconds["AAPL"] == pytest.approx(10)
     assert bar_age_seconds["AAPL"] == pytest.approx(30)
+
+
+def test_publish_defaults_to_the_same_clock_admit_measures_against():
+    """publish()'s default `now` and admit()'s ET-aware clock are the same clock (issue #78).
+
+    Before clock unification these could silently drift: publication was
+    stamped with naive local time while bar age was measured in ET. A
+    just-published entry with a fresh bar must clear both checks using only
+    the default clocks on each side.
+    """
+    cache = LiveSessionCache(interval_minutes=1)
+    now = datetime.now(_ET)
+    cache.publish({"AAPL": {"timestamp": now.isoformat()}}, ["AAPL"])
+
+    result = cache.admit(["AAPL"], datetime.now(_ET))
+
+    assert "AAPL" in result.admitted

--- a/tests/test_live_session_cache.py
+++ b/tests/test_live_session_cache.py
@@ -159,13 +159,7 @@ def test_ages_reports_publication_and_bar_age_for_everything_held():
 
 
 def test_publish_defaults_to_the_same_clock_admit_measures_against():
-    """publish()'s default `now` and admit()'s ET-aware clock are the same clock (issue #78).
-
-    Before clock unification these could silently drift: publication was
-    stamped with naive local time while bar age was measured in ET. A
-    just-published entry with a fresh bar must clear both checks using only
-    the default clocks on each side.
-    """
+    """A just-published entry with a fresh bar clears admit() using only each side's default clock."""
     cache = LiveSessionCache(interval_minutes=1)
     now = datetime.now(_ET)
     cache.publish({"AAPL": {"timestamp": now.isoformat()}}, ["AAPL"])
@@ -173,3 +167,23 @@ def test_publish_defaults_to_the_same_clock_admit_measures_against():
     result = cache.admit(["AAPL"], datetime.now(_ET))
 
     assert "AAPL" in result.admitted
+
+
+def test_ages_measures_publication_age_correctly_across_a_dst_transition():
+    """Two aware datetimes sharing one ZoneInfo instance must still yield real elapsed seconds.
+
+    Plain `datetime` subtraction between operands with the same tzinfo
+    object ignores tzinfo and compares wall-clock fields directly, which is
+    wrong by one hour across a DST transition; ages()/admit() must use
+    timestamp()-based arithmetic instead.
+    """
+    cache = LiveSessionCache(interval_minutes=1)
+    published_at = datetime(2024, 3, 9, 12, 0, tzinfo=_ET)  # EST, before spring-forward
+    now = datetime(2024, 3, 11, 12, 0, tzinfo=_ET)  # 2 wall-clock days later, after it
+    cache.publish({"AAPL": {"timestamp": now.isoformat()}}, ["AAPL"], now=published_at)
+
+    cache_age_seconds, _ = cache.ages(now)
+
+    # Real elapsed time is 47h (one DST hour was skipped), not the 48h a
+    # same-tzinfo subtraction would report
+    assert cache_age_seconds["AAPL"] == pytest.approx(47 * 3600)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -32,8 +32,6 @@ from argus.data.pipeline import (
     _required_raw_bars,
     _resample_ohlcv,
     _return_since,
-    max_bar_age_seconds,
-    session_state_ttl_seconds,
 )
 from argus.params import SYSTEM
 from tests.helpers.candles import dst_straddling_candles, et_intraday_candles
@@ -356,18 +354,6 @@ def test_momentum_1d_is_stable_under_dropping_up_to_10_oldest_bars(drop: int):
 
     assert baseline is not None
     assert trimmed == baseline
-
-
-def test_session_state_ttl_seconds_tolerates_one_missed_sweep():
-    """The write-age TTL covers two fetch sweeps (MFT-14), not one decision cycle's worth."""
-    assert session_state_ttl_seconds() == 2 * _FETCH_INTERVAL + SYSTEM.freshness_margin_seconds
-
-
-def test_max_bar_age_seconds_scales_with_interval():
-    """The bar-age budget grows with the candle interval, matching the issue's 480s-at-1m figure."""
-    assert max_bar_age_seconds(1) == _FETCH_INTERVAL + 2 * 1 * 60 + SYSTEM.freshness_margin_seconds
-    assert max_bar_age_seconds(1) == 480
-    assert max_bar_age_seconds(5) > max_bar_age_seconds(1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import pytest
 
 from argus.agents.portfolio import half_kelly_weight, build_signal_table
+from argus.orchestration.state import TickerSnapshot
 from argus.schemas.signals import RiskAssessment, RiskVerdict, Signal, MacroContext, Regime
 
 def test_half_kelly_weight_bullish():
@@ -62,24 +63,24 @@ def test_build_signal_table():
         timestamp=datetime.now(),
     )
 
-    all_signals = {
-        "AAPL": {
-            "fundamental": MockSignal(Signal.BULLISH, 0.8),
-            "technical": MockSignal(Signal.NEUTRAL, 0.5),
-            "sentiment": MockSignal(Signal.BULLISH, 0.7),
-            "aggregated": MockSignal(Signal.BULLISH, 0.85, agents_present=["fundamental", "technical", "sentiment"]),
-            "risk": RiskAssessment(verdict=RiskVerdict.APPROVE, proposed_weight=0.15, approved_weight=0.15, var_99=0.02, stop_loss=150.0, portfolio_beta=1.1, api_calls_used=0, timestamp=datetime.now()),
-        },
-        "TSLA": {
-            "risk": RiskAssessment(verdict=RiskVerdict.VETO, proposed_weight=0.15, approved_weight=0.0, var_99=0.08, stop_loss=None, portfolio_beta=2.0, veto_reasons=["Too risky"], api_calls_used=0, timestamp=datetime.now()),
-        },
-        "MSFT": {
-            "fundamental": MockSignal(Signal.BEARISH, 0.9),
-            "risk": RiskAssessment(verdict=RiskVerdict.REDUCE, proposed_weight=0.15, approved_weight=0.05, var_99=0.05, stop_loss=280.0, portfolio_beta=0.9, api_calls_used=0, timestamp=datetime.now()),
-        }
+    snapshots = {
+        "AAPL": TickerSnapshot(
+            fundamental=MockSignal(Signal.BULLISH, 0.8),
+            technical=MockSignal(Signal.NEUTRAL, 0.5),
+            sentiment=MockSignal(Signal.BULLISH, 0.7),
+            aggregated=MockSignal(Signal.BULLISH, 0.85, agents_present=["fundamental", "technical", "sentiment"]),
+            risk=RiskAssessment(verdict=RiskVerdict.APPROVE, proposed_weight=0.15, approved_weight=0.15, var_99=0.02, stop_loss=150.0, portfolio_beta=1.1, api_calls_used=0, timestamp=datetime.now()),
+        ),
+        "TSLA": TickerSnapshot(
+            risk=RiskAssessment(verdict=RiskVerdict.VETO, proposed_weight=0.15, approved_weight=0.0, var_99=0.08, stop_loss=None, portfolio_beta=2.0, veto_reasons=["Too risky"], api_calls_used=0, timestamp=datetime.now()),
+        ),
+        "MSFT": TickerSnapshot(
+            fundamental=MockSignal(Signal.BEARISH, 0.9),
+            risk=RiskAssessment(verdict=RiskVerdict.REDUCE, proposed_weight=0.15, approved_weight=0.05, var_99=0.05, stop_loss=280.0, portfolio_beta=0.9, api_calls_used=0, timestamp=datetime.now()),
+        ),
     }
 
-    table = build_signal_table(all_signals, macro)
+    table = build_signal_table(snapshots, macro)
 
     assert "AAPL:" in table
     assert "MSFT:" in table

--- a/tests/test_portfolio_enforcement.py
+++ b/tests/test_portfolio_enforcement.py
@@ -15,6 +15,7 @@ import json
 from datetime import datetime
 
 from argus.agents.portfolio import PortfolioManagerAgent
+from argus.orchestration.state import TickerSnapshot
 from argus.params import PORTFOLIO, SYSTEM
 from argus.schemas.signals import PortfolioAllocation, PositionAllocation, RiskAssessment, RiskVerdict
 from argus.seams import FixtureLLMClient
@@ -62,12 +63,12 @@ def _llm_response(portfolio: list[dict]) -> FixtureLLMClient:
 def test_allocate_enforces_caps_vetoes_and_fabrications_in_code():
     """An over-cap allocation is clamped, a VETO'd ticker is zeroed-not-dropped,
 
-    and a fabricated ticker absent from all_signals is dropped — each producing
+    and a fabricated ticker absent from snapshots is dropped — each producing
     an adjustments entry rather than validating silently.
     """
-    all_signals = {
-        "OVER_CAP": {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)},
-        "VETOED": {"risk": _risk(RiskVerdict.VETO, approved_weight=0.0, proposed_weight=0.10)},
+    snapshots = {
+        "OVER_CAP": TickerSnapshot(risk=_risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)),
+        "VETOED": TickerSnapshot(risk=_risk(RiskVerdict.VETO, approved_weight=0.0, proposed_weight=0.10)),
     }
 
     llm_client = _llm_response(
@@ -103,7 +104,7 @@ def test_allocate_enforces_caps_vetoes_and_fabrications_in_code():
     adjustments: list[str] = []
     alloc = agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
-        all_signals=all_signals,
+        snapshots=snapshots,
         macro=None,
         adjustments=adjustments,
     )
@@ -130,7 +131,7 @@ def test_allocate_names_the_json_parse_stage_on_exhausted_retries(monkeypatch):
     adjustments: list[str] = []
     alloc = agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
-        all_signals={"OVER_CAP": {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)}},
+        snapshots={"OVER_CAP": TickerSnapshot(risk=_risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10))},
         macro=None,
         adjustments=adjustments,
     )
@@ -151,7 +152,7 @@ def test_allocate_names_the_schema_validation_stage_on_exhausted_retries(monkeyp
     adjustments: list[str] = []
     alloc = agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
-        all_signals={"OVER_CAP": {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10)}},
+        snapshots={"OVER_CAP": TickerSnapshot(risk=_risk(RiskVerdict.APPROVE, approved_weight=0.10, proposed_weight=0.10))},
         macro=None,
         adjustments=adjustments,
     )
@@ -190,8 +191,8 @@ def test_allocate_clamps_cash_reserve_to_schema_floor_at_high_deployment():
     caps["T6"] = 0.051
     tickers.append("T6")
 
-    all_signals = {
-        t: {"risk": _risk(RiskVerdict.APPROVE, approved_weight=caps[t], proposed_weight=caps[t])}
+    snapshots = {
+        t: TickerSnapshot(risk=_risk(RiskVerdict.APPROVE, approved_weight=caps[t], proposed_weight=caps[t]))
         for t in tickers
     }
     portfolio = [
@@ -210,7 +211,7 @@ def test_allocate_clamps_cash_reserve_to_schema_floor_at_high_deployment():
     agent = PortfolioManagerAgent(llm_client=llm_client)
     alloc = agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.95, "risk_tolerance": "MODERATE"},
-        all_signals=all_signals,
+        snapshots=snapshots,
         macro=None,
     )
 
@@ -223,8 +224,8 @@ def test_allocate_states_achievable_deployment_ceiling_not_raw_invest_pct():
     (min(invest_pct, sum of approved Caps)), not raw invest_pct, so ALLOCATION RULE 3's
     target is reachable for a small approved universe under per-position caps.
     """
-    all_signals = {
-        t: {"risk": _risk(RiskVerdict.APPROVE, approved_weight=0.15, proposed_weight=0.15)}
+    snapshots = {
+        t: TickerSnapshot(risk=_risk(RiskVerdict.APPROVE, approved_weight=0.15, proposed_weight=0.15))
         for t in ("A", "B", "C")
     }
     llm_client = _CapturingLLMClient(
@@ -234,7 +235,7 @@ def test_allocate_states_achievable_deployment_ceiling_not_raw_invest_pct():
     agent = PortfolioManagerAgent(llm_client=llm_client)
     agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.95, "risk_tolerance": "MODERATE"},
-        all_signals=all_signals,
+        snapshots=snapshots,
         macro=None,
     )
 

--- a/tests/test_portfolio_enforcement.py
+++ b/tests/test_portfolio_enforcement.py
@@ -16,15 +16,12 @@ from datetime import datetime
 
 import pytest
 
-import argus.agents.portfolio as portfolio_module
 from argus.agents.portfolio import PortfolioManagerAgent
 from argus.orchestration.governor import RateLimitExceeded
 from argus.params import PORTFOLIO, SYSTEM
 from argus.schemas.signals import (
     PortfolioAllocation,
-    PortfolioProposal,
     PositionAllocation,
-    ProposedPosition,
     RiskAssessment,
     RiskVerdict,
 )
@@ -47,14 +44,6 @@ class _CapturingLLMClient:
     def complete(self, system_prompt: str, user_prompt: str) -> str:
         self.last_prompt = user_prompt
         return json.dumps(self._response_json)
-
-
-def test_prompt_declared_fields_match_the_proposal_schema():
-    """The prompt's declared output fields and the proposal schemas' fields must never drift apart."""
-    assert set(portfolio_module._POSITION_FIELD_DESCRIPTIONS) == set(ProposedPosition.model_fields)
-    assert set(portfolio_module._PROPOSAL_FIELD_DESCRIPTIONS) == (
-        set(PortfolioProposal.model_fields) - {"portfolio"}
-    )
 
 
 def test_allocate_reraises_on_governor_exhaustion_without_retrying():

--- a/tests/test_position_sizing.py
+++ b/tests/test_position_sizing.py
@@ -11,6 +11,7 @@ import json
 from datetime import datetime
 
 from argus.agents.portfolio import PortfolioManagerAgent
+from argus.orchestration.state import TickerSnapshot
 from argus.schemas.signals import AggregatedSignal, RiskAssessment, RiskVerdict, Signal
 from argus.seams import FixtureLLMClient
 
@@ -60,27 +61,27 @@ def _agent_with_capture(body: dict) -> tuple[PortfolioManagerAgent, list[str]]:
 
 def test_bearish_ticker_receives_no_kelly_anchor():
     """A BEARISH ticker is never listed under HALF-KELLY ANCHORS, even with outcome data."""
-    all_signals = {
-        "BULL": {
-            "risk": _risk(),
-            "aggregated": _agg(
+    snapshots = {
+        "BULL": TickerSnapshot(
+            risk=_risk(),
+            aggregated=_agg(
                 "BULL",
                 Signal.BULLISH,
                 {"technical": 0.5},
                 reliability={"technical": 0.65},
                 reliability_n={"technical": 20},
             ),
-        },
-        "BEAR": {
-            "risk": _risk(),
-            "aggregated": _agg(
+        ),
+        "BEAR": TickerSnapshot(
+            risk=_risk(),
+            aggregated=_agg(
                 "BEAR",
                 Signal.BEARISH,
                 {"technical": 0.5},
                 reliability={"technical": 0.65},
                 reliability_n={"technical": 20},
             ),
-        },
+        ),
     }
     body = {
         "portfolio": [],
@@ -91,7 +92,7 @@ def test_bearish_ticker_receives_no_kelly_anchor():
     agent, prompts = _agent_with_capture(body)
     agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
-        all_signals=all_signals,
+        snapshots=snapshots,
         macro=None,
     )
 
@@ -102,17 +103,17 @@ def test_bearish_ticker_receives_no_kelly_anchor():
 
 def test_kelly_anchor_block_omitted_when_no_agent_has_data():
     """The whole HALF-KELLY ANCHORS block is omitted, with an explanation, when n == 0 for every agent."""
-    all_signals = {
-        "AAPL": {
-            "risk": _risk(),
-            "aggregated": _agg(
+    snapshots = {
+        "AAPL": TickerSnapshot(
+            risk=_risk(),
+            aggregated=_agg(
                 "AAPL",
                 Signal.BULLISH,
                 {"technical": 0.5},
                 reliability={"technical": 0.5, "fundamental": 0.5, "sentiment": 0.5},
                 reliability_n={"technical": 0, "fundamental": 0, "sentiment": 0},
             ),
-        },
+        ),
     }
     body = {
         "portfolio": [],
@@ -123,7 +124,7 @@ def test_kelly_anchor_block_omitted_when_no_agent_has_data():
     agent, prompts = _agent_with_capture(body)
     agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
-        all_signals=all_signals,
+        snapshots=snapshots,
         macro=None,
     )
 
@@ -134,17 +135,17 @@ def test_kelly_anchor_block_omitted_when_no_agent_has_data():
 
 def test_kelly_anchor_uses_primary_drivers_measured_win_rate_not_conviction():
     """The anchor is derived from the argmax(weighted_votes) agent's reliability rate."""
-    all_signals = {
-        "AAPL": {
-            "risk": _risk(),
-            "aggregated": _agg(
+    snapshots = {
+        "AAPL": TickerSnapshot(
+            risk=_risk(),
+            aggregated=_agg(
                 "AAPL",
                 Signal.BULLISH,
                 {"technical": 0.9, "fundamental": 0.1},
                 reliability={"technical": 0.7, "fundamental": 0.5},
                 reliability_n={"technical": 30, "fundamental": 0},
             ),
-        },
+        ),
     }
     body = {
         "portfolio": [],
@@ -155,7 +156,7 @@ def test_kelly_anchor_uses_primary_drivers_measured_win_rate_not_conviction():
     agent, prompts = _agent_with_capture(body)
     agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.5, "risk_tolerance": "MODERATE"},
-        all_signals=all_signals,
+        snapshots=snapshots,
         macro=None,
     )
 
@@ -170,8 +171,8 @@ def test_capital_base_is_total_wealth_not_wealth_times_invest_pct():
     capital base and again by the LLM's deployment target, so requesting 80%
     deployment produced roughly invest_pct^2 (64%) of true total wealth.
     """
-    all_signals = {
-        "AAPL": {"risk": _risk()},
+    snapshots = {
+        "AAPL": TickerSnapshot(risk=_risk()),
     }
     body = {
         "portfolio": [
@@ -191,7 +192,7 @@ def test_capital_base_is_total_wealth_not_wealth_times_invest_pct():
     agent, prompts = _agent_with_capture(body)
     alloc = agent.allocate(
         user_profile={"total_wealth": 100_000.0, "invest_pct": 0.8, "risk_tolerance": "MODERATE"},
-        all_signals=all_signals,
+        snapshots=snapshots,
         macro=None,
     )
 

--- a/tests/test_prompting.py
+++ b/tests/test_prompting.py
@@ -1,0 +1,113 @@
+"""
+Tests for argus/schemas/prompting.py's field_list() and schema_block() — the
+two render functions that turn a Pydantic model's PromptText markers into the
+literal text an LLM prompt shows. No agent is migrated onto this module yet
+(issue #76 is expand-only), so these tests exercise it directly against
+throwaway models built for each case.
+"""
+
+from typing import Annotated
+
+import pytest
+from pydantic import BaseModel
+
+from argus.schemas.prompting import PromptText, field_list, schema_block
+
+
+class _Flat(BaseModel):
+    """A flat model with every field marked."""
+
+    signal: Annotated[str, PromptText('"BULLISH|BEARISH|NEUTRAL"')]
+    conviction: Annotated[float, PromptText("<float 0.0-1.0>")]
+
+
+class _MissingMarker(BaseModel):
+    """A flat model where one field carries no PromptText marker."""
+
+    signal: Annotated[str, PromptText('"BULLISH|BEARISH|NEUTRAL"')]
+    conviction: float
+
+
+class _Nested(BaseModel):
+    """A single nested-model field, unmarked as the contract requires."""
+
+    ticker: Annotated[str, PromptText('""')]
+    position: _Flat
+
+
+class _NestedList(BaseModel):
+    """A list-of-nested-model field, unmarked as the contract requires."""
+
+    ticker: Annotated[str, PromptText('""')]
+    positions: list[_Flat]
+
+
+class _NestedWithMarker(BaseModel):
+    """A nested-model field that incorrectly carries a PromptText marker."""
+
+    position: Annotated[_Flat, PromptText("{}")]
+
+
+class _NestedListWithMarker(BaseModel):
+    """A list-of-nested-model field that incorrectly carries a PromptText marker."""
+
+    positions: Annotated[list[_Flat], PromptText("[]")]
+
+
+def test_schema_block_includes_every_field():
+    """Every field's name and marker text appear in the rendered block."""
+    result = schema_block(_Flat)
+    assert result == '{"signal":"BULLISH|BEARISH|NEUTRAL","conviction":<float 0.0-1.0>}'
+
+
+def test_schema_block_uses_marker_text_verbatim():
+    """Marker text is copied through unmodified, not reformatted."""
+    result = schema_block(_Flat)
+    assert '"<float 0.0-1.0>"' not in result  # sanity: conviction's value has no outer quotes
+    assert "<float 0.0-1.0>" in result
+
+
+def test_field_list_includes_every_field_and_joins_with_comma_space():
+    """field_list joins each field's marker text verbatim with ', '."""
+    result = field_list(_Flat)
+    assert result == '"BULLISH|BEARISH|NEUTRAL", <float 0.0-1.0>'
+
+
+def test_schema_block_renders_nested_model_as_its_own_block():
+    """A nested-model field renders as a JSON object, not a marker lookup."""
+    result = schema_block(_Nested)
+    assert result == (
+        '{"ticker":"","position":{"signal":"BULLISH|BEARISH|NEUTRAL","conviction":<float 0.0-1.0>}}'
+    )
+
+
+def test_schema_block_wraps_list_of_nested_model_in_brackets():
+    """A list-of-nested-model field renders its block wrapped in brackets."""
+    result = schema_block(_NestedList)
+    assert result == (
+        '{"ticker":"","positions":[{"signal":"BULLISH|BEARISH|NEUTRAL","conviction":<float 0.0-1.0>}]}'
+    )
+
+
+def test_schema_block_raises_on_scalar_field_with_no_marker():
+    """A scalar field with no PromptText marker fails loudly rather than rendering blank."""
+    with pytest.raises(TypeError):
+        schema_block(_MissingMarker)
+
+
+def test_field_list_raises_on_scalar_field_with_no_marker():
+    """field_list applies the same no-marker enforcement as schema_block."""
+    with pytest.raises(TypeError):
+        field_list(_MissingMarker)
+
+
+def test_schema_block_raises_on_nested_model_field_carrying_a_marker():
+    """A nested-model field must not carry a PromptText marker of its own."""
+    with pytest.raises(TypeError):
+        schema_block(_NestedWithMarker)
+
+
+def test_schema_block_raises_on_nested_list_field_carrying_a_marker():
+    """A list-of-nested-model field must not carry a PromptText marker of its own."""
+    with pytest.raises(TypeError):
+        schema_block(_NestedListWithMarker)

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -782,6 +782,7 @@ def test_run_reconciliation_pass_over_matured_decisions_produces_outcome_and_equ
     assert isinstance(report, ReconciliationReport)
     assert report.decisions_loaded == 1
     assert report.outcomes_stored == 1
+    assert report.paper_book_updated is True
     assert report.equity == pytest.approx(105_000.0)
     assert report.drawdown == pytest.approx(0.0)
     assert report.decisions_compacted is not None
@@ -917,6 +918,7 @@ def test_run_reconciliation_pass_paper_book_not_partially_applied_when_its_step_
         horizon_days=5,
     )
 
+    assert report.paper_book_updated is False
     assert report.equity == 0.0
     assert len(report.errors) == 1
     assert "paper-book update failed" in report.errors[0]

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -19,6 +19,7 @@ from argus.memory.cultural import CulturalMemoryManager
 from argus.orchestration.aggregator import HybridSignalAggregator
 from argus.orchestration.graph import build_checkpoint_serde, build_graph
 from argus.orchestration.reconciliation import (
+    ReconciliationReport,
     compact_decisions_jsonl,
     compute_realized_return,
     credit_primary_driver,
@@ -27,8 +28,11 @@ from argus.orchestration.reconciliation import (
     prune_checkpoints,
     reconcile_decision,
     reconcile_decisions,
+    run_reconciliation_pass,
 )
 from argus.orchestration.state import ARGUSState
+from argus.risk import paper_book
+from argus.risk.paper_book import PaperBook
 from argus.schemas.signals import (
     ARGUSDecision,
     FundamentalSignal,
@@ -712,3 +716,211 @@ def test_prune_checkpoints_nothing_stale_deletes_nothing(tmp_path):
     deleted = prune_checkpoints(db_path, cutoff=datetime.now() - timedelta(days=30))
 
     assert deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# run_reconciliation_pass (issue #77)
+# ---------------------------------------------------------------------------
+
+
+def _matured_decision(ticker: str, start: datetime, price: float = 100.0) -> ARGUSDecision:
+    """A decision that took a position and has cleared a 5-day horizon by `start` + 5 days."""
+    return ARGUSDecision(
+        ticker=ticker,
+        session_timestamp=start,
+        technical=_technical(Signal.BULLISH, 0.8, ticker=ticker, price=price),
+        allocation=_allocation(ticker=ticker),
+    )
+
+
+def _autospec_cultural(expired: int = 0) -> mock.MagicMock:
+    """An autospec CulturalMemoryManager with the return values reconcile_decisions and expiry need."""
+    cultural = mock.create_autospec(CulturalMemoryManager, instance=True)
+    cultural.already_reconciled.return_value = set()
+    cultural.expire_pending_snapshots.return_value = expired
+    return cultural
+
+
+def _put_checkpoint_with_decisions(
+    saver: SqliteSaver, thread_id: str, ts: datetime, decisions: list[ARGUSDecision]
+) -> None:
+    """Writes a checkpoint for `thread_id` stamped with `ts`, carrying `decisions` in its channel value."""
+    config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    checkpoint = {
+        "v": 1,
+        "ts": ts.isoformat(),
+        "id": thread_id,
+        "channel_values": {"decisions": decisions},
+        "channel_versions": {"decisions": "1"},
+        "versions_seen": {},
+    }
+    saver.put(config, checkpoint, {"source": "input", "step": 1, "writes": {}}, {})
+
+
+def test_run_reconciliation_pass_over_matured_decisions_produces_outcome_and_equity(tmp_path):
+    """A full pass over matured decisions stores the outcome and compounds its return onto paper equity."""
+    start = datetime(2026, 1, 1)
+    decision = _matured_decision("TEST", start)
+    decisions_log = tmp_path / "decisions.jsonl"
+    with open(decisions_log, "w", encoding="utf-8") as f:
+        f.write(decision.model_dump_json() + "\n")
+
+    book_path = tmp_path / "paper_equity.json"
+    paper_book.save(PaperBook(equity=100_000.0, high_water_mark=100_000.0), str(book_path))
+
+    market_data = _ten_day_series(start, start_price=100.0)
+    cultural = _autospec_cultural()
+
+    report = run_reconciliation_pass(
+        market_data,
+        cultural,
+        str(book_path),
+        decisions_log_path=str(decisions_log),
+        horizon_days=5,
+    )
+
+    assert isinstance(report, ReconciliationReport)
+    assert report.decisions_loaded == 1
+    assert report.outcomes_stored == 1
+    assert report.equity == pytest.approx(105_000.0)
+    assert report.drawdown == pytest.approx(0.0)
+    assert report.decisions_compacted is not None
+    assert report.checkpoints_pruned is None
+    assert report.pending_snapshots_expired == 0
+    assert report.errors == []
+    cultural.store_trade_outcome.assert_called_once()
+
+    reloaded = paper_book.load(str(book_path))
+    assert reloaded.equity == pytest.approx(105_000.0)
+
+
+def test_run_reconciliation_pass_reading_from_checkpoints_bounds_checkpoints(tmp_path):
+    """With only a checkpoint path, decisions are read from it and it alone is bounded."""
+    start = datetime(2026, 1, 1)
+    decision = _matured_decision("TEST", start)
+    db_path = str(tmp_path / "argus_graph.db")
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    saver = SqliteSaver(conn, serde=build_checkpoint_serde())
+    _put_checkpoint_with_decisions(saver, "session-thread", start, [decision])
+    conn.close()
+
+    market_data = _ten_day_series(start, start_price=100.0)
+    cultural = _autospec_cultural()
+
+    report = run_reconciliation_pass(
+        market_data,
+        cultural,
+        str(tmp_path / "paper_equity.json"),
+        checkpoint_db_path=db_path,
+        horizon_days=5,
+    )
+
+    assert report.decisions_loaded == 1
+    assert report.outcomes_stored == 1
+    assert report.decisions_compacted is None
+    assert report.checkpoints_pruned is not None
+    assert report.errors == []
+
+
+def test_run_reconciliation_pass_given_both_paths_bounds_both(tmp_path):
+    """With both paths given, the decisions log wins as the read source and both stores are bounded."""
+    start = datetime(2026, 1, 1)
+    decision = _matured_decision("TEST", start)
+    decisions_log = tmp_path / "decisions.jsonl"
+    with open(decisions_log, "w", encoding="utf-8") as f:
+        f.write(decision.model_dump_json() + "\n")
+
+    db_path = str(tmp_path / "argus_graph.db")
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    saver = SqliteSaver(conn, serde=build_checkpoint_serde())
+    _put_checkpoint(saver, "stale-thread", datetime(2020, 1, 1))
+    conn.close()
+
+    market_data = _ten_day_series(start, start_price=100.0)
+    cultural = _autospec_cultural()
+
+    report = run_reconciliation_pass(
+        market_data,
+        cultural,
+        str(tmp_path / "paper_equity.json"),
+        decisions_log_path=str(decisions_log),
+        checkpoint_db_path=db_path,
+        horizon_days=5,
+    )
+
+    # The checkpoint's only thread carries no decisions -> the log (with one) is the read source.
+    assert report.decisions_loaded == 1
+    assert report.decisions_compacted is not None
+    assert report.checkpoints_pruned is not None
+    assert report.checkpoints_pruned >= 1
+    assert report.errors == []
+
+
+def test_run_reconciliation_pass_one_store_failing_leaves_the_others_bounded_and_names_it(tmp_path):
+    """A corrupt checkpoint database fails that one store without skipping decisions.jsonl compaction."""
+    start = datetime(2026, 1, 1)
+    decision = _matured_decision("TEST", start)
+    decisions_log = tmp_path / "decisions.jsonl"
+    with open(decisions_log, "w", encoding="utf-8") as f:
+        f.write(decision.model_dump_json() + "\n")
+
+    db_path = tmp_path / "argus_graph.db"
+    db_path.write_bytes(b"not a sqlite database")
+
+    market_data = _ten_day_series(start, start_price=100.0)
+    cultural = _autospec_cultural(expired=3)
+
+    report = run_reconciliation_pass(
+        market_data,
+        cultural,
+        str(tmp_path / "paper_equity.json"),
+        decisions_log_path=str(decisions_log),
+        checkpoint_db_path=str(db_path),
+        horizon_days=5,
+    )
+
+    assert report.decisions_compacted is not None
+    assert report.checkpoints_pruned is None
+    assert report.pending_snapshots_expired == 3
+    assert report.outcomes_stored == 1
+    assert len(report.errors) == 1
+    assert "checkpoint" in report.errors[0]
+
+
+def test_run_reconciliation_pass_paper_book_not_partially_applied_when_its_step_fails(
+    tmp_path, monkeypatch
+):
+    """A paper-book save failure leaves the persisted book exactly as it was, and names the failure."""
+    start = datetime(2026, 1, 1)
+    decision = _matured_decision("TEST", start)
+    decisions_log = tmp_path / "decisions.jsonl"
+    with open(decisions_log, "w", encoding="utf-8") as f:
+        f.write(decision.model_dump_json() + "\n")
+
+    book_path = tmp_path / "paper_equity.json"
+    paper_book.save(PaperBook(equity=12_345.0, high_water_mark=12_345.0), str(book_path))
+    original_bytes = book_path.read_bytes()
+
+    def _boom(_book, _path) -> None:
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(paper_book, "save", _boom)
+
+    market_data = _ten_day_series(start, start_price=100.0)
+    cultural = _autospec_cultural()
+
+    report = run_reconciliation_pass(
+        market_data,
+        cultural,
+        str(book_path),
+        decisions_log_path=str(decisions_log),
+        horizon_days=5,
+    )
+
+    assert report.equity == 0.0
+    assert len(report.errors) == 1
+    assert "paper-book update failed" in report.errors[0]
+    assert book_path.read_bytes() == original_bytes
+    # Independent of the failed paper-book step, the other stores still ran.
+    assert report.decisions_compacted is not None
+    assert report.pending_snapshots_expired == 0

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -849,7 +849,7 @@ def test_run_reconciliation_pass_given_both_paths_bounds_both(tmp_path):
         horizon_days=5,
     )
 
-    # The checkpoint's only thread carries no decisions -> the log (with one) is the read source.
+    # The checkpoint's only thread carries no decisions -> the log (with one) is the read source
     assert report.decisions_loaded == 1
     assert report.decisions_compacted is not None
     assert report.checkpoints_pruned is not None
@@ -923,6 +923,6 @@ def test_run_reconciliation_pass_paper_book_not_partially_applied_when_its_step_
     assert len(report.errors) == 1
     assert "paper-book update failed" in report.errors[0]
     assert book_path.read_bytes() == original_bytes
-    # Independent of the failed paper-book step, the other stores still ran.
+    # Independent of the failed paper-book step, the other stores still ran
     assert report.decisions_compacted is not None
     assert report.pending_snapshots_expired == 0

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -9,11 +9,10 @@ import argus.agents.sentiment as sentiment_module
 from argus.agents.sentiment import (
     SentimentAgent,
     aggregate_finbert_scores,
-    SentimentDailyCache,
     _check_earnings_calendar,
 )
 from argus.orchestration.governor import RateLimitExceeded
-from argus.schemas.signals import SentimentSignal, SentimentVerdict, Signal
+from argus.schemas.signals import SentimentVerdict
 
 def test_aggregate_finbert_scores_empty():
     """An empty article list returns the neutral, low-confidence default."""
@@ -43,36 +42,6 @@ def test_aggregate_finbert_scores_confidence_cap():
     scored = [{"numeric": 1.0, "label": "positive"} for _ in range(15)]
     res = aggregate_finbert_scores(scored)
     assert res["confidence"] == 1.0 # capped at 1.0
-
-def test_sentiment_daily_cache():
-    """A cache entry becomes stale, and unretrievable, once its TTL elapses."""
-    cache = SentimentDailyCache()
-    assert cache.is_stale("AAPL")
-
-    signal = SentimentSignal(
-        ticker="AAPL",
-        finbert_net_score=0.5,
-        pct_positive=0.7,
-        pct_negative=0.1,
-        news_volume_7d=12,
-        upcoming_catalyst=False,
-        signal=Signal.BULLISH,
-        conviction=0.8,
-        sentiment_decay_risk="LOW",
-        reasoning="Test",
-        api_calls_used=0,
-        timestamp=datetime.now(),
-    )
-
-    cache.set("AAPL", signal)
-    assert not cache.is_stale("AAPL")
-    assert cache.get("AAPL") == signal
-
-    # Backdate the entry past the cache's 86400s TTL to force staleness
-    cache._cache["AAPL"] = (signal, datetime.now() - timedelta(days=2))
-    assert cache.is_stale("AAPL")
-    assert cache.get("AAPL") is None
-
 
 class _StubMarketData:
     """Minimal MarketDataProvider stub exposing only what SentimentAgent.analyze uses."""

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -5,7 +5,6 @@ Tests for the Sentiment Agent and its pure-Python helpers.
 from datetime import datetime, timedelta
 
 
-import argus.agents.sentiment as sentiment_module
 from argus.agents.sentiment import (
     SentimentAgent,
     aggregate_finbert_scores,

--- a/tests/test_sentiment.py
+++ b/tests/test_sentiment.py
@@ -13,7 +13,7 @@ from argus.agents.sentiment import (
     _check_earnings_calendar,
 )
 from argus.orchestration.governor import RateLimitExceeded
-from argus.schemas.signals import SentimentSignal, SentimentVerdict, Signal
+from argus.schemas.signals import SentimentSignal, Signal
 
 def test_aggregate_finbert_scores_empty():
     """An empty article list returns the neutral, low-confidence default."""
@@ -112,11 +112,6 @@ class _RecordingLLMClient:
     def complete(self, system_prompt, user_prompt):
         self.last_user_prompt = user_prompt
         return self._response_text
-
-
-def test_prompt_declared_fields_match_the_verdict_schema():
-    """The prompt's declared output fields and SentimentVerdict's fields must never drift apart."""
-    assert set(sentiment_module._VERDICT_FIELD_DESCRIPTIONS) == set(SentimentVerdict.model_fields)
 
 
 def test_analyze_degrades_the_ticker_on_governor_exhaustion_without_retrying(monkeypatch):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,47 @@
+"""
+tests/test_state.py
+
+Tests for TickerSnapshot and build_ticker_snapshots.
+"""
+
+from datetime import datetime
+
+from argus.orchestration.state import TickerSnapshot, build_ticker_snapshots
+from argus.schemas.signals import RiskAssessment, RiskVerdict
+
+TIMESTAMP = datetime(2026, 1, 1)
+
+
+def _risk(verdict: RiskVerdict) -> RiskAssessment:
+    return RiskAssessment(
+        verdict=verdict,
+        approved_weight=0.0 if verdict == RiskVerdict.VETO else 0.10,
+        proposed_weight=0.10,
+        timestamp=TIMESTAMP,
+    )
+
+
+def test_risk_approved_true_for_approve_and_reduce():
+    """APPROVE and REDUCE verdicts permit an equity allocation."""
+    assert TickerSnapshot(risk=_risk(RiskVerdict.APPROVE)).risk_approved
+    assert TickerSnapshot(risk=_risk(RiskVerdict.REDUCE)).risk_approved
+
+
+def test_risk_approved_false_for_veto_or_missing():
+    """A VETO verdict, or no risk assessment at all, blocks an equity allocation."""
+    assert not TickerSnapshot(risk=_risk(RiskVerdict.VETO)).risk_approved
+    assert not TickerSnapshot().risk_approved
+
+
+def test_build_ticker_snapshots_covers_whole_universe_with_absent_specialists_empty():
+    """Every universe ticker gets a snapshot, even one no specialist produced output for."""
+    state = {
+        "universe": ["AAPL", "UNCOVERED"],
+        "risk_assessments": {"AAPL": _risk(RiskVerdict.APPROVE)},
+    }
+
+    snapshots = build_ticker_snapshots(state)
+
+    assert set(snapshots) == {"AAPL", "UNCOVERED"}
+    assert snapshots["AAPL"].risk_approved
+    assert snapshots["UNCOVERED"] == TickerSnapshot()


### PR DESCRIPTION
## Summary
Combines the six independent refactors from the 2026-08-29 architecture review, each filed as its own `ready-for-agent` issue with no hard dependency between them:

- **#76** — Renders each agent's declared output-schema prompt text from the Pydantic model itself (`argus.schemas.prompting`), deleting four hand-maintained field-description dicts and their drift tests.
- **#77** — Adds `run_reconciliation_pass`, composing decision loading, outcome reconciliation, paper-book update, and store bounding into one sequence shared by the API loop and the CLI script.
- **#78** — Adds `LiveSessionCache`, moving the four-clause freshness gate out of the analyze route into its own module.
- **#79** — Adds a `TickerSnapshot` frozen dataclass typing the per-ticker join into the portfolio agent, replacing an untyped dict-of-dicts.
- **#80** — Replaces the fundamental and sentiment agents' near-identical hand-rolled TTL caches with one generic `TTLCache`.
- **#81** — Adds `remaining_capacity()` to the LLM client port so the fundamental agent asks its injected client for rate-limit pressure instead of importing the governor singleton directly.

Merging #79 (branched before #67-75's decoder migration landed) required hand-resolving the portfolio agent's response-enforcement loop, combining #76's Pydantic-based proposal handling with #79's TickerSnapshot-based risk lookups; #80 and #81 needed smaller import/test resolutions where they touched the same files. 486 tests pass, mypy and ruff clean.

Supersedes #82 (issue #76's standalone PR), which is being closed in favor of this combined PR.

## Test plan
- [x] `pytest` — 486 passed
- [x] `mypy argus/` — clean
- [x] `ruff check .` — clean